### PR TITLE
refactor(agent): 子 Agent / 召回 / 主 Agent 上下文摘要切换为 auto tool choice

### DIFF
--- a/apps/server/src/agent/capabilities/context-summary/operations/context-summary.operation.ts
+++ b/apps/server/src/agent/capabilities/context-summary/operations/context-summary.operation.ts
@@ -1,5 +1,5 @@
 import type { LlmClient } from "../../../../llm/client.js";
-import type { LlmMessage, Tool } from "../../../../llm/types.js";
+import type { LlmMessage, LlmToolChoice, Tool } from "../../../../llm/types.js";
 import type { Operation, ToolExecutor } from "@kagami/agent-runtime";
 import { SUMMARY_TOOL_NAME } from "../tools/summary.tool.js";
 
@@ -19,19 +19,23 @@ export class ContextSummaryOperation
   private readonly llmClient: LlmClient;
   private readonly summaryToolExecutor: ToolExecutor;
   private readonly reminderMessageFactory: () => Extract<LlmMessage, { role: "user" }>;
+  private readonly toolChoice: LlmToolChoice;
 
   public constructor({
     llmClient,
     summaryToolExecutor,
     reminderMessageFactory,
+    toolChoice,
   }: {
     llmClient: LlmClient;
     summaryToolExecutor: ToolExecutor;
     reminderMessageFactory: () => Extract<LlmMessage, { role: "user" }>;
+    toolChoice?: LlmToolChoice;
   }) {
     this.llmClient = llmClient;
     this.summaryToolExecutor = summaryToolExecutor;
     this.reminderMessageFactory = reminderMessageFactory;
+    this.toolChoice = toolChoice ?? { tool_name: SUMMARY_TOOL_NAME };
   }
 
   public async execute(input: ContextSummaryInput): Promise<string | null> {
@@ -40,7 +44,7 @@ export class ContextSummaryOperation
         system: input.systemPrompt,
         messages: [...input.messages, this.reminderMessageFactory()],
         tools: input.tools,
-        toolChoice: { tool_name: SUMMARY_TOOL_NAME },
+        toolChoice: this.toolChoice,
       },
       {
         usage: "contextSummarizer",

--- a/apps/server/src/agent/capabilities/story/runtime/story-recall.extension.ts
+++ b/apps/server/src/agent/capabilities/story/runtime/story-recall.extension.ts
@@ -143,7 +143,7 @@ export class StoryRecallExtension implements LoopAgentExtension<
         system: snapshot.systemPrompt,
         messages,
         tools: this.availableTools,
-        toolChoice: { tool_name: "search_memory" },
+        toolChoice: "auto",
       },
       { usage: "agent" },
     );

--- a/apps/server/src/agent/capabilities/web-search/task-agent/web-search-task-agent.ts
+++ b/apps/server/src/agent/capabilities/web-search/task-agent/web-search-task-agent.ts
@@ -27,6 +27,7 @@ export class WebSearchTaskAgent
   }) {
     super({
       model: llmClient,
+      toolChoice: "auto",
       taskTools: taskTools ?? searchTools ?? failMissingTaskTools(),
       terminalToolNames: [FINALIZE_WEB_SEARCH_TOOL_NAME],
     });

--- a/apps/server/src/app/agent-runtime.factory.ts
+++ b/apps/server/src/app/agent-runtime.factory.ts
@@ -256,6 +256,7 @@ export async function buildAgentRuntime({
     llmClient,
     summaryToolExecutor,
     reminderMessageFactory: createRootContextSummaryReminderMessage,
+    toolChoice: "auto",
   });
   const storyContextSummaryOperation = new ContextSummaryOperation({
     llmClient,

--- a/apps/server/test/agent/web-search-agent.test.ts
+++ b/apps/server/test/agent/web-search-agent.test.ts
@@ -122,7 +122,7 @@ describe("WebSearchAgent", () => {
           },
           createWebSearchInstructionMessage("OpenAI 最近有什么新动态？"),
         ],
-        toolChoice: "required",
+        toolChoice: "auto",
         tools: expect.arrayContaining([
           expect.objectContaining({ name: SEARCH_WEB_RAW_TOOL_NAME }),
           expect.objectContaining({ name: FINALIZE_WEB_SEARCH_TOOL_NAME }),

--- a/packages/agent-runtime/src/task-agent-runtime.ts
+++ b/packages/agent-runtime/src/task-agent-runtime.ts
@@ -3,6 +3,7 @@ import {
   ReActKernel,
   type AssistantLikeMessage,
   type ReActModel,
+  type ReActModelToolChoice,
   type ToolLikeMessage,
 } from "./react-kernel.js";
 import type { ToolExecutor } from "./tool/tool-catalog.js";
@@ -36,11 +37,13 @@ export abstract class BaseTaskAgent<
   public constructor({
     kernel,
     model,
+    toolChoice,
     taskTools,
     terminalToolNames,
   }: {
     kernel?: ReActKernel<TMessage, TUsage>;
     model?: TaskAgentModel<TMessage, TUsage>;
+    toolChoice?: ReActModelToolChoice;
     taskTools: ToolExecutor<TMessage>;
     /**
      * Names of the tools whose invocation marks the task as complete.
@@ -55,7 +58,12 @@ export abstract class BaseTaskAgent<
     if (terminalToolNames.length === 0) {
       throw new Error("BaseTaskAgent requires at least one terminalToolName");
     }
-    this.kernel = kernel ?? new ReActKernel({ model: model ?? failMissingTaskAgentModel() });
+    this.kernel =
+      kernel ??
+      new ReActKernel({
+        model: model ?? failMissingTaskAgentModel(),
+        ...(toolChoice !== undefined ? { toolChoice } : {}),
+      });
     this.taskTools = taskTools;
     this.terminalToolNames = new Set(terminalToolNames);
   }


### PR DESCRIPTION
## 背景

上一个 PR（#56）把主 Agent 的 \`tool_choice\` 切到 \`auto\`，但当时 PR 描述里"不影响 KV 缓存"的判断是错的。查 [Anthropic Prompt Caching 文档](https://platform.claude.com/docs/en/docs/build-with-claude/prompt-caching) 后确认：

> Changes to \`tool_choice\` parameter only affect message blocks.

即 \`tool_choice\` 变化会让 **messages cache 失效**（tools / system cache 仍然命中）。

主 Agent 改 \`auto\` 后，所有**仍以 \`required\` 或指定 tool 发起、且基于主 Agent 上下文**的 fork 路径，每次都会让 messages cache miss —— 例如 web-search 每次 fork 都要重算主 Agent 累积的整段历史。本 PR 让这些 fork 路径统一对齐到 \`auto\`，恢复缓存复用。

## 改动

| 位置 | 旧 | 新 |
|---|---|---|
| \`BaseTaskAgent\`（agent-runtime）| 默认 kernel = \`required\` | 新增可选 \`toolChoice\` 参数透传 |
| \`WebSearchTaskAgent\` | required | **auto** |
| \`story-recall.extension\` | \`{ tool_name: "search_memory" }\` | **auto** |
| \`ContextSummaryOperation\` | 写死 \`{ tool_name: SUMMARY_TOOL_NAME }\` | 新增可选 \`toolChoice\`，默认仍为 \`{ tool_name: SUMMARY_TOOL_NAME }\` |
| factory: root 用的 ContextSummaryOperation 实例 | (默认) | **auto** |
| factory: story 用的 ContextSummaryOperation 实例 | (默认) | **不变**（保持指定 tool）|

Story Agent 自身的 kernel、Story Agent 用的上下文摘要均保持原状 —— **Story Agent 的 messages 上下文独立于主 Agent，与主 Agent 缓存本来就不共享，切换无收益**。

## 缓存对齐效果

| 路径 | 主 Agent messages cache 复用 |
|---|---|
| 主 Agent 自身多轮 | ✅ |
| web-search fork 首次请求 | ✅ |
| web-search 内部多轮 | ✅ |
| story-recall 召回 | ✅ |
| 主 Agent context-summary 触发的请求 | ✅（复用主 Agent 累积前缀，仅重算追加的 reminder 消息和摘要响应）|
| Story Agent 自身（含其 context-summary）| 不变，独立上下文 |

## 风险（暂不补 fallback）

| 路径 | 风险 | 现有兜底 |
|---|---|---|
| web-search 子 Agent | 模型纯文本不调 \`finalize_web_search\` → loop 不停 | ❌ 无，需观察 |
| story-recall | 模型不调 \`search_memory\` | ✅ \`if (!toolCall) return null\`，跳过该轮召回 |
| 主 Agent context-summary | 模型不调 \`summary\` tool | ✅ \`if (!summary) return false\`，本轮不压缩，下一轮再触发 |

## 验证

- \`pnpm typecheck\` ✅
- \`pnpm lint\` ✅
- \`pnpm format\` ✅
- \`pnpm --filter @kagami/server test\` ✅（425 个测试全部通过）

## Test plan

- [x] typecheck / lint / format / test 全部通过
- [ ] 部署后观察 web-search 是否出现 loop 不停（如有再补 fallback）

🤖 Generated with [Claude Code](https://claude.com/claude-code)