### PR TITLE
fix: 修复LLM调用失败记录显示[object Object]问题

### DIFF
--- a/docs/knowledge/base_message_handler.md
+++ b/docs/knowledge/base_message_handler.md
@@ -59,9 +59,10 @@ protected async processAndReply(): Promise<boolean> {
         
         return false;
     } catch (error) {
-        // 7. 记录失败的LLM调用
+        // 7. 记录失败的LLM调用 - 使用JSON序列化确保复杂错误对象能被完整记录
+        const errorMessage = error instanceof Error ? error.message : JSON.stringify(error, null, 2);
         if (inputForLog) {
-            void logger.logLLMCall("fail", inputForLog, error.message);
+            void logger.logLLMCall("fail", inputForLog, errorMessage);
         }
         throw error;
     }
@@ -248,9 +249,9 @@ interface PromptTemplateContext {
 ## 错误处理
 
 ### LLM 调用错误
-- **API 错误**：记录错误并重新抛出
+- **API 错误**：使用JSON序列化记录完整错误信息（避免"[object Object]"问题），记录后重新抛出
 - **解析错误**：返回空响应，不发送消息
-- **网络错误**：由 [[llm_client]] 处理
+- **网络错误**：由 [[llm_client]] 处理，同样使用JSON序列化记录详细信息
 
 ### 消息发送错误
 - **发送失败**：记录错误并重新抛出

--- a/docs/knowledge/llm_client.md
+++ b/docs/knowledge/llm_client.md
@@ -32,7 +32,7 @@ async oneTurnChat(messages: ChatCompletionMessageParam[]): Promise<string> {
 
         return content;
     } catch (error) {
-        console.error(`LLM 请求失败: ${error instanceof Error ? error.message : String(error)}`);
+        console.error(`LLM 请求失败: ${error instanceof Error ? error.message : JSON.stringify(error, null, 2)}`);
         return "";  // 返回空字符串而不是抛异常，让上层处理日志记录
     }
 }
@@ -63,7 +63,7 @@ response_format: {
 ### 错误处理
 - **静默错误处理**：返回空字符串而不抛异常，让上层决定如何处理
 - **空响应检查**：验证 API 返回内容的有效性
-- **详细错误日志**：记录错误信息到控制台便于调试
+- **详细错误日志**：使用JSON序列化记录完整错误信息到控制台，避免"[object Object]"问题
 - **上层职责分离**：日志记录由调用方（[[base_message_handler]]）负责
 
 ## 依赖关系

--- a/docs/knowledge/logger.md
+++ b/docs/knowledge/logger.md
@@ -81,9 +81,10 @@ export class BaseMessageHandler {
             
             // ... 处理响应
         } catch (error) {
-            // 记录失败的LLM调用
+            // 记录失败的LLM调用 - 使用JSON序列化确保复杂错误对象能被完整记录
+            const errorMessage = error instanceof Error ? error.message : JSON.stringify(error, null, 2);
             if (inputForLog) {
-                void logger.logLLMCall("fail", inputForLog, error.message);
+                void logger.logLLMCall("fail", inputForLog, errorMessage);
             }
             throw error;
         }
@@ -101,6 +102,7 @@ export class BaseMessageHandler {
 - 记录完整的输入参数（model、messages 等）
 - 保存原始输出内容，包括无效 JSON
 - 自动序列化非字符串类型的数据
+- **增强错误记录**：对于复杂错误对象，使用JSON序列化记录完整信息，避免"[object Object]"问题
 
 ### 错误容忍
 - 日志记录过程中的错误不会中断 LLM 调用

--- a/kagami-bot/src/base_message_handler.ts
+++ b/kagami-bot/src/base_message_handler.ts
@@ -116,7 +116,7 @@ export abstract class BaseMessageHandler implements MessageHandler {
             }
         } catch (error) {
             console.error(`[群 ${String(this.groupId)}] LLM 回复失败:`, error);
-            const errorMessage = error instanceof Error ? error.message : String(error);
+            const errorMessage = error instanceof Error ? error.message : JSON.stringify(error, null, 2);
             
             // 记录失败的LLM调用
             if (inputForLog) {

--- a/kagami-bot/src/llm.ts
+++ b/kagami-bot/src/llm.ts
@@ -38,7 +38,7 @@ export class LlmClient {
 
             return content;
         } catch (error) {
-            console.error(`LLM 请求失败: ${error instanceof Error ? error.message : String(error)}`);
+            console.error(`LLM 请求失败: ${error instanceof Error ? error.message : JSON.stringify(error, null, 2)}`);
             return "";  // 返回空字符串而不是抛异常，让上层处理日志记录
         }
     }


### PR DESCRIPTION
- 将base_message_handler.ts中的String(error)改为JSON.stringify(error, null, 2)
- 将llm.ts中的String(error)改为JSON.stringify(error, null, 2)
- 更新相关知识图谱文档以反映错误处理的改进