### PR TITLE
refactor: 移除优雅关闭机制并重构领域模型

### DIFF
--- a/docs/knowledge/kagami_bot.md
+++ b/docs/knowledge/kagami_bot.md
@@ -44,22 +44,6 @@ async function bootstrap() {
 start(): void {
     console.log("Kagami 机器人启动成功");
     console.log(`活跃会话数量: ${String(this.sessionManager.getSessionCount())}`);
-
-    this.setupGracefulShutdown();
-}
-```
-
-### 关闭流程
-```typescript
-stop(): void {
-    console.log("正在停止 Kagami 机器人...");
-
-    try {
-        this.sessionManager.shutdownAllSessions();
-        console.log("Kagami 机器人停止成功");
-    } catch (error) {
-        console.error("关闭过程中发生错误:", error);
-    }
 }
 ```
 
@@ -96,7 +80,6 @@ export const newKagamiBot = (sessionManager: SessionManager) => {
 ### 运行时阶段
 - 会话初始化失败不会终止整个应用
 - 单个群组连接失败不影响其他群组
-- 优雅关闭时捕获并记录清理过程中的错误
 
 ## 生命周期管理
 
@@ -107,13 +90,6 @@ export const newKagamiBot = (sessionManager: SessionManager) => {
 4. **LLM 层**：LlmClientManager 创建（依赖 ConfigManager 和 Database）
 5. **编排层**：SessionManager 创建并自动初始化所有会话
 6. **应用层**：KagamiBot 创建并启动
-7. **信号处理器注册**：setupGracefulShutdown()
-
-### 关闭顺序
-1. 接收关闭信号（SIGINT/SIGTERM）
-2. 关闭所有群组会话
-3. 断开 NapCat 连接
-4. 进程退出
 
 ## 依赖注入架构
 
@@ -147,20 +123,6 @@ if (import.meta.url === `file://${process.argv[1]}`) {
         console.error("致命错误:", error);
         process.exit(1);
     });
-}
-```
-
-### 优雅关闭
-```typescript
-private setupGracefulShutdown(): void {
-    const shutdown = (signal: string) => {
-        console.log(`接收到 ${signal} 信号，正在优雅关闭...`);
-        this.stop();
-        process.exit(0);
-    };
-
-    process.on("SIGINT", () => { shutdown("SIGINT"); });
-    process.on("SIGTERM", () => { shutdown("SIGTERM"); });
 }
 ```
 

--- a/docs/knowledge/llm_client.md
+++ b/docs/knowledge/llm_client.md
@@ -10,15 +10,25 @@ LlmClient 是单个 LLM 模型的调用客户端，通过 [[llm_provider_abstrac
 ```typescript
 async oneTurnChat(request: OneTurnChatRequest): Promise<LlmResponse> {
     // 生成输入字符串用于记录（保持原有格式）
-    const inputForLog = JSON.stringify(request.messages, null, 2);
+    const inputForLog = JSON.stringify(request.messages, null, 2); // TODO: 增加日志信息
 
     try {
         const llmResponse = await this.provider.oneTurnChat(this.model, request);
-        void this.llmCallLogRepository.logLLMCall("success", inputForLog, llmResponse.content ?? "");
+        void this.llmCallLogRepository.insert({
+            status: "success",
+            input: inputForLog,
+            output: llmResponse.content ?? "",
+            timestamp: new Date(),
+        }); // TODO: 保存工具调用
         return llmResponse;
     } catch (error) {
         const errorMessage = error instanceof Error ? error.message : JSON.stringify(error, null, 2);
-        void this.llmCallLogRepository.logLLMCall("fail", inputForLog, `模型 ${this.model} 调用失败: ${errorMessage}`);
+        void this.llmCallLogRepository.insert({
+            status: "fail",
+            input: inputForLog,
+            output: `模型 ${this.model} 调用失败: ${errorMessage}`,
+            timestamp: new Date(),
+        });
         throw error;
     }
 }

--- a/docs/knowledge/session_manager.md
+++ b/docs/knowledge/session_manager.md
@@ -145,25 +145,6 @@ async broadcastMessage(content: SendMessageSegment[]): Promise<number> {
 }
 ```
 
-## 生命周期管理
-
-### 关闭流程
-```typescript
-shutdownAllSessions(): void {
-    console.log("正在关闭所有会话...");
-
-    try {
-        this.napcatFacade.disconnect();
-        console.log("连接管理器已关闭");
-    } catch (error) {
-        console.error("关闭连接管理器失败:", error);
-    }
-
-    this.sessions.clear();
-    console.log("所有会话已关闭");
-}
-```
-
 ## 状态监控
 
 ### 连接状态查询

--- a/kagami-bot/src/domain/llm_call_log.ts
+++ b/kagami-bot/src/domain/llm_call_log.ts
@@ -1,23 +1,14 @@
 export type LlmCallStatus = "success" | "fail";
 
-export class LlmCallLog {
-    readonly id: number;
+interface LlmCallLogData {
     readonly timestamp: Date;
     readonly status: LlmCallStatus;
     readonly input: string;
     readonly output: string;
-
-    constructor(
-        id: number,
-        timestamp: Date,
-        status: LlmCallStatus,
-        input: string,
-        output: string,
-    ) {
-        this.id = id;
-        this.timestamp = timestamp;
-        this.status = status;
-        this.input = input;
-        this.output = output;
-    }
 }
+
+export type LlmCallLog = LlmCallLogData & {
+    readonly id: number;
+};
+
+export type LlmCallLogCreateRequest = LlmCallLogData;

--- a/kagami-bot/src/infra/llm_call_log_repository.ts
+++ b/kagami-bot/src/infra/llm_call_log_repository.ts
@@ -1,5 +1,5 @@
 import { Database } from "./db.js";
-import { LlmCallStatus } from "../domain/llm_call_log.js";
+import { LlmCallLogCreateRequest } from "../domain/llm_call_log.js";
 
 export class LlmCallLogRepository {
     private database: Database;
@@ -8,17 +8,14 @@ export class LlmCallLogRepository {
         this.database = database;
     }
 
-    async logLLMCall(
-        status: LlmCallStatus,
-        input: string,
-        output: string,
-    ): Promise<void> {
+    async insert(llmCallLog: LlmCallLogCreateRequest): Promise<void> {
         try {
             await this.database.prisma().llmCallLog.create({
                 data: {
-                    status,
-                    input,
-                    output,
+                    status: llmCallLog.status,
+                    input: llmCallLog.input,
+                    output: llmCallLog.output,
+                    timestamp: llmCallLog.timestamp,
                 },
             });
         } catch (error) {

--- a/kagami-bot/src/llm.ts
+++ b/kagami-bot/src/llm.ts
@@ -19,11 +19,21 @@ export class LlmClient {
 
         try {
             const llmResponse = await this.provider.oneTurnChat(this.model, request);
-            void this.llmCallLogRepository.logLLMCall("success", inputForLog, llmResponse.content ?? ""); // TODO: 保存工具调用
+            void this.llmCallLogRepository.insert({
+                status: "success",
+                input: inputForLog,
+                output: llmResponse.content ?? "",
+                timestamp: new Date(),
+            }); // TODO: 保存工具调用
             return llmResponse;
         } catch (error) {
             const errorMessage = error instanceof Error ? error.message : JSON.stringify(error, null, 2);
-            void this.llmCallLogRepository.logLLMCall("fail", inputForLog, `模型 ${this.model} 调用失败: ${errorMessage}`);
+            void this.llmCallLogRepository.insert({
+                status: "fail",
+                input: inputForLog,
+                output: `模型 ${this.model} 调用失败: ${errorMessage}`,
+                timestamp: new Date(),
+            });
             throw error;
         }
     }

--- a/kagami-bot/src/main.ts
+++ b/kagami-bot/src/main.ts
@@ -16,30 +16,6 @@ class KagamiBot {
     start(): void {
         console.log("Kagami 机器人启动成功");
         console.log(`活跃会话数量: ${String(this.sessionManager.getSessionCount())}`);
-
-        this.setupGracefulShutdown();
-    }
-
-    stop(): void {
-        console.log("正在停止 Kagami 机器人...");
-
-        try {
-            this.sessionManager.shutdownAllSessions();
-            console.log("Kagami 机器人停止成功");
-        } catch (error) {
-            console.error("关闭过程中发生错误:", error);
-        }
-    }
-
-    private setupGracefulShutdown(): void {
-        const shutdown = (signal: string) => {
-            console.log(`接收到 ${signal} 信号，正在优雅关闭...`);
-            this.stop();
-            process.exit(0);
-        };
-
-        process.on("SIGINT", () => { shutdown("SIGINT"); });
-        process.on("SIGTERM", () => { shutdown("SIGTERM"); });
     }
 }
 

--- a/kagami-bot/src/session_manager.ts
+++ b/kagami-bot/src/session_manager.ts
@@ -64,20 +64,6 @@ export class SessionManager {
         }
     }
 
-    shutdownAllSessions(): void {
-        console.log("正在关闭所有会话...");
-
-        try {
-            this.napcatFacade.disconnect();
-            console.log("连接管理器已关闭");
-        } catch (error) {
-            console.error("关闭连接管理器失败:", error);
-        }
-
-        this.sessions.clear();
-        console.log("所有会话已关闭");
-    }
-
     getSessionCount(): number {
         return this.sessions.size;
     }


### PR DESCRIPTION
- 移除 KagamiBot 和 SessionManager 的优雅关闭功能
  - 删除 KagamiBot.stop() 和 setupGracefulShutdown() 方法
  - 删除 SessionManager.shutdownAllSessions() 方法
  - 移除 SIGINT/SIGTERM 信号处理逻辑
- 简化领域层设计
  - LlmCallLog 从 class 重构为 type，提升简洁性
  - 新增 LlmCallLogCreateRequest 类型用于创建请求
  - 增强类型系统的关注点分离（实体 vs 创建请求）
- 优化 Repository 接口
  - 重命名 logLLMCall() → insert()，更符合数据访问语义
  - 使用 LlmCallLogCreateRequest 整合参数，提升接口清晰度
  - 显式传递 timestamp 字段，增强数据完整性
- 同步更新知识图谱文档反映架构变更