### PR TITLE
feat(agent): Portal 展示已装 App 列表

### DIFF
--- a/apps/server/src/agent/apps/calc/calc.app.ts
+++ b/apps/server/src/agent/apps/calc/calc.app.ts
@@ -12,6 +12,7 @@ export const CALC_APP_ID = "calc";
  */
 export class CalcApp implements App {
   public readonly id = CALC_APP_ID;
+  public readonly displayName = "计算器";
   public readonly tools = [new CalculateTool()];
 
   public canInvoke(): boolean {

--- a/apps/server/src/agent/runtime/context/context-message-factory.ts
+++ b/apps/server/src/agent/runtime/context/context-message-factory.ts
@@ -60,8 +60,13 @@ export function createStateSystemReminderMessage(input: {
     displayName: string;
     description: string;
   }>;
+  apps?: Array<{
+    id: string;
+    displayName: string;
+  }>;
 }): UserMessage {
   const children = input.children ?? [];
+  const apps = input.apps ?? [];
   const lines = ["<system_reminder>"];
 
   if (children.length > 0) {
@@ -71,6 +76,13 @@ export function createStateSystemReminderMessage(input: {
     }
   } else {
     lines.push(`你进入了 ${input.displayName} 节点`);
+  }
+
+  if (apps.length > 0) {
+    lines.push("也可以进入以下 App：");
+    for (const app of apps) {
+      lines.push(`- ${app.id}：${app.displayName}`);
+    }
   }
 
   lines.push("</system_reminder>");

--- a/apps/server/src/agent/runtime/root-agent/session/root-agent-session.ts
+++ b/apps/server/src/agent/runtime/root-agent/session/root-agent-session.ts
@@ -1,4 +1,4 @@
-import type { AppId } from "@kagami/agent-runtime";
+import type { AppId, AppManager } from "@kagami/agent-runtime";
 import type { AgentContext } from "../../context/agent-context.js";
 import type { LlmMessage } from "../../../../llm/types.js";
 import {
@@ -113,6 +113,8 @@ type RootAgentSessionDeps = {
   notificationTimeWindowMs?: number;
   ithomeNewsService?: Pick<IthomeNewsService, "getFeedOverview" | "enterFeed" | "openArticle">;
   terminalService?: Pick<TerminalService, "getCwd">;
+  /** App 框架。Portal 渲染时需要枚举已注册 Apps 喂给 reminder 消息。 */
+  appManager?: AppManager;
 };
 
 const DEFAULT_NOTIFICATION_TIME_WINDOW_MS = 30_000;
@@ -144,6 +146,8 @@ export class RootAgentSession implements RootAgentSessionController, RootAgentSt
    * 仅在内存中持有；不进 snapshot；reset 时一并清空。
    */
   private currentApp: AppId | undefined = undefined;
+  /** Portal 渲染时枚举已注册 Apps。可选；undefined 时退化为不展示 Apps 段落。 */
+  private readonly appManager: AppManager | null;
 
   public constructor({
     context,
@@ -153,11 +157,13 @@ export class RootAgentSession implements RootAgentSessionController, RootAgentSt
     notificationTimeWindowMs,
     ithomeNewsService,
     terminalService,
+    appManager,
   }: RootAgentSessionDeps) {
     this.context = context;
     this.napcatGatewayService = napcatGatewayService;
     this.recentMessageLimit = recentMessageLimit;
     this.ithomeNewsService = ithomeNewsService ?? null;
+    this.appManager = appManager ?? null;
     this.terminalService = terminalService ?? null;
     this.notificationAccumulator = new NotificationAccumulator({
       timeWindowMs: notificationTimeWindowMs ?? DEFAULT_NOTIFICATION_TIME_WINDOW_MS,
@@ -741,6 +747,16 @@ export class RootAgentSession implements RootAgentSessionController, RootAgentSt
     const state = this.requireState(stateId);
     const children = await state.listChildren();
 
+    // 只在 Portal 状态下列 Apps。其他状态都是状态树深处，Apps 不在视野里
+    // （进 App 强制要求先 back 回 Portal，这一约束跟 EnterTool 的闸门一致）。
+    const apps =
+      stateId === "portal"
+        ? (this.appManager?.getAllApps() ?? []).map(app => ({
+            id: app.id,
+            displayName: app.displayName,
+          }))
+        : undefined;
+
     return createStateSystemReminderMessage({
       displayName: state.getDisplayName(),
       children: await Promise.all(
@@ -750,6 +766,7 @@ export class RootAgentSession implements RootAgentSessionController, RootAgentSt
           description: await child.getDescription(),
         })),
       ),
+      apps,
     });
   }
 

--- a/apps/server/src/app/agent-runtime.factory.ts
+++ b/apps/server/src/app/agent-runtime.factory.ts
@@ -238,6 +238,7 @@ export async function buildAgentRuntime({
     notificationTimeWindowMs: config.server.agent.notificationBatchWindowMs,
     ithomeNewsService,
     terminalService,
+    appManager,
   });
   const helpTool = new HelpTool({
     appManager,

--- a/apps/server/test/agent/enter.tool.test.ts
+++ b/apps/server/test/agent/enter.tool.test.ts
@@ -5,6 +5,7 @@ import { EnterTool } from "../../src/agent/runtime/root-agent/tools/enter.tool.j
 function createFakeApp(id: string): App {
   return {
     id,
+    displayName: id,
     tools: [],
     canInvoke: () => true,
     help: async () => `you are in ${id}`,

--- a/apps/server/test/context/context-message-factory.test.ts
+++ b/apps/server/test/context/context-message-factory.test.ts
@@ -131,6 +131,44 @@ describe("context-message-factory", () => {
     });
   });
 
+  it("should render apps section when apps are provided", () => {
+    expect(
+      createStateSystemReminderMessage({
+        displayName: "门户",
+        children: [
+          {
+            id: "qq_group:123",
+            displayName: "QQ 群 测试群",
+            description: "聊天",
+          },
+        ],
+        apps: [{ id: "calc", displayName: "计算器" }],
+      }),
+    ).toEqual({
+      role: "user",
+      content: [
+        "<system_reminder>",
+        "你进入了 门户 节点，有以下子节点可进入：",
+        "- QQ 群 测试群 (qq_group:123): 聊天",
+        "也可以进入以下 App：",
+        "- calc：计算器",
+        "</system_reminder>",
+      ].join("\n"),
+    });
+  });
+
+  it("should omit apps section when apps array is empty", () => {
+    expect(
+      createStateSystemReminderMessage({
+        displayName: "门户",
+        apps: [],
+      }),
+    ).toEqual({
+      role: "user",
+      content: ["<system_reminder>", "你进入了 门户 节点", "</system_reminder>"].join("\n"),
+    });
+  });
+
   it("should render ithome article list and detail messages", () => {
     expect(
       createIthomeArticleListMessage({

--- a/packages/agent-runtime/src/app/app.ts
+++ b/packages/agent-runtime/src/app/app.ts
@@ -15,6 +15,9 @@ export interface App {
   /** 唯一短串识别符，用作 Registry key 与外部 enter 目标 id。 */
   readonly id: AppId;
 
+  /** 给 Kagami 看的人类可读短名，例如 "计算器"。在 Portal 列出 App 时使用。 */
+  readonly displayName: string;
+
   /**
    * 这个 App 贡献给 InvokeTool 的子工具集合。
    *


### PR DESCRIPTION
## Summary

Phase 2 漏的一个口子：calc App 已注册但 Kagami 在 Portal 里看不到它，只能靠外部告诉或盲猜 \`enter({id: \"calc\"})\`。修复 Portal reminder，把已注册 Apps 列在子节点之后。

修复后 Portal 看到：

\`\`\`
<system_reminder>
你进入了 门户 节点，有以下子节点可进入：
- QQ 群 ... (qq_group:...): ...
- IT 之家 (ithome): ...
- 终端 (terminal): ...
也可以进入以下 App：
- calc：计算器
</system_reminder>
\`\`\`

## 改动

| 文件 | 改动 |
|---|---|
| \`packages/agent-runtime/src/app/app.ts\` | App 接口加 \`displayName: string\` |
| \`apps/server/src/agent/apps/calc/calc.app.ts\` | \`CalcApp.displayName = \"计算器\"\` |
| \`apps/server/src/agent/runtime/context/context-message-factory.ts\` | \`createStateSystemReminderMessage\` 加 \`apps?\` 参数 + 段落渲染 |
| \`apps/server/src/agent/runtime/root-agent/session/root-agent-session.ts\` | 构造取 \`appManager\`；仅在 Portal 状态下喂给 message factory（其他状态不喂——跟"进 App 必须在 Portal\"闸门一致） |
| \`apps/server/src/app/agent-runtime.factory.ts\` | RootAgentSession 构造传 \`appManager\` |

## 测试

- 新增 2 个 message factory 测试覆盖 apps 段落渲染 / 空数组不渲染
- \`createFakeApp\` 工厂补 displayName 字段
- **437 / 437 passed**

## Test plan

- [x] \`pnpm build\` 全绿
- [x] \`pnpm typecheck\` 全绿
- [x] \`pnpm lint\` 全绿
- [x] \`pnpm format\` 全绿
- [x] \`pnpm --filter @kagami/server test\` 全绿（437 / 437）
- [x] 现有 capabilities 一行不动；qq / ithome / terminal / web-search / story 测试无回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)