### PR TITLE
feat: 将时间戳格式改为上海时区的 YYYY-MM-DD HH:mm:ss 格式

### DIFF
--- a/docs/knowledge/index.md
+++ b/docs/knowledge/index.md
@@ -35,6 +35,7 @@ Kagami 是一个基于 TypeScript 的 QQ 群聊机器人，集成 LLM 功能实�
 - [[api_key_manager]] - 多 API Key 轮询管理
 - [[energy_manager]] - 体力值系统管理
 - [[message_data_model]] - 消息数据结构定义
+- [[timezone_utils]] - 时区处理工具，提供 Asia/Shanghai 时间戳
 
 ## 关系图谱
 

--- a/docs/knowledge/message_data_model.md
+++ b/docs/knowledge/message_data_model.md
@@ -14,7 +14,7 @@ export interface Message {
     userId: number;               // 发送者 QQ 号
     userNickname?: string;        // 发送者昵称（可选）
     content: SendMessageSegment[]; // 结构化消息内容
-    timestamp: Date;              // 发送时间
+    timestamp: string;            // 发送时间 (Asia/Shanghai时区，格式: YYYY-MM-DD HH:mm:ss)
     metadata?: {                  // 扩展元数据（可选）
         thoughts?: string[];       // LLM 思考过程
         hasReply?: boolean;       // 是否包含回复内容
@@ -65,7 +65,7 @@ const message: Message = {
     userId: ctx.user_id,
     userNickname,                    // 异步获取的用户昵称
     content: ctx.message,            // 原始的 SendMessageSegment[]
-    timestamp: new Date(),
+    timestamp: getShanghaiTimestamp(), // 使用上海时区
     metadata: replyToMessageId ? { replyToMessageId } : undefined,
 };
 ```
@@ -78,7 +78,7 @@ const botMessage: Message = {
     groupId: this.groupId,
     userId: this.botQQ,
     content: reply ?? [],
-    timestamp: new Date(),
+    timestamp: getShanghaiTimestamp(), // 使用上海时区
     metadata: { 
         thoughts,      // LLM 的思考过程
         hasReply: !!reply // 是否包含实际回复
@@ -124,7 +124,7 @@ messages.push({
   "content": [
     {"type": "text", "data": {"text": "今天天气真好"}}
   ],
-  "timestamp": "2024-01-01T12:00:00Z"
+  "timestamp": "2024-01-01 20:00:00"
 }
 ```
 
@@ -139,7 +139,7 @@ messages.push({
     {"type": "at", "data": {"qq": "987654321"}},
     {"type": "text", "data": {"text": " 你好吗？"}}
   ],
-  "timestamp": "2024-01-01T12:01:00Z"
+  "timestamp": "2024-01-01 20:01:00"
 }
 ```
 
@@ -154,7 +154,7 @@ messages.push({
     {"type": "reply", "data": {"id": "123456"}},
     {"type": "text", "data": {"text": "确实是呢"}}
   ],
-  "timestamp": "2024-01-01T12:02:00Z",
+  "timestamp": "2024-01-01 20:02:00",
   "metadata": {
     "replyToMessageId": "123456"
   }
@@ -168,7 +168,7 @@ messages.push({
   "groupId": 789012,
   "userId": 987654321,
   "content": [],
-  "timestamp": "2024-01-01T12:03:00Z",
+  "timestamp": "2024-01-01 20:03:00",
   "metadata": {
     "thoughts": [
       "用户们在讨论天气，这是很自然的闲聊",
@@ -188,7 +188,7 @@ messages.push({
   "content": [
     {"type": "text", "data": {"text": "是的，阳光明媚的日子总是让人心情愉快"}}
   ],
-  "timestamp": "2024-01-01T12:04:00Z",
+  "timestamp": "2024-01-01 20:04:00",
   "metadata": {
     "thoughts": [
       "张三在分享天气很好的感受",
@@ -203,7 +203,7 @@ messages.push({
 
 ### 类型依赖
 - **SendMessageSegment**：来自 `node-napcat-ts` 库的标准消息段类型
-- **Date**：JavaScript 标准 Date 对象
+- **string**：时间戳使用字符串格式，由 [[timezone_utils]] 生成
 
 ### 使用者
 - [[session]] - 创建和传递 Message 对象

--- a/docs/knowledge/session.md
+++ b/docs/knowledge/session.md
@@ -30,7 +30,7 @@ async handleMessage(context: unknown): Promise<void> {
         userId: ctx.user_id,
         userNickname,
         content: ctx.message,
-        timestamp: new Date(),
+        timestamp: getShanghaiTimestamp(), // Asia/Shanghai时区
         metadata: replyToMessageId ? { replyToMessageId } : undefined,
     };
 
@@ -76,7 +76,7 @@ const message: Message = {
     userId: ctx.user_id,
     userNickname,
     content: ctx.message,      // 保持原始的 SendMessageSegment[] 格式
-    timestamp: new Date(),
+    timestamp: getShanghaiTimestamp(), // Asia/Shanghai时区
     metadata: replyToMessageId ? { replyToMessageId } : undefined,
 };
 ```

--- a/docs/knowledge/timezone_utils.md
+++ b/docs/knowledge/timezone_utils.md
@@ -1,0 +1,79 @@
+# 时区工具 (Timezone Utils)
+
+## 概述
+
+时区工具模块提供了处理 Asia/Shanghai 时区的时间戳格式化功能，确保系统中的时间戳使用中国标准时间而非 UTC 时间。
+
+## 核心功能
+
+### 时间戳格式化
+- 将当前时间或指定时间转换为上海时区
+- 输出标准化的时间戳格式：`"YYYY-MM-DD HH:mm:ss"`
+- 不包含毫秒信息和时区标识
+
+### 主要函数
+
+#### `getShanghaiTimestamp(): string`
+- **功能**：获取当前上海时区的时间戳字符串
+- **返回值**：格式为 `"YYYY-MM-DD HH:mm:ss"` 的字符串
+- **使用场景**：创建新消息时的时间戳
+
+#### `formatShanghaiTimestamp(date: Date): string`
+- **功能**：将指定 Date 对象转换为上海时区时间戳
+- **参数**：`date` - 要转换的 Date 对象
+- **返回值**：格式为 `"YYYY-MM-DD HH:mm:ss"` 的字符串
+- **使用场景**：转换历史时间戳
+
+## 技术实现
+
+### 时区转换原理
+1. 获取本地时间的 UTC 时间戳
+2. 计算 UTC+8 偏移量（8 * 3600000 毫秒）
+3. 创建目标时区的 Date 对象
+4. 格式化为指定字符串格式
+
+### 代码示例
+```typescript
+import { getShanghaiTimestamp, formatShanghaiTimestamp } from './utils/timezone.js';
+
+// 获取当前上海时间
+const now = getShanghaiTimestamp();
+// 输出: "2024-01-01 20:00:00"
+
+// 转换指定时间
+const utcTime = new Date('2024-01-01T12:00:00.000Z');
+const shanghaiTime = formatShanghaiTimestamp(utcTime);
+// 输出: "2024-01-01 20:00:00"
+```
+
+## 关联关系
+
+### 依赖关系
+- **无外部依赖**：使用原生 JavaScript Date API
+
+### 被使用关系
+- [[session]] - 用户消息时间戳创建
+- [[base_message_handler]] - 机器人消息时间戳创建
+
+## 使用位置
+
+### 消息创建
+- `src/session.ts:56` - 用户消息时间戳
+- `src/base_message_handler.ts:74` - 机器人消息时间戳
+
+## 设计考虑
+
+### 为什么使用字符串格式
+1. **可读性**：`"2024-01-01 20:00:00"` 比 ISO 格式更易读
+2. **一致性**：统一的时区表示，避免混淆
+3. **简化**：LLM 处理时不需要解析复杂的时区信息
+
+### 为什么使用上海时区
+1. **用户体验**：与中国用户的本地时间一致
+2. **上下文相关性**：LLM 能更好理解时间相关的对话
+
+## 维护注意事项
+
+1. **夏令时处理**：中国不使用夏令时，固定 UTC+8
+2. **精度考虑**：目前精确到秒，如需更高精度可扩展
+3. **性能优化**：函数调用频繁时可考虑缓存优化

--- a/src/base_message_handler.ts
+++ b/src/base_message_handler.ts
@@ -4,6 +4,7 @@ import { SendMessageSegment } from "node-napcat-ts";
 import { LlmClient } from "./llm.js";
 import { Message, MessageHandler, Session } from "./session.js";
 import { MasterConfig } from "./config.js";
+import { getShanghaiTimestamp } from "./utils/timezone.js";
 
 // 新的JSON数组结构化输出接口
 interface ThoughtItem {
@@ -70,7 +71,7 @@ export abstract class BaseMessageHandler implements MessageHandler {
                 groupId: this.groupId,
                 userId: this.botQQ,
                 content: reply ?? [], // 存储实际的回复内容
-                timestamp: new Date(),
+                timestamp: getShanghaiTimestamp(),
                 // 可以考虑在这里存储完整的响应，包括thoughts
                 metadata: { thoughts, hasReply: !!reply },
             };

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,5 +1,6 @@
 import { SendMessageSegment } from "node-napcat-ts";
 import { ConnectionManager } from "./connection_manager.js";
+import { getShanghaiTimestamp } from "./utils/timezone.js";
 
 export interface Message {
     id: string;
@@ -7,7 +8,7 @@ export interface Message {
     userId: number;
     userNickname?: string;
     content: SendMessageSegment[];
-    timestamp: Date;
+    timestamp: string;
     metadata?: {
         thoughts?: string[];
         hasReply?: boolean;
@@ -52,7 +53,7 @@ export class Session {
                 userId: ctx.user_id,
                 userNickname,
                 content: ctx.message,
-                timestamp: new Date(),
+                timestamp: getShanghaiTimestamp(),
                 metadata: replyToMessageId ? { replyToMessageId } : undefined,
             };
 

--- a/src/utils/timezone.ts
+++ b/src/utils/timezone.ts
@@ -1,0 +1,49 @@
+/**
+ * 时区工具函数
+ * 用于处理 Asia/Shanghai 时区的时间戳格式化
+ */
+
+/**
+ * 获取当前 Asia/Shanghai 时区的时间戳字符串
+ * @returns 格式为 "YYYY-MM-DD HH:mm:ss" 的时间戳字符串
+ */
+export function getShanghaiTimestamp(): string {
+    const now = new Date();
+    
+    // 计算 UTC+8 时区的时间
+    // getTimezoneOffset() 返回的是分钟数，且与实际时区相反
+    // 例如对于 UTC+8，getTimezoneOffset() 通常返回 -480（-8 * 60）
+    const utcTime = now.getTime() + (now.getTimezoneOffset() * 60000);
+    const shanghaiTime = new Date(utcTime + (8 * 3600000)); // UTC+8
+    
+    // 格式化为 YYYY-MM-DD HH:mm:ss
+    const year = shanghaiTime.getFullYear();
+    const month = String(shanghaiTime.getMonth() + 1).padStart(2, "0");
+    const day = String(shanghaiTime.getDate()).padStart(2, "0");
+    const hours = String(shanghaiTime.getHours()).padStart(2, "0");
+    const minutes = String(shanghaiTime.getMinutes()).padStart(2, "0");
+    const seconds = String(shanghaiTime.getSeconds()).padStart(2, "0");
+    
+    return `${String(year)}-${month}-${day} ${hours}:${minutes}:${seconds}`;
+}
+
+/**
+ * 获取指定 Date 对象在 Asia/Shanghai 时区的时间戳字符串
+ * @param date 要转换的 Date 对象
+ * @returns 格式为 "YYYY-MM-DD HH:mm:ss" 的时间戳字符串
+ */
+export function formatShanghaiTimestamp(date: Date): string {
+    // 计算 UTC+8 时区的时间
+    const utcTime = date.getTime() + (date.getTimezoneOffset() * 60000);
+    const shanghaiTime = new Date(utcTime + (8 * 3600000)); // UTC+8
+    
+    // 格式化为 YYYY-MM-DD HH:mm:ss
+    const year = shanghaiTime.getFullYear();
+    const month = String(shanghaiTime.getMonth() + 1).padStart(2, "0");
+    const day = String(shanghaiTime.getDate()).padStart(2, "0");
+    const hours = String(shanghaiTime.getHours()).padStart(2, "0");
+    const minutes = String(shanghaiTime.getMinutes()).padStart(2, "0");
+    const seconds = String(shanghaiTime.getSeconds()).padStart(2, "0");
+    
+    return `${String(year)}-${month}-${day} ${hours}:${minutes}:${seconds}`;
+}


### PR DESCRIPTION
- 创建时区工具函数模块 src/utils/timezone.ts
- 修改消息时间戳从 Date 类型改为 string 类型
- 更新 session.ts 和 base_message_handler.ts 使用新的时间戳格式
- 更新相关知识图谱文档，添加 timezone_utils 模块说明
- 时间戳现在使用 Asia/Shanghai 时区，格式为 "YYYY-MM-DD HH:mm:ss"