### PR TITLE
refactor: 分离 MessageHandler 上下文管理职责，创建独立的 ContextManager 类

### DIFF
--- a/docs/knowledge/context_manager.md
+++ b/docs/knowledge/context_manager.md
@@ -1,0 +1,257 @@
+# ContextManager 上下文管理器
+
+## 定义
+
+ContextManager 是专门负责消息上下文管理的类，从 [[message_handler]] 中分离出来，实现了单一职责原则。位于 `src/context_manager.ts`，专注于消息历史管理和 LLM 数据准备。
+
+## 核心功能
+
+### 消息历史管理
+```typescript
+addMessageToHistory(message: Message): void {
+    this.messageHistory.push(message);
+
+    // 使用 LRU 策略，保持最近 N 条消息
+    if (this.messageHistory.length > this.maxHistorySize) {
+        this.messageHistory.shift();
+    }
+}
+```
+
+### LLM 上下文构建
+```typescript
+buildChatMessages(): ChatMessages[] {
+    // 使用Handlebars模板生成系统提示
+    const systemPrompt = this.promptTemplateManager.generatePrompt({
+        botQQ: this.botQQ,
+        masterConfig: this.masterConfig,
+        currentTime: getShanghaiTimestamp(),
+    });
+
+    const messages: ChatMessages[] = [
+        {
+            role: "system",
+            content: [{ type: "text", value: systemPrompt }],
+        },
+    ];
+
+    this.messageHistory.forEach(msg => {
+        switch (msg.type) {
+            case "bot_msg": {
+                // Bot 的消息作为 assistant
+                const responseArray: LlmResponseItem[] = [];
+
+                // 添加所有thoughts
+                msg.value.thoughts.forEach(thought => {
+                    responseArray.push({ type: "thought", content: thought });
+                });
+
+                // 添加chat（如果有）
+                if (msg.value.chat && msg.value.chat.length > 0) {
+                    responseArray.push({ type: "chat", content: msg.value.chat });
+                }
+
+                messages.push({
+                    role: "assistant",
+                    content: [{ type: "text", value: JSON.stringify(responseArray) }],
+                });
+                break;
+            }
+            case "group_msg": {
+                // 用户消息作为 user - 使用自然语言格式的chat字段
+                messages.push({
+                    role: "user",
+                    content: [{ type: "text", value: msg.value.chat }],
+                });
+                break;
+            }
+        }
+    });
+
+    return messages;
+}
+```
+
+### 只读访问接口
+```typescript
+getMessageHistory(): readonly Message[] {
+    return this.messageHistory;
+}
+```
+
+## 构造函数与配置
+
+### 初始化参数
+```typescript
+constructor(
+    botQQ: number,
+    groupId: number,
+    masterConfig?: MasterConfig,
+    maxHistorySize = 40,
+) {
+    this.botQQ = botQQ;
+    this.groupId = groupId;
+    this.masterConfig = masterConfig;
+    this.maxHistorySize = maxHistorySize;
+    this.promptTemplateManager = new PromptTemplateManager();
+}
+```
+
+### 核心属性
+- **botQQ**: 机器人QQ号，用于生成系统提示词
+- **groupId**: 群组ID，用于上下文识别
+- **messageHistory**: 消息历史数组，采用LRU策略
+- **maxHistorySize**: 历史消息最大长度，默认40条
+- **promptTemplateManager**: 提示词模板管理器
+- **masterConfig**: 主人配置信息（可选）
+
+## 思考链数据结构
+
+### 类型定义
+```typescript
+interface ThoughtItem {
+    type: "thought";
+    content: string;
+}
+
+interface ChatItem {
+    type: "chat";
+    content: SendMessageSegment[];
+}
+
+type LlmResponseItem = ThoughtItem | ChatItem;
+```
+
+### 数据转换
+- **用户消息**: 转换为 `role: "user"` 的自然语言格式
+- **机器人消息**: 转换为 `role: "assistant"` 的结构化JSON格式，包含思考链
+- **系统消息**: 通过 [[prompt_template_manager]] 生成动态提示词
+
+## 架构优势
+
+### 单一职责
+- **专注上下文管理**: 只负责消息历史和LLM数据准备
+- **职责明确**: 与消息处理流程完全分离
+- **易于测试**: 纯数据操作，便于单元测试
+
+### 封装性
+- **私有属性**: 所有内部状态都是私有的
+- **受控访问**: 通过公共方法控制数据操作
+- **只读接口**: `getMessageHistory()` 提供安全的数据访问
+
+### 可复用性
+- **独立性**: 不依赖具体的消息处理逻辑
+- **配置灵活**: 支持不同的历史长度和配置
+- **模块化**: 可以在不同上下文中复用
+
+## 内存管理
+
+### LRU 策略
+```typescript
+// 自动清理旧消息，保持内存使用稳定
+if (this.messageHistory.length > this.maxHistorySize) {
+    this.messageHistory.shift();
+}
+```
+
+### 性能特性
+- **常数时间添加**: 数组push操作
+- **常数时间清理**: 数组shift操作
+- **可配置大小**: 通过maxHistorySize控制内存使用
+- **无内存泄漏**: 自动清理超出限制的历史记录
+
+## 依赖关系
+
+### 核心依赖
+- [[prompt_template_manager]] - Handlebars模板系统
+- [[message_data_model]] - Message接口和相关类型
+- [[config_system]] - MasterConfig配置类型
+
+### 导入的类型
+- **SendMessageSegment**: node-napcat-ts的消息段类型
+- **ChatMessages**: LLM提供商的消息格式
+- **Message**: 内部消息数据模型
+
+### 使用者
+- [[message_handler]] - 主要使用者，通过组合方式使用ContextManager
+
+## 使用示例
+
+### 在MessageHandler中的使用
+```typescript
+export class MessageHandler implements IMessageHandler {
+    private contextManager: ContextManager;
+    protected session: Session;
+
+    constructor(
+        botQQ: number,
+        groupId: number,
+        session: Session,
+        masterConfig?: MasterConfig,
+        maxHistorySize = 40,
+    ) {
+        this.session = session;
+        this.contextManager = new ContextManager(botQQ, groupId, masterConfig, maxHistorySize);
+    }
+
+    async handleMessage(message: Message): Promise<void> {
+        // 添加消息到历史
+        this.contextManager.addMessageToHistory(message);
+
+        // 处理消息...
+        await this.tryProcessAndReply();
+    }
+
+    protected async processAndReply(): Promise<void> {
+        // 构建LLM上下文
+        const chatMessages = this.contextManager.buildChatMessages();
+
+        // 调用LLM...
+        const llmResponse = await llmClientManager.callWithFallback(chatMessages);
+
+        // 将响应添加到历史
+        const botMessage: Message = {
+            type: "bot_msg",
+            value: { thoughts, chat: reply },
+        };
+        this.contextManager.addMessageToHistory(botMessage);
+    }
+}
+```
+
+### 独立使用示例
+```typescript
+// 创建上下文管理器
+const contextManager = new ContextManager(
+    123456789,  // botQQ
+    987654321,  // groupId
+    masterConfig,
+    50  // maxHistorySize
+);
+
+// 添加用户消息
+const userMessage: Message = {
+    type: "group_msg",
+    value: {
+        id: "msg123",
+        userId: 111111,
+        userNickname: "用户名",
+        chat: "Hello, bot!",
+        timestamp: "2024-01-01 12:00:00"
+    }
+};
+contextManager.addMessageToHistory(userMessage);
+
+// 构建LLM上下文
+const chatMessages = contextManager.buildChatMessages();
+
+// 获取历史记录（只读）
+const history = contextManager.getMessageHistory();
+console.log(`当前历史记录数量: ${history.length}`);
+```
+
+## 相关文件
+- `src/context_manager.ts` - 主要实现
+- `src/message_handler.ts` - 主要使用者
+- `src/prompt_template_manager.ts` - 提示词模板依赖
+- `src/session.ts` - Message类型定义

--- a/docs/knowledge/index.md
+++ b/docs/knowledge/index.md
@@ -37,6 +37,7 @@ Kagami System
 
 ### 消息处理
 - [[message_handler]] - 统一消息处理器，集成 LLM 和并发控制
+- [[context_manager]] - 上下文管理器，负责消息历史管理和LLM数据准备
 
 ### 支持组件
 - [[llm_client_manager]] - LLM 客户端管理器，负责模型降级和统一调用
@@ -61,18 +62,23 @@ KagamiBot
 │                   → logger → DatabaseLayer
 └── SessionManager → ConnectionManager
     └── Session → MessageHandler → LlmClientManager
-                                → PromptTemplateManager
+                                 → ContextManager → PromptTemplateManager
 ```
 
 ### 消息流
 ```
-napcat群消息 → ConnectionManager → SessionManager → Session → MessageHandler → LlmClientManager → LlmClient[] → 回复
+napcat群消息 → ConnectionManager → SessionManager → Session → MessageHandler
+                                                             ↓
+                                              ContextManager → LlmClientManager → LlmClient[] → 回复
+                                                             ↓
+                                                    PromptTemplateManager
 ```
 
 ## 核心特性
 
 - **分层架构**：职责分离，模块化设计
-- **统一处理**：简化的消息处理架构，集成所有功能
+- **统一处理**：简化的消息处理架构，专注流程控制
+- **上下文管理**：独立的消息历史管理和LLM数据准备模块
 - **模型降级**：支持多模型按优先级降级，提高可用性
 - **思考链**：LLM 支持结构化的思考-回复流程
 - **模板化提示词**：基于 Handlebars 的动态 prompt 生成系统

--- a/kagami-bot/src/config.ts
+++ b/kagami-bot/src/config.ts
@@ -2,9 +2,6 @@ import * as fs from "fs";
 import * as yaml from "yaml";
 import { ProviderConfig } from "./llm_providers/types.js";
 
-// 重新导出类型
-export { ProviderConfig } from "./llm_providers/types.js";
-
 export function findProviderByModel(providers: Record<string, ProviderConfig>, model: string): string | null {
     for (const [providerName, config] of Object.entries(providers)) {
         if (config.models.includes(model)) {

--- a/kagami-bot/src/context_manager.ts
+++ b/kagami-bot/src/context_manager.ts
@@ -1,0 +1,104 @@
+import { SendMessageSegment } from "node-napcat-ts";
+import { Message } from "./session.js";
+import { MasterConfig } from "./config.js";
+import { PromptTemplateManager } from "./prompt_template_manager.js";
+import { getShanghaiTimestamp } from "./utils/timezone.js";
+import { ChatMessages } from "./llm_providers/types.js";
+
+interface ThoughtItem {
+    type: "thought";
+    content: string;
+}
+
+interface ChatItem {
+    type: "chat";
+    content: SendMessageSegment[];
+}
+
+type LlmResponseItem = ThoughtItem | ChatItem;
+
+export class ContextManager {
+    private botQQ: number;
+    private groupId: number;
+    private messageHistory: Message[] = [];
+    private maxHistorySize: number;
+    private promptTemplateManager: PromptTemplateManager;
+    private masterConfig?: MasterConfig;
+
+    constructor(
+        botQQ: number,
+        groupId: number,
+        masterConfig?: MasterConfig,
+        maxHistorySize = 40,
+    ) {
+        this.botQQ = botQQ;
+        this.groupId = groupId;
+        this.masterConfig = masterConfig;
+        this.maxHistorySize = maxHistorySize;
+        this.promptTemplateManager = new PromptTemplateManager();
+    }
+
+    addMessageToHistory(message: Message): void {
+        this.messageHistory.push(message);
+
+        // 使用 LRU 策略，保持最近 N 条消息
+        if (this.messageHistory.length > this.maxHistorySize) {
+            this.messageHistory.shift();
+        }
+    }
+
+    buildChatMessages(): ChatMessages[] {
+        // 使用Handlebars模板生成系统提示
+        const systemPrompt = this.promptTemplateManager.generatePrompt({
+            botQQ: this.botQQ,
+            masterConfig: this.masterConfig,
+            currentTime: getShanghaiTimestamp(),
+        });
+
+        const messages: ChatMessages[] = [
+            {
+                role: "system",
+                content: [{ type: "text", value: systemPrompt }],
+            },
+        ];
+
+        this.messageHistory.forEach(msg => {
+            switch (msg.type) {
+                case "bot_msg": {
+                    // Bot 的消息作为 assistant
+                    const responseArray: LlmResponseItem[] = [];
+
+                    // 添加所有thoughts
+                    msg.value.thoughts.forEach(thought => {
+                        responseArray.push({ type: "thought", content: thought });
+                    });
+
+                    // 添加chat（如果有）
+                    if (msg.value.chat && msg.value.chat.length > 0) {
+                        responseArray.push({ type: "chat", content: msg.value.chat });
+                    }
+
+                    messages.push({
+                        role: "assistant",
+                        content: [{ type: "text", value: JSON.stringify(responseArray) }],
+                    });
+                    break;
+                }
+                case "group_msg": {
+                    // 用户消息作为 user - 使用自然语言格式的chat字段
+                    messages.push({
+                        role: "user",
+                        content: [{ type: "text", value: msg.value.chat }],
+                    });
+                    break;
+                }
+            }
+        });
+
+        return messages;
+    }
+
+    getMessageHistory(): readonly Message[] {
+        return this.messageHistory;
+    }
+}

--- a/kagami-bot/src/llm.ts
+++ b/kagami-bot/src/llm.ts
@@ -1,5 +1,4 @@
-import { ProviderConfig } from "./config.js";
-import { LlmProvider, ChatMessages } from "./llm_providers/types.js";
+import { ProviderConfig, LlmProvider, ChatMessages } from "./llm_providers/types.js";
 import { createLlmProvider } from "./llm_providers/factory.js";
 import { logger } from "./middleware/logger.js";
 

--- a/kagami-bot/src/llm_providers/types.ts
+++ b/kagami-bot/src/llm_providers/types.ts
@@ -1,13 +1,3 @@
-// deprecated
-export interface ChatMessageData {
-    role: "system" | "user" | "assistant";
-    content: string | {
-        type: "text" | "image_url";
-        text?: string;
-        image_url?: { url: string };
-    }[];
-}
-
 export type ChatMessagePart =
     | {
         type: "text",

--- a/kagami-bot/src/session.ts
+++ b/kagami-bot/src/session.ts
@@ -154,4 +154,8 @@ export class Session {
     setMessageHandler(handler: MessageHandler): void {
         this.messageHandler = handler;
     }
+
+    getGroupId(): number {
+        return this.groupId;
+    }
 }


### PR DESCRIPTION
- 创建新的 ContextManager 类，专门负责消息历史管理和LLM上下文构建
- 重构 MessageHandler 类，使用组合模式委托上下文管理给 ContextManager
- 移除 config.ts 中不必要的重新导出，简化导入结构
- 修复 llm_providers/types.ts 中的类型安全问题，移除已弃用的接口
- 更新 Session 类，添加 getGroupId() 方法支持更好的封装
- 增强消息处理的自然语言转换功能和错误处理能力
- 更新相关文档，反映新的架构和职责分离