### PR TITLE
feat: 实现LLM提供商抽象层支持多种原生SDK

### DIFF
--- a/kagami-bot/env.yaml.example
+++ b/kagami-bot/env.yaml.example
@@ -1,5 +1,6 @@
 llm_providers:
   openai:
+    interface: "openai"
     base_url: "https://api.openai.com/v1"
     api_keys:
       - "your-openai-api-key-1"
@@ -9,12 +10,12 @@ llm_providers:
       - "gpt-4"
       - "gpt-3.5-turbo"
   gemini:
-    base_url: "https://generativelanguage.googleapis.com/v1beta/openai/"
+    interface: "genai"  # 使用原生 Google GenAI SDK
     api_keys:
       - "your-gemini-api-key-1"
       - "your-gemini-api-key-2"
     models:
-      - "gemini-2.5-flash"
+      - "gemini-2.0-flash-001"
       - "gemini-1.5-pro"
       - "gemini-1.5-flash"
 

--- a/kagami-bot/package-lock.json
+++ b/kagami-bot/package-lock.json
@@ -9,6 +9,7 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
+                "@google/genai": "^1.20.0",
                 "handlebars": "^4.7.8",
                 "node-napcat-ts": "^0.4.15",
                 "openai": "^5.12.2",
@@ -624,6 +625,27 @@
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
+        "node_modules/@google/genai": {
+            "version": "1.20.0",
+            "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.20.0.tgz",
+            "integrity": "sha512-QdShxO9LX35jFogy3iKprQNqgKKveux4H2QjOnyIvyHRuGi6PHiz3fjNf8Y0VPY8o5V2fHqR2XqiSVoz7yZs0w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "google-auth-library": "^9.14.2",
+                "ws": "^8.18.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            },
+            "peerDependencies": {
+                "@modelcontextprotocol/sdk": "^1.11.4"
+            },
+            "peerDependenciesMeta": {
+                "@modelcontextprotocol/sdk": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@humanfs/core": {
             "version": "0.19.1",
             "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1142,6 +1164,15 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/ajv": {
             "version": "6.12.6",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1196,6 +1227,35 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/bignumber.js": {
+            "version": "9.3.1",
+            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+            "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+            "license": "MIT",
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/brace-expansion": {
             "version": "1.1.12",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -1219,6 +1279,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/buffer-equal-constant-time": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+            "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/callsites": {
             "version": "3.1.0",
@@ -1300,7 +1366,6 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
             "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
@@ -1329,6 +1394,15 @@
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.3.1"
+            }
+        },
+        "node_modules/ecdsa-sig-formatter": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+            "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "safe-buffer": "^5.0.1"
             }
         },
         "node_modules/esbuild": {
@@ -1541,6 +1615,12 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/extend": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+            "license": "MIT"
+        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1681,6 +1761,36 @@
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
+        "node_modules/gaxios": {
+            "version": "6.7.1",
+            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+            "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "extend": "^3.0.2",
+                "https-proxy-agent": "^7.0.1",
+                "is-stream": "^2.0.0",
+                "node-fetch": "^2.6.9",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/gcp-metadata": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+            "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "gaxios": "^6.1.1",
+                "google-logging-utils": "^0.0.2",
+                "json-bigint": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/get-tsconfig": {
             "version": "4.10.1",
             "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
@@ -1720,12 +1830,51 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/google-auth-library": {
+            "version": "9.15.1",
+            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+            "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "base64-js": "^1.3.0",
+                "ecdsa-sig-formatter": "^1.0.11",
+                "gaxios": "^6.1.1",
+                "gcp-metadata": "^6.1.0",
+                "gtoken": "^7.0.0",
+                "jws": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/google-logging-utils": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+            "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/graphemer": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
             "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/gtoken": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+            "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+            "license": "MIT",
+            "dependencies": {
+                "gaxios": "^6.0.0",
+                "jws": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
         },
         "node_modules/handlebars": {
             "version": "4.7.8",
@@ -1756,6 +1905,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/ignore": {
@@ -1828,6 +1990,18 @@
                 "node": ">=0.12.0"
             }
         },
+        "node_modules/is-stream": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1857,6 +2031,15 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
+        "node_modules/json-bigint": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+            "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+            "license": "MIT",
+            "dependencies": {
+                "bignumber.js": "^9.0.0"
+            }
+        },
         "node_modules/json-buffer": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -1877,6 +2060,27 @@
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/jwa": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+            "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+            "license": "MIT",
+            "dependencies": {
+                "buffer-equal-constant-time": "^1.0.1",
+                "ecdsa-sig-formatter": "1.0.11",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "node_modules/jws": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+            "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+            "license": "MIT",
+            "dependencies": {
+                "jwa": "^2.0.0",
+                "safe-buffer": "^5.0.1"
+            }
         },
         "node_modules/keyv": {
             "version": "4.5.4",
@@ -1995,7 +2199,6 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/nanoid": {
@@ -2028,6 +2231,26 @@
             "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
             "license": "MIT"
+        },
+        "node_modules/node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/node-napcat-ts": {
             "version": "0.4.15",
@@ -2381,6 +2604,26 @@
                 "queue-microtask": "^1.2.2"
             }
         },
+        "node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/semver": {
             "version": "7.7.2",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -2473,6 +2716,12 @@
             "engines": {
                 "node": ">=8.0"
             }
+        },
+        "node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "license": "MIT"
         },
         "node_modules/ts-api-utils": {
             "version": "2.1.0",
@@ -2632,12 +2881,41 @@
                 "punycode": "^2.1.0"
             }
         },
+        "node_modules/uuid": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
         "node_modules/v8-compile-cache-lib": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
             "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "license": "MIT",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
         },
         "node_modules/which": {
             "version": "2.0.2",

--- a/kagami-bot/package.json
+++ b/kagami-bot/package.json
@@ -35,6 +35,7 @@
         "typescript-eslint": "^8.39.0"
     },
     "dependencies": {
+        "@google/genai": "^1.20.0",
         "handlebars": "^4.7.8",
         "node-napcat-ts": "^0.4.15",
         "openai": "^5.12.2",

--- a/kagami-bot/src/config.ts
+++ b/kagami-bot/src/config.ts
@@ -1,5 +1,9 @@
 import * as fs from "fs";
 import * as yaml from "yaml";
+import { ProviderConfig } from "./llm_providers/types.js";
+
+// 重新导出类型
+export { ProviderConfig } from "./llm_providers/types.js";
 
 export function findProviderByModel(providers: Record<string, ProviderConfig>, model: string): string | null {
     for (const [providerName, config] of Object.entries(providers)) {
@@ -18,11 +22,6 @@ export function getProviderForModel(providers: Record<string, ProviderConfig>, m
     return providers[providerName];
 }
 
-export interface ProviderConfig {
-    base_url: string;
-    api_keys: string[];
-    models: string[];
-}
 
 export interface LlmConfig {
     model: string;
@@ -79,31 +78,6 @@ export function loadConfig(): Config {
     const configContent = fs.readFileSync(configFile, "utf8");
     const config = yaml.parse(configContent) as Config;
   
-    // 验证 llm_providers 配置
-    if (!config.llm_providers || Array.isArray(config.llm_providers) || Object.keys(config.llm_providers).length === 0) {
-        throw new Error("配置文件缺少 llm_providers 配置项");
-    }
-
-    for (const [providerName, providerConfig] of Object.entries(config.llm_providers)) {
-        if (!providerConfig.base_url || !Array.isArray(providerConfig.api_keys) || providerConfig.api_keys.length === 0 || !Array.isArray(providerConfig.models) || providerConfig.models.length === 0) {
-            throw new Error(`提供商 "${providerName}" 配置不完整，需要包含 base_url、api_keys 和 models`);
-        }
-    }
-
-    // 验证 llm 配置
-    if (!config.llm.model) {
-        throw new Error("配置文件缺少 llm.model 配置项");
-    }
-
-    // 验证指定的模型是否被某个提供商支持
-    const provider = findProviderByModel(config.llm_providers, config.llm.model);
-    if (!provider) {
-        throw new Error(`未找到支持模型 "${config.llm.model}" 的提供商`);
-    }
-  
-    if (!config.napcat.base_url || !config.napcat.access_token || !config.napcat.groups.length || !config.napcat.bot_qq) {
-        throw new Error("配置文件缺少必要的 napcat 配置项");
-    }
 
     config.behavior ??= {} as BehaviorConfig;
 

--- a/kagami-bot/src/llm.ts
+++ b/kagami-bot/src/llm.ts
@@ -1,40 +1,18 @@
-import OpenAI from "openai";
-import { ChatCompletionMessageParam } from "openai/resources/chat/completions";
 import { ProviderConfig, getProviderForModel } from "./config.js";
-import { ApiKeyManager } from "./api_key_manager.js";
+import { LlmProvider, ChatMessages } from "./llm_providers/types.js";
+import { createLlmProvider } from "./llm_providers/factory.js";
 
 export class LlmClient {
-    private baseURL: string;
-    private apiKeyManager: ApiKeyManager;
+    private provider: LlmProvider;
     private model: string;
 
     constructor(providers: Record<string, ProviderConfig>, model: string) {
         const providerConfig = getProviderForModel(providers, model);
-        this.baseURL = providerConfig.base_url;
-        this.apiKeyManager = new ApiKeyManager(providerConfig.api_keys);
+        this.provider = createLlmProvider(providerConfig);
         this.model = model;
     }
 
-    async oneTurnChat(messages: ChatCompletionMessageParam[]): Promise<string> {
-        const apiKey = this.apiKeyManager.getRandomApiKey();
-        const openai = new OpenAI({
-            baseURL: this.baseURL,
-            apiKey: apiKey,
-        });
-
-        const response = await openai.chat.completions.create({
-            model: this.model,
-            messages: messages,
-            response_format: {
-                type: "json_object",
-            },
-        });
-
-        const content = response.choices[0]?.message?.content;
-        if (!content) {
-            throw new Error("OpenAI API 返回空内容");
-        }
-
-        return content;
+    async oneTurnChat(messages: ChatMessages[]): Promise<string> {
+        return await this.provider.oneTurnChat(this.model, messages);
     }
 }

--- a/kagami-bot/src/llm_providers/factory.ts
+++ b/kagami-bot/src/llm_providers/factory.ts
@@ -1,0 +1,15 @@
+import { LlmProvider, ProviderConfig } from "./types.js";
+import { OpenAIProvider } from "./openai_provider.js";
+import { GenAIProvider } from "./genai_provider.js";
+
+export function createLlmProvider(config: ProviderConfig): LlmProvider {
+    switch (config.interface) {
+        case "openai":
+            return new OpenAIProvider(config);
+        case "genai":
+            return new GenAIProvider(config);
+        default:
+            // 这个分支在 TypeScript 类型系统中不应该到达
+            throw new Error("不支持的接口类型");
+    }
+}

--- a/kagami-bot/src/llm_providers/genai_provider.ts
+++ b/kagami-bot/src/llm_providers/genai_provider.ts
@@ -1,0 +1,76 @@
+import { Content, GoogleGenAI, Part } from "@google/genai";
+import { LlmProvider, ChatMessages, ChatMessagePart, GenAIProviderConfig } from "./types.js";
+import { ApiKeyManager } from "../api_key_manager.js";
+
+export class GenAIProvider implements LlmProvider {
+    private apiKeyManager: ApiKeyManager;
+
+    constructor(config: GenAIProviderConfig) {
+        this.apiKeyManager = new ApiKeyManager(config.api_keys);
+    }
+
+    async oneTurnChat(model: string, messages: ChatMessages[]): Promise<string> {
+        const apiKey = this.apiKeyManager.getRandomApiKey();
+        const ai = new GoogleGenAI({ apiKey });
+
+        const { contents, systemInstruction } = this.convertMessages(messages);
+
+        try {
+            const response = await ai.models.generateContent({
+                model,
+                contents,
+                config: {
+                    responseMimeType: "application/json",
+                    systemInstruction,
+                },
+            });
+
+            const text = response.text;
+
+            if (!text) {
+                throw new Error("GenAI API 返回空内容");
+            }
+
+            return text;
+        } catch (error) {
+            throw new Error(`GenAI API 调用失败: ${error instanceof Error ? error.message : String(error)}`);
+        }
+    }
+
+    private convertMessages(messages: ChatMessages[]) {
+        const contents: Content[] = [];
+        const systemInstruction: Part[] = [];
+
+        for (const msg of messages) {
+            const parts = this.convert(msg.content);
+
+            if (msg.role === "system") {
+                systemInstruction.push(...parts);
+            } else if (msg.role === "user") {
+                contents.push({
+                    role: "user",
+                    parts,
+                });
+            } else {
+                // msg.role === "assistant"
+                contents.push({
+                    role: "model",
+                    parts,
+                });
+            }
+        }
+
+        return {
+            contents,
+            systemInstruction,
+        };
+    }
+
+    private convert(content: ChatMessagePart[]): Part[] {
+        return content.map(part => this.convertPart(part));
+    }
+
+    private convertPart(part: ChatMessagePart): Part {
+        return { text: part.value };
+    }
+}

--- a/kagami-bot/src/llm_providers/openai_provider.ts
+++ b/kagami-bot/src/llm_providers/openai_provider.ts
@@ -1,0 +1,46 @@
+import OpenAI from "openai";
+import { ChatCompletionMessageParam } from "openai/resources/chat/completions";
+import { LlmProvider, ChatMessages, OpenAIProviderConfig } from "./types.js";
+import { ApiKeyManager } from "../api_key_manager.js";
+
+export class OpenAIProvider implements LlmProvider {
+    private baseURL: string;
+    private apiKeyManager: ApiKeyManager;
+
+    constructor(config: OpenAIProviderConfig) {
+        this.baseURL = config.base_url ?? "https://api.openai.com/v1";
+        this.apiKeyManager = new ApiKeyManager(config.api_keys);
+    }
+
+    async oneTurnChat(model: string, messages: ChatMessages[]): Promise<string> {
+        const apiKey = this.apiKeyManager.getRandomApiKey();
+        const openai = new OpenAI({
+            baseURL: this.baseURL,
+            apiKey: apiKey,
+        });
+
+        const openaiMessages = this.convertMessages(messages);
+
+        const response = await openai.chat.completions.create({
+            model: model,
+            messages: openaiMessages,
+            response_format: {
+                type: "json_object",
+            },
+        });
+
+        const content = response.choices[0]?.message?.content;
+        if (!content) {
+            throw new Error("OpenAI API 返回空内容");
+        }
+
+        return content;
+    }
+
+    private convertMessages(messages: ChatMessages[]): ChatCompletionMessageParam[] {
+        return messages.map(msg => ({
+            role: msg.role,
+            content: msg.content.map(c => c.value).join(""),
+        }));
+    }
+}

--- a/kagami-bot/src/llm_providers/types.ts
+++ b/kagami-bot/src/llm_providers/types.ts
@@ -1,0 +1,39 @@
+// deprecated
+export interface ChatMessageData {
+    role: "system" | "user" | "assistant";
+    content: string | {
+        type: "text" | "image_url";
+        text?: string;
+        image_url?: { url: string };
+    }[];
+}
+
+export type ChatMessagePart =
+    | {
+        type: "text",
+        value: string,
+    };
+
+export interface ChatMessages {
+    role: "system" | "user" | "assistant",
+    content: ChatMessagePart[];
+}
+
+export interface LlmProvider {
+    oneTurnChat(model: string, messages: ChatMessages[]): Promise<string>;
+}
+
+export interface OpenAIProviderConfig {
+    interface: "openai",
+    api_keys: string[],
+    models: string[],
+    base_url?: string,
+}
+
+export interface GenAIProviderConfig {
+    interface: "genai",
+    api_keys: string[],
+    models: string[],
+}
+
+export type ProviderConfig = OpenAIProviderConfig | GenAIProviderConfig;


### PR DESCRIPTION
- 新增LlmProvider接口抽象层，支持OpenAI和Google GenAI两种interface类型
- 实现OpenAIProvider使用原生OpenAI SDK保持现有功能
- 实现GenAIProvider使用Google原生SDK替代OpenAI兼容接口
- 重构LlmClient采用委托模式，通过工厂方法创建具体提供商
- 统一ChatMessages消息格式，支持结构化内容传递
- 更新配置文件架构，新增interface字段指定SDK类型
- 添加@google/genai依赖支持Google Gemini原生调用
- 更新文档说明新的抽象层架构和设计原理