### PR TITLE
perf(agent/story): StoryRecall 异步化，主 Agent 不再为召回等待

### DIFF
--- a/apps/server/src/agent/capabilities/story/runtime/story-recall.extension.ts
+++ b/apps/server/src/agent/capabilities/story/runtime/story-recall.extension.ts
@@ -1,30 +1,18 @@
 import type { LoopAgentExtension } from "@kagami/agent-runtime";
-import type { LlmClient } from "../../../../llm/client.js";
-import type { LlmMessage, Tool } from "../../../../llm/types.js";
+import type { LlmMessage } from "../../../../llm/types.js";
 import type {
   RootAgentCompletion,
   RootAgentToolExecutionData,
   RootLoopExtensionContext,
 } from "../../../runtime/root-agent/root-agent-runtime.js";
-import type { StoryRecallService } from "../application/story-recall.service.js";
-import { AppLogger } from "../../../../logger/logger.js";
+import type { StoryRecallScheduler } from "./story-recall.scheduler.js";
 
-const logger = new AppLogger({ source: "agent.story-recall" });
-
-const QUERY_GENERATION_INSTRUCTION = [
-  "<system_instruction>",
-  "请根据当前对话上下文，调用 search_memory 工具搜索可能相关的历史记忆。",
-  "生成一个能捕捉当前话题核心的搜索查询。",
-  "</system_instruction>",
-].join("\n");
-
-function formatRecallDate(date: Date): string {
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, "0");
-  const d = String(date.getDate()).padStart(2, "0");
-  return `${y}-${m}-${d}`;
-}
-
+/**
+ * StoryRecallExtension：薄壳，仅在每轮 onBeforeRound 给 scheduler 踢一脚。
+ *
+ * 真实召回逻辑在 StoryRecallScheduler 里异步进行；本扩展不再 await 召回结果。
+ * 召回完成会以事件方式回到主 Agent 事件队列，由 session 路由进上下文。
+ */
 export class StoryRecallExtension implements LoopAgentExtension<
   RootLoopExtensionContext,
   LlmMessage,
@@ -32,145 +20,21 @@ export class StoryRecallExtension implements LoopAgentExtension<
   RootAgentCompletion,
   RootAgentToolExecutionData
 > {
-  private readonly llmClient: LlmClient;
-  private readonly storyRecallService: StoryRecallService;
-  private readonly availableTools: Tool[];
-  private readonly topK: number;
-  private readonly scoreThreshold: number;
+  private readonly scheduler: StoryRecallScheduler;
 
-  private readonly injectedStoryIds = new Set<string>();
-  private lastRecallMessageCount = 0;
-
-  public constructor({
-    llmClient,
-    storyRecallService,
-    availableTools,
-    topK,
-    scoreThreshold,
-  }: {
-    llmClient: LlmClient;
-    storyRecallService: StoryRecallService;
-    availableTools: Tool[];
-    topK: number;
-    scoreThreshold: number;
-  }) {
-    this.llmClient = llmClient;
-    this.storyRecallService = storyRecallService;
-    this.availableTools = availableTools;
-    this.topK = topK;
-    this.scoreThreshold = scoreThreshold;
+  public constructor({ scheduler }: { scheduler: StoryRecallScheduler }) {
+    this.scheduler = scheduler;
   }
 
-  public async onBeforeRound(context: RootLoopExtensionContext): Promise<void> {
-    try {
-      await this.performRecall(context);
-    } catch (error) {
-      logger.warn("Story recall failed; skipping", {
-        event: "agent.story_recall.failed",
-        errorName: error instanceof Error ? error.name : "Error",
-        errorMessage: error instanceof Error ? error.message : String(error),
-      });
-    }
+  public onBeforeRound(): void {
+    this.scheduler.trigger();
   }
 
   public onContextCompacted(): void {
-    this.injectedStoryIds.clear();
-    this.lastRecallMessageCount = 0;
+    this.scheduler.onContextCompacted();
   }
 
   public onAfterReset(): void {
-    this.injectedStoryIds.clear();
-    this.lastRecallMessageCount = 0;
-  }
-
-  private async performRecall(context: RootLoopExtensionContext): Promise<void> {
-    const snapshot = await context.host.getContextSnapshot();
-
-    if (snapshot.messages.length === this.lastRecallMessageCount) {
-      return;
-    }
-
-    const query = await this.generateQuery(snapshot);
-    if (!query || query.trim().length < 2) {
-      this.lastRecallMessageCount = snapshot.messages.length;
-      return;
-    }
-
-    logger.info("Story recall query generated", {
-      event: "agent.story_recall.query_generated",
-      queryText: query,
-    });
-
-    const results = await this.storyRecallService.search({
-      query,
-      topK: this.topK,
-    });
-
-    const filtered = results.filter(
-      r => r.score >= this.scoreThreshold && !this.injectedStoryIds.has(r.story.id),
-    );
-
-    if (filtered.length > 0) {
-      const recallMessage = this.formatRecallMessage(filtered);
-      await context.host.appendMessages([recallMessage]);
-
-      for (const r of filtered) {
-        this.injectedStoryIds.add(r.story.id);
-      }
-
-      logger.info("Story recall results injected", {
-        event: "agent.story_recall.injected",
-        count: filtered.length,
-        storyIds: filtered.map(r => r.story.id),
-        scores: filtered.map(r => r.score.toFixed(3)),
-      });
-    }
-
-    this.lastRecallMessageCount = snapshot.messages.length;
-  }
-
-  private async generateQuery(snapshot: {
-    systemPrompt: string;
-    messages: LlmMessage[];
-  }): Promise<string | null> {
-    const messages: LlmMessage[] = [
-      ...snapshot.messages,
-      { role: "user" as const, content: QUERY_GENERATION_INSTRUCTION },
-    ];
-
-    const response = await this.llmClient.chat(
-      {
-        system: snapshot.systemPrompt,
-        messages,
-        tools: this.availableTools,
-        toolChoice: "auto",
-      },
-      { usage: "agent" },
-    );
-
-    const toolCall = response.message.toolCalls?.[0];
-    if (!toolCall || toolCall.name !== "search_memory") {
-      return null;
-    }
-
-    const query = toolCall.arguments?.query;
-    if (typeof query !== "string") {
-      return null;
-    }
-
-    return query;
-  }
-
-  private formatRecallMessage(
-    results: Awaited<ReturnType<StoryRecallService["search"]>>,
-  ): LlmMessage {
-    const parts = results.map(r => {
-      const date = formatRecallDate(r.story.createdAt);
-      return [`你想起了一件发生在 ${date} 的事情：`, "", r.story.markdown].join("\n");
-    });
-
-    const content = ["<story_recall>", ...parts, "</story_recall>"].join("\n");
-
-    return { role: "user", content };
+    this.scheduler.onAfterReset();
   }
 }

--- a/apps/server/src/agent/capabilities/story/runtime/story-recall.scheduler.ts
+++ b/apps/server/src/agent/capabilities/story/runtime/story-recall.scheduler.ts
@@ -1,0 +1,191 @@
+import type { Queue } from "@kagami/agent-runtime";
+import type { AgentContext } from "../../../runtime/context/agent-context.js";
+import type { Event, StoryRecallStoryPayload } from "../../../runtime/event/event.js";
+import type { LlmClient } from "../../../../llm/client.js";
+import type { LlmMessage, Tool } from "../../../../llm/types.js";
+import { AppLogger } from "../../../../logger/logger.js";
+import type { StoryRecallService } from "../application/story-recall.service.js";
+
+const logger = new AppLogger({ source: "agent.story-recall" });
+
+const QUERY_GENERATION_INSTRUCTION = [
+  "<system_instruction>",
+  "请根据当前对话上下文，调用 search_memory 工具搜索可能相关的历史记忆。",
+  "生成一个能捕捉当前话题核心的搜索查询。",
+  "</system_instruction>",
+].join("\n");
+
+export type StoryRecallSchedulerDeps = {
+  llmClient: LlmClient;
+  storyRecallService: StoryRecallService;
+  agentContext: AgentContext;
+  eventQueue: Queue<Event>;
+  availableTools: Tool[];
+  topK: number;
+  scoreThreshold: number;
+};
+
+/**
+ * StoryRecallScheduler：单例后台调度器，串行执行 story recall。
+ *
+ * 调度语义（trailing coalescing）：
+ * - trigger() 时若当前没有在跑，立刻启动一次；
+ * - trigger() 时若已经在跑，把 pendingRerun 置为 true（不论触发多少次只追加一次）；
+ * - 当前任务结束后，若 pendingRerun 为 true 则立刻再跑一次。
+ *
+ * 一次成功跑出非空结果时，会把召回到的故事以 StoryRecallCompletedEvent
+ * 形式塞入主 Agent 的事件队列，session 路由后追加到上下文并触发新一轮 round。
+ * 召回结果为空时不入队事件，避免无意义的唤醒。
+ *
+ * 去重：injectedStoryIds 跨任务保留，避免反复把同一条故事推给主 Agent。
+ * onContextCompacted / onAfterReset 会清空。
+ */
+export class StoryRecallScheduler {
+  private readonly llmClient: LlmClient;
+  private readonly storyRecallService: StoryRecallService;
+  private readonly agentContext: AgentContext;
+  private readonly eventQueue: Queue<Event>;
+  private readonly availableTools: Tool[];
+  private readonly topK: number;
+  private readonly scoreThreshold: number;
+
+  private readonly injectedStoryIds = new Set<string>();
+  private running = false;
+  private pendingRerun = false;
+
+  public constructor(deps: StoryRecallSchedulerDeps) {
+    this.llmClient = deps.llmClient;
+    this.storyRecallService = deps.storyRecallService;
+    this.agentContext = deps.agentContext;
+    this.eventQueue = deps.eventQueue;
+    this.availableTools = deps.availableTools;
+    this.topK = deps.topK;
+    this.scoreThreshold = deps.scoreThreshold;
+  }
+
+  public trigger(): void {
+    if (this.running) {
+      this.pendingRerun = true;
+      return;
+    }
+
+    this.running = true;
+    void this.runLoop();
+  }
+
+  public onContextCompacted(): void {
+    this.injectedStoryIds.clear();
+  }
+
+  public onAfterReset(): void {
+    this.injectedStoryIds.clear();
+    this.pendingRerun = false;
+  }
+
+  private async runLoop(): Promise<void> {
+    try {
+      while (true) {
+        await this.runOnce();
+        if (!this.pendingRerun) {
+          break;
+        }
+        this.pendingRerun = false;
+      }
+    } finally {
+      this.running = false;
+    }
+  }
+
+  private async runOnce(): Promise<void> {
+    try {
+      await this.performRecall();
+    } catch (error) {
+      logger.warn("Story recall failed; skipping", {
+        event: "agent.story_recall.failed",
+        errorName: error instanceof Error ? error.name : "Error",
+        errorMessage: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  private async performRecall(): Promise<void> {
+    const snapshot = await this.agentContext.getSnapshot();
+
+    const query = await this.generateQuery(snapshot);
+    if (!query || query.trim().length < 2) {
+      return;
+    }
+
+    logger.info("Story recall query generated", {
+      event: "agent.story_recall.query_generated",
+      queryText: query,
+    });
+
+    const results = await this.storyRecallService.search({
+      query,
+      topK: this.topK,
+    });
+
+    const filtered = results.filter(
+      r => r.score >= this.scoreThreshold && !this.injectedStoryIds.has(r.story.id),
+    );
+
+    if (filtered.length === 0) {
+      return;
+    }
+
+    const stories: StoryRecallStoryPayload[] = filtered.map(r => ({
+      id: r.story.id,
+      markdown: r.story.markdown,
+      createdAt: r.story.createdAt,
+    }));
+
+    this.eventQueue.enqueue({
+      type: "story_recall_completed",
+      data: { stories },
+    });
+
+    for (const r of filtered) {
+      this.injectedStoryIds.add(r.story.id);
+    }
+
+    logger.info("Story recall results enqueued", {
+      event: "agent.story_recall.enqueued",
+      count: filtered.length,
+      storyIds: filtered.map(r => r.story.id),
+      scores: filtered.map(r => r.score.toFixed(3)),
+    });
+  }
+
+  private async generateQuery(snapshot: {
+    systemPrompt: string;
+    messages: LlmMessage[];
+  }): Promise<string | null> {
+    const messages: LlmMessage[] = [
+      ...snapshot.messages,
+      { role: "user" as const, content: QUERY_GENERATION_INSTRUCTION },
+    ];
+
+    const response = await this.llmClient.chat(
+      {
+        system: snapshot.systemPrompt,
+        messages,
+        tools: this.availableTools,
+        toolChoice: "auto",
+      },
+      { usage: "agent" },
+    );
+
+    const toolCall = response.message.toolCalls?.[0];
+    if (!toolCall || toolCall.name !== "search_memory") {
+      return null;
+    }
+
+    const query = toolCall.arguments?.query;
+    if (typeof query !== "string") {
+      return null;
+    }
+
+    return query;
+  }
+}

--- a/apps/server/src/agent/runtime/context/context-message-factory.ts
+++ b/apps/server/src/agent/runtime/context/context-message-factory.ts
@@ -157,6 +157,24 @@ export function createCrossStateNotificationMessage(
   return createUserMessage(lines.join("\n"));
 }
 
+export function createStoryRecallMessage(
+  stories: Array<{ id: string; markdown: string; createdAt: Date }>,
+): UserMessage {
+  const parts = stories.map(story => {
+    const date = formatStoryRecallDate(story.createdAt);
+    return [`你想起了一件发生在 ${date} 的事情：`, "", story.markdown].join("\n");
+  });
+
+  return createUserMessage(["<story_recall>", ...parts, "</story_recall>"].join("\n"));
+}
+
+function formatStoryRecallDate(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
 export function createWebSearchInstructionMessage(question: string): UserMessage {
   return createUserMessage(
     renderServerStaticTemplate(import.meta.url, "context/web-search-instruction.hbs", {

--- a/apps/server/src/agent/runtime/event/event.ts
+++ b/apps/server/src/agent/runtime/event/event.ts
@@ -41,9 +41,28 @@ export type WakeEvent = {
   type: "wake";
 };
 
+export type StoryRecallStoryPayload = {
+  id: string;
+  markdown: string;
+  createdAt: Date;
+};
+
+/**
+ * Story recall 后台任务异步完成后，把召回到的故事以事件形式塞回主 Agent 的事件队列。
+ * Session 在路由时把 stories 装配成 <story_recall> user message 并追加到上下文，
+ * 同时触发新一轮 round，让主 Agent 想起记忆后继续行动。召回结果为空时不会发出该事件。
+ */
+export type StoryRecallCompletedEvent = {
+  type: "story_recall_completed";
+  data: {
+    stories: StoryRecallStoryPayload[];
+  };
+};
+
 export type Event =
   | NapcatGroupMessageEvent
   | NapcatPrivateMessageEvent
   | NapcatFriendListUpdatedEvent
   | NewsArticleIngestedEvent
+  | StoryRecallCompletedEvent
   | WakeEvent;

--- a/apps/server/src/agent/runtime/root-agent/session/root-agent-session.ts
+++ b/apps/server/src/agent/runtime/root-agent/session/root-agent-session.ts
@@ -5,6 +5,7 @@ import {
   createCrossStateNotificationMessage,
   createIthomeArticleDetailMessage,
   createStateSystemReminderMessage,
+  createStoryRecallMessage,
 } from "../../context/context-message-factory.js";
 import { NotificationAccumulator } from "../notification/notification-accumulator.js";
 import type { Event } from "../../event/event.js";
@@ -373,6 +374,13 @@ export class RootAgentSession implements RootAgentSessionController, RootAgentSt
       // dequeuing it already woke any consumer; session does nothing.
       return {
         shouldTriggerRound: false,
+      };
+    }
+
+    if (event.type === "story_recall_completed") {
+      this.pendingIncomingMessages.push(createStoryRecallMessage(event.data.stories));
+      return {
+        shouldTriggerRound: true,
       };
     }
 
@@ -792,7 +800,11 @@ export class RootAgentSession implements RootAgentSessionController, RootAgentSt
         : null;
     }
 
-    if (event.type === "napcat_friend_list_updated" || event.type === "wake") {
+    if (
+      event.type === "napcat_friend_list_updated" ||
+      event.type === "wake" ||
+      event.type === "story_recall_completed"
+    ) {
       return null;
     }
 

--- a/apps/server/src/app/agent-runtime.factory.ts
+++ b/apps/server/src/app/agent-runtime.factory.ts
@@ -79,6 +79,7 @@ import { StoryRecallService } from "../agent/capabilities/story/application/stor
 import { StoryService } from "../agent/capabilities/story/application/story.service.js";
 import { StoryLoopAgent } from "../agent/capabilities/story/runtime/story-agent.runtime.js";
 import { StoryRecallExtension } from "../agent/capabilities/story/runtime/story-recall.extension.js";
+import { StoryRecallScheduler } from "../agent/capabilities/story/runtime/story-recall.scheduler.js";
 import {
   SearchMemoryTool,
   SEARCH_MEMORY_TOOL_NAME,
@@ -294,12 +295,17 @@ export async function buildAgentRuntime({
     sourceRuntimeKey: ROOT_AGENT_RUNTIME_SNAPSHOT_RUNTIME_KEY,
     eventQueue: storyEventQueue,
   });
-  const storyRecallExtension = new StoryRecallExtension({
+  const storyRecallScheduler = new StoryRecallScheduler({
     llmClient,
     storyRecallService,
+    agentContext: context,
+    eventQueue,
     availableTools: rootAgentTools.definitions(),
     topK: config.server.agent.story.recall.topK,
     scoreThreshold: config.server.agent.story.recall.scoreThreshold,
+  });
+  const storyRecallExtension = new StoryRecallExtension({
+    scheduler: storyRecallScheduler,
   });
   const rootAgentRuntime = new RootLoopAgent({
     llmClient,


### PR DESCRIPTION
## 背景

收到一条消息后，主 Agent 必须先同步跑一轮 StoryRecall（生成 query → embedding → 检索）再决定回复，等于把每轮思考时间延长了一倍，用户感知到的回复延迟相当难看。

## 改动

把同步 StoryRecallExtension 改造成 **trailing coalescing 后台调度器**：

- 新增 `StoryRecallScheduler`：单例后台任务，`running` + `pendingRerun` 两位状态机。
  - `trigger()` 时若没在跑就立刻跑；若在跑只把 `pendingRerun` 置 true（不论被踢多少次只追加一次）。
  - 任务跑完后若 `pendingRerun` 为真则立刻再跑一次。
  - 净效果：持续唤醒就持续召回，不饿死也不空转。
- 新增 `StoryRecallCompletedEvent`：data 是业务数据 `{ stories: [{ id, markdown, createdAt }] }`，不是 LlmMessage。
  - 召回**非空**时入队该事件 → Session 顶层路由识别 → 装配成 `<story_recall>` user message → 追加到上下文 → 触发新一轮 round（主 Agent "想起来" 后继续行动）。
  - 召回**为空**不入队，避免无意义唤醒。
- `StoryRecallExtension` 简化为薄壳，`onBeforeRound` 仅调 `scheduler.trigger()` 立刻返回。
- `injectedStoryIds` 跨任务保留去重，压缩时清空。
- 移除 `lastRecallMessageCount` 去重。

## 用户感知差异

- **改造前**：收到消息 → 等同步召回（一次完整 LLM round）→ 才进入回复推理。每轮思考延迟翻倍。
- **改造后**：收到消息 → 主 Agent 立刻开始回复推理；召回任务后台跑；命中非空结果后通过事件唤醒主 Agent，让他想起记忆后继续补充行动。

## KV 缓存友好性

- 召回消息只在 Session `consumeIncomingEvent` 阶段进 context 尾部，路径与 wake / QQ 消息一致，不破坏稳定前缀。
- 召回为空不入队，避免没用的事件污染上下文。
- 异步任务通过事件队列回流而非直接 \`appendMessages\`，绕开了 "正在跑的 LLM 请求与 context 改写并发" 的语义混乱。

## 设计权衡

- 召回结果会**晚一轮**才进入上下文（异步代价）。可接受——比每轮多等一次 LLM 强多了。
- 召回回来时若主 Agent 正在 \`wait\` 里睡，会被唤醒跑一轮 LLM。这不是浪费，正是产品想要的 "想起来后继续行动"。
- 压缩期间在跑的召回不丢弃，结果照常回流到新前缀（按 KV 缓存红线，召回 message 走尾部追加路径，不破坏新前缀稳定性）。

## 测试

- \`pnpm typecheck\` ✅
- \`pnpm lint\` ✅
- \`pnpm format\` ✅
- \`pnpm build\` ✅
- \`pnpm test\` ✅（425 个测试全部通过）

## Test plan

- [ ] 手动验证：发一条消息，观察主 Agent 是否在 StoryRecall 返回之前就开始回复
- [ ] 手动验证：等若干秒后召回结果是否通过事件追加到上下文并触发新一轮思考
- [ ] 手动验证：连续发多条消息时，scheduler 的 trailing coalescing 是否生效（同时只有一个召回在跑，且会接着跑下一次）
- [ ] 手动验证：召回为空时主 Agent 不会被无谓唤醒

🤖 Generated with [Claude Code](https://claude.com/claude-code)