### PR TITLE
fix(agent): InvokeTool 分流 App 工具与状态树工具

### DIFF
--- a/apps/server/src/agent/apps/calc/calc.app.ts
+++ b/apps/server/src/agent/apps/calc/calc.app.ts
@@ -12,6 +12,7 @@ export const CALC_APP_ID = "calc";
  */
 export class CalcApp implements App {
   public readonly id = CALC_APP_ID;
+  public readonly displayName = "计算器";
   public readonly tools = [new CalculateTool()];
 
   public canInvoke(): boolean {

--- a/apps/server/src/agent/runtime/context/context-message-factory.ts
+++ b/apps/server/src/agent/runtime/context/context-message-factory.ts
@@ -60,8 +60,13 @@ export function createStateSystemReminderMessage(input: {
     displayName: string;
     description: string;
   }>;
+  apps?: Array<{
+    id: string;
+    displayName: string;
+  }>;
 }): UserMessage {
   const children = input.children ?? [];
+  const apps = input.apps ?? [];
   const lines = ["<system_reminder>"];
 
   if (children.length > 0) {
@@ -71,6 +76,13 @@ export function createStateSystemReminderMessage(input: {
     }
   } else {
     lines.push(`你进入了 ${input.displayName} 节点`);
+  }
+
+  if (apps.length > 0) {
+    lines.push("也可以进入以下 App：");
+    for (const app of apps) {
+      lines.push(`- ${app.id}：${app.displayName}`);
+    }
   }
 
   lines.push("</system_reminder>");

--- a/apps/server/src/agent/runtime/root-agent/session/root-agent-session.ts
+++ b/apps/server/src/agent/runtime/root-agent/session/root-agent-session.ts
@@ -1,4 +1,4 @@
-import type { AppId } from "@kagami/agent-runtime";
+import type { AppId, AppManager } from "@kagami/agent-runtime";
 import type { AgentContext } from "../../context/agent-context.js";
 import type { LlmMessage } from "../../../../llm/types.js";
 import {
@@ -113,6 +113,8 @@ type RootAgentSessionDeps = {
   notificationTimeWindowMs?: number;
   ithomeNewsService?: Pick<IthomeNewsService, "getFeedOverview" | "enterFeed" | "openArticle">;
   terminalService?: Pick<TerminalService, "getCwd">;
+  /** App 框架。Portal 渲染时需要枚举已注册 Apps 喂给 reminder 消息。 */
+  appManager?: AppManager;
 };
 
 const DEFAULT_NOTIFICATION_TIME_WINDOW_MS = 30_000;
@@ -144,6 +146,8 @@ export class RootAgentSession implements RootAgentSessionController, RootAgentSt
    * 仅在内存中持有；不进 snapshot；reset 时一并清空。
    */
   private currentApp: AppId | undefined = undefined;
+  /** Portal 渲染时枚举已注册 Apps。可选；undefined 时退化为不展示 Apps 段落。 */
+  private readonly appManager: AppManager | null;
 
   public constructor({
     context,
@@ -153,11 +157,13 @@ export class RootAgentSession implements RootAgentSessionController, RootAgentSt
     notificationTimeWindowMs,
     ithomeNewsService,
     terminalService,
+    appManager,
   }: RootAgentSessionDeps) {
     this.context = context;
     this.napcatGatewayService = napcatGatewayService;
     this.recentMessageLimit = recentMessageLimit;
     this.ithomeNewsService = ithomeNewsService ?? null;
+    this.appManager = appManager ?? null;
     this.terminalService = terminalService ?? null;
     this.notificationAccumulator = new NotificationAccumulator({
       timeWindowMs: notificationTimeWindowMs ?? DEFAULT_NOTIFICATION_TIME_WINDOW_MS,
@@ -741,6 +747,16 @@ export class RootAgentSession implements RootAgentSessionController, RootAgentSt
     const state = this.requireState(stateId);
     const children = await state.listChildren();
 
+    // 只在 Portal 状态下列 Apps。其他状态都是状态树深处，Apps 不在视野里
+    // （进 App 强制要求先 back 回 Portal，这一约束跟 EnterTool 的闸门一致）。
+    const apps =
+      stateId === "portal"
+        ? (this.appManager?.getAllApps() ?? []).map(app => ({
+            id: app.id,
+            displayName: app.displayName,
+          }))
+        : undefined;
+
     return createStateSystemReminderMessage({
       displayName: state.getDisplayName(),
       children: await Promise.all(
@@ -750,6 +766,7 @@ export class RootAgentSession implements RootAgentSessionController, RootAgentSt
           description: await child.getDescription(),
         })),
       ),
+      apps,
     });
   }
 

--- a/apps/server/src/agent/runtime/root-agent/tools/invoke.tool.ts
+++ b/apps/server/src/agent/runtime/root-agent/tools/invoke.tool.ts
@@ -82,7 +82,26 @@ export class InvokeTool extends ZodToolComponent<typeof InvokeArgumentsSchema> {
       };
     }
 
-    if (!availableTools.includes(input.tool as (typeof availableTools)[number])) {
+    // 工具分流：App 工具走 AppManager.canInvoke，非 App 工具走状态树 availableTools
+    // 检查。两个来源不能用同一个 union 列表判，因为 App 工具不在 state.getAvailableInvokeTools()
+    // 视野里。
+    const isAppTool = this.appManager.ownsTool(input.tool);
+    if (isAppTool) {
+      const canInvokeResult = this.appManager.canInvoke(
+        input.tool,
+        rootAgentSession.getCurrentApp(),
+      );
+      if (!canInvokeResult.ok) {
+        return {
+          content: JSON.stringify({
+            ok: false,
+            error: "INVOKE_TOOL_APP_GUARD",
+            tool: input.tool,
+            message: canInvokeResult.reason,
+          }),
+        };
+      }
+    } else if (!availableTools.includes(input.tool as (typeof availableTools)[number])) {
       const availableToolDefinitions = this.getToolDefinitionsByNames(availableTools);
       return {
         content: JSON.stringify({
@@ -95,21 +114,6 @@ export class InvokeTool extends ZodToolComponent<typeof InvokeArgumentsSchema> {
             state: state.focusedStateId,
             availableToolDefinitions,
           }),
-          availableTools,
-        }),
-      };
-    }
-
-    // App 框架 canInvoke 检查：若 input.tool 属于某个 App，由 AppManager 决定
-    // 现在能不能调。当前未注册任何 App，所有非 App 工具都会直接 ok。
-    const canInvokeResult = this.appManager.canInvoke(input.tool, rootAgentSession.getCurrentApp());
-    if (!canInvokeResult.ok) {
-      return {
-        content: JSON.stringify({
-          ok: false,
-          error: "INVOKE_TOOL_APP_GUARD",
-          tool: input.tool,
-          message: canInvokeResult.reason,
           availableTools,
         }),
       };

--- a/apps/server/src/app/agent-runtime.factory.ts
+++ b/apps/server/src/app/agent-runtime.factory.ts
@@ -238,6 +238,7 @@ export async function buildAgentRuntime({
     notificationTimeWindowMs: config.server.agent.notificationBatchWindowMs,
     ithomeNewsService,
     terminalService,
+    appManager,
   });
   const helpTool = new HelpTool({
     appManager,

--- a/apps/server/test/agent/enter.tool.test.ts
+++ b/apps/server/test/agent/enter.tool.test.ts
@@ -5,6 +5,7 @@ import { EnterTool } from "../../src/agent/runtime/root-agent/tools/enter.tool.j
 function createFakeApp(id: string): App {
   return {
     id,
+    displayName: id,
     tools: [],
     canInvoke: () => true,
     help: async () => `you are in ${id}`,

--- a/apps/server/test/agent/invoke.tool.test.ts
+++ b/apps/server/test/agent/invoke.tool.test.ts
@@ -285,4 +285,67 @@ describe("invoke tool", () => {
     expect(JSON.parse(result.content).message).toContain("当前状态可用的 invoke 工具说明：");
     expect(JSON.parse(result.content).message).toContain("`open_ithome_article`");
   });
+
+  it("should bypass state-tree availableTools check for App-owned tools", async () => {
+    // 回归测试：之前 InvokeTool 把 App 工具也走状态树 availableTools 检查，
+    // 导致 Kagami 进 calc 后调 calculate 被"Portal 没有 invoke 子工具"挡住。
+    const { CalcApp } = await import("../../src/agent/apps/calc/calc.app.js");
+    const appManager = new AppManager();
+    appManager.register(new CalcApp());
+
+    const calcTool = appManager.getApp("calc")!.tools[0];
+    const tool = new InvokeTool({
+      tools: [calcTool],
+      appManager,
+    });
+
+    const result = await tool.execute({ tool: "calculate", a: 6, op: "*", b: 7 }, {
+      rootAgentSession: {
+        getState: () => ({
+          focusedStateId: "portal" as const,
+          stateStack: ["portal"] as const,
+          waiting: null,
+        }),
+        // Portal 状态树视野下 availableTools 是空的
+        getAvailableInvokeTools: () => [],
+        // 但 Kagami 已经 enter 进了 calc App
+        getCurrentApp: () => "calc",
+      },
+    } as Parameters<typeof tool.execute>[1]);
+
+    expect(JSON.parse(result.content)).toMatchObject({
+      ok: true,
+      result: 42,
+    });
+  });
+
+  it("should reject App-owned tool with APP_GUARD when not in the owning App", async () => {
+    const { CalcApp } = await import("../../src/agent/apps/calc/calc.app.js");
+    const appManager = new AppManager();
+    appManager.register(new CalcApp());
+
+    const calcTool = appManager.getApp("calc")!.tools[0];
+    const tool = new InvokeTool({
+      tools: [calcTool],
+      appManager,
+    });
+
+    const result = await tool.execute({ tool: "calculate", a: 1, op: "+", b: 1 }, {
+      rootAgentSession: {
+        getState: () => ({
+          focusedStateId: "portal" as const,
+          stateStack: ["portal"] as const,
+          waiting: null,
+        }),
+        getAvailableInvokeTools: () => [],
+        // 没在 calc 里
+        getCurrentApp: () => undefined,
+      },
+    } as Parameters<typeof tool.execute>[1]);
+
+    expect(JSON.parse(result.content)).toMatchObject({
+      ok: false,
+      error: "INVOKE_TOOL_APP_GUARD",
+    });
+  });
 });

--- a/apps/server/test/context/context-message-factory.test.ts
+++ b/apps/server/test/context/context-message-factory.test.ts
@@ -131,6 +131,44 @@ describe("context-message-factory", () => {
     });
   });
 
+  it("should render apps section when apps are provided", () => {
+    expect(
+      createStateSystemReminderMessage({
+        displayName: "门户",
+        children: [
+          {
+            id: "qq_group:123",
+            displayName: "QQ 群 测试群",
+            description: "聊天",
+          },
+        ],
+        apps: [{ id: "calc", displayName: "计算器" }],
+      }),
+    ).toEqual({
+      role: "user",
+      content: [
+        "<system_reminder>",
+        "你进入了 门户 节点，有以下子节点可进入：",
+        "- QQ 群 测试群 (qq_group:123): 聊天",
+        "也可以进入以下 App：",
+        "- calc：计算器",
+        "</system_reminder>",
+      ].join("\n"),
+    });
+  });
+
+  it("should omit apps section when apps array is empty", () => {
+    expect(
+      createStateSystemReminderMessage({
+        displayName: "门户",
+        apps: [],
+      }),
+    ).toEqual({
+      role: "user",
+      content: ["<system_reminder>", "你进入了 门户 节点", "</system_reminder>"].join("\n"),
+    });
+  });
+
   it("should render ithome article list and detail messages", () => {
     expect(
       createIthomeArticleListMessage({

--- a/packages/agent-runtime/src/app/app.ts
+++ b/packages/agent-runtime/src/app/app.ts
@@ -90,10 +90,23 @@ export class AppManager {
   }
 
   /**
+   * 给 InvokeTool 用：判断 toolName 是否被某个注册过的 App 拥有。
+   *
+   * 返回 true → 该工具的可用性完全由 AppManager.canInvoke 决定，跳过状态树
+   *            availableTools 检查（App 工具不存在于状态树视野里）
+   * 返回 false → 该工具是状态树时代的旧工具，走原状态树 availableTools 判
+   */
+  public ownsTool(toolName: string): boolean {
+    return this.toolOwners.has(toolName);
+  }
+
+  /**
    * 给 InvokeTool 用：判断 toolName 是否可以在 currentApp 下被调用。
    *
+   * 调用前提：调用方已经通过 ownsTool 确认 toolName 属于某 App。
+   *
    * 规则：
-   * 1. 不属于任何注册过的 App → ok（不限制，留给原有 flat 工具系统）
+   * 1. 不属于任何注册过的 App → ok（理论上不会走到这里，调用方应先用 ownsTool 判）
    * 2. 属于某 App，但 Kagami 不在该 App → not ok，返回提示
    * 3. 属于当前 App，但 App 自己说 "不能调" → not ok
    */

--- a/packages/agent-runtime/src/app/app.ts
+++ b/packages/agent-runtime/src/app/app.ts
@@ -15,6 +15,9 @@ export interface App {
   /** 唯一短串识别符，用作 Registry key 与外部 enter 目标 id。 */
   readonly id: AppId;
 
+  /** 给 Kagami 看的人类可读短名，例如 "计算器"。在 Portal 列出 App 时使用。 */
+  readonly displayName: string;
+
   /**
    * 这个 App 贡献给 InvokeTool 的子工具集合。
    *


### PR DESCRIPTION
## Bug

Kagami 进 calc App 后调 \`invoke({tool: \"calculate\", ...})\` 返回：

\`\`\`json
{
  \"ok\": false,
  \"error\": \"INVOKE_TOOL_NOT_AVAILABLE\",
  \"tool\": \"calculate\",
  \"state\": \"portal\",
  \"message\": \"invoke 子工具 calculate 不能在当前状态 portal 下调用。当前状态没有可用的 invoke 子工具。\",
  \"availableTools\": []
}
\`\`\`

## 根因

InvokeTool 把 App 工具和状态树工具都走**同一个 union 检查**，依赖 \`session.getAvailableInvokeTools()\` 当 gatekeeper。但：

- App 工具不在状态树视野里，状态树 \`PortalState.getAvailableInvokeTools()\` 始终返回 \`[]\`
- Phase 2 设计的两个维度（状态树 vs currentApp）是正交的，单一 union 列表表达不了
- 检查顺序里状态树在前，App 工具被无差别拒绝；AppManager.canInvoke 这一步根本走不到

## 修复

分流两类工具：

\`\`\`ts
const isAppTool = this.appManager.ownsTool(input.tool);
if (isAppTool) {
  // 只用 AppManager.canInvoke 判
} else {
  // 走原状态树 availableTools 判
}
\`\`\`

具体改动：
- \`AppManager\` 加 \`ownsTool(toolName): boolean\` 方法暴露内部 toolOwners 表
- \`InvokeTool\` 把"状态树 availableTools 检查"和"AppManager.canInvoke 检查"从串联改为分流

## 回归测试

新增 2 个 InvokeTool 测试：
- App 工具在 Portal 状态树视野下仍能被调（前提是 currentApp 匹配）
- 不在 owning App 里时返 \`APP_GUARD\`（确认错误分类正确，不是误报 NOT_AVAILABLE）

## Test plan

- [x] \`pnpm build\` 全绿
- [x] \`pnpm typecheck\` 全绿
- [x] \`pnpm lint\` 全绿
- [x] \`pnpm format\` 全绿
- [x] \`pnpm --filter @kagami/server test\` 全绿（**439 / 439**）

🤖 Generated with [Claude Code](https://claude.com/claude-code)