### PR TITLE
refactor(agent): InvokeTool 改成 owner-driven dispatch

### DIFF
--- a/apps/server/src/agent/runtime/root-agent/tools/invoke.tool.ts
+++ b/apps/server/src/agent/runtime/root-agent/tools/invoke.tool.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 import { isRecord } from "../../../../common/prisma-json.js";
 import {
-  AppManager,
   ToolCatalog,
+  type InvokeSubtoolOwner,
   type JsonSchema,
   type ToolComponent,
   type ToolContext,
@@ -27,6 +27,13 @@ type InvokeToolContext = ToolContext & {
   rootAgentSession?: RootAgentSessionController;
 };
 
+/**
+ * InvokeTool 不再自己判断"这个工具能不能调"，而是把这件事委派给一个 owner 列表。
+ * 每个 owner 实现 InvokeSubtoolOwner 协议，声明它拥有哪些工具以及在当前 ctx 下
+ * 能不能调。InvokeTool 的主路径就是：找到 owner → 让 owner gate → 执行。
+ *
+ * 设计动机见 packages/agent-runtime/src/tool/subtool-owner.ts 的注释。
+ */
 export class InvokeTool extends ZodToolComponent<typeof InvokeArgumentsSchema> {
   public readonly name = INVOKE_TOOL_NAME;
   public readonly description =
@@ -37,15 +44,21 @@ export class InvokeTool extends ZodToolComponent<typeof InvokeArgumentsSchema> {
   private readonly invokeToolSet: ToolExecutor;
   private readonly invokeToolNames: Set<string>;
   private readonly invokeToolDefinitionByName: ReadonlyMap<string, ToolDefinition>;
-  private readonly appManager: AppManager;
+  private readonly owners: readonly InvokeSubtoolOwner[];
 
-  public constructor({ tools, appManager }: { tools: ToolComponent[]; appManager: AppManager }) {
+  public constructor({
+    tools,
+    owners,
+  }: {
+    tools: ToolComponent[];
+    owners: readonly InvokeSubtoolOwner[];
+  }) {
     super();
     this.parameters = buildInvokeParameters(tools);
     this.invokeToolSet = new ToolCatalog(tools).pick(tools.map(tool => tool.name));
     this.invokeToolNames = new Set(tools.map(tool => tool.name));
     this.invokeToolDefinitionByName = new Map(tools.map(tool => [tool.name, tool.llmTool]));
-    this.appManager = appManager;
+    this.owners = owners;
   }
 
   protected async executeTyped(
@@ -64,7 +77,6 @@ export class InvokeTool extends ZodToolComponent<typeof InvokeArgumentsSchema> {
       };
     }
 
-    const state = rootAgentSession.getState();
     const availableTools = rootAgentSession.getAvailableInvokeTools();
     if (!this.invokeToolNames.has(input.tool)) {
       const availableToolDefinitions = this.getToolDefinitionsByNames(availableTools);
@@ -82,39 +94,31 @@ export class InvokeTool extends ZodToolComponent<typeof InvokeArgumentsSchema> {
       };
     }
 
-    // 工具分流：App 工具走 AppManager.canInvoke，非 App 工具走状态树 availableTools
-    // 检查。两个来源不能用同一个 union 列表判，因为 App 工具不在 state.getAvailableInvokeTools()
-    // 视野里。
-    const isAppTool = this.appManager.ownsTool(input.tool);
-    if (isAppTool) {
-      const canInvokeResult = this.appManager.canInvoke(
-        input.tool,
-        rootAgentSession.getCurrentApp(),
-      );
-      if (!canInvokeResult.ok) {
-        return {
-          content: JSON.stringify({
-            ok: false,
-            error: "INVOKE_TOOL_APP_GUARD",
-            tool: input.tool,
-            message: canInvokeResult.reason,
-          }),
-        };
-      }
-    } else if (!availableTools.includes(input.tool as (typeof availableTools)[number])) {
-      const availableToolDefinitions = this.getToolDefinitionsByNames(availableTools);
+    // Owner-driven dispatch：找到拥有该工具的 owner，让 owner 做 gate 决策。
+    const owner = this.owners.find(o => o.ownsTool(input.tool));
+    if (!owner) {
+      // 理论上不会走到这里：tool 已在 invokeToolNames 里，意味着它在 master 列表里，
+      // 而 master 列表里的工具必然被某个 owner 拥有（AppManager.ownsTool 或 catch-all）。
+      // 留一个保护性兜底，方便排查 owners 配置错误。
       return {
         content: JSON.stringify({
           ok: false,
-          error: "INVOKE_TOOL_NOT_AVAILABLE",
+          error: "INVOKE_TOOL_NO_OWNER",
           tool: input.tool,
-          state: state.focusedStateId,
-          message: buildInvokeToolUnavailableMessage({
-            tool: input.tool,
-            state: state.focusedStateId,
-            availableToolDefinitions,
-          }),
-          availableTools,
+          message: `invoke 子工具 ${input.tool} 没有匹配的 owner，这可能是 owners 配置错误。`,
+        }),
+      };
+    }
+
+    const guard = owner.canInvokeNow(input.tool, context);
+    if (!guard.ok) {
+      return {
+        content: JSON.stringify({
+          ok: false,
+          error: guard.error,
+          tool: input.tool,
+          message: guard.message,
+          ...(guard.extras ?? {}),
         }),
       };
     }
@@ -132,7 +136,7 @@ export class InvokeTool extends ZodToolComponent<typeof InvokeArgumentsSchema> {
     };
   }
 
-  private getToolDefinitionsByNames(toolNames: string[]): ToolDefinition[] {
+  private getToolDefinitionsByNames(toolNames: readonly string[]): ToolDefinition[] {
     return toolNames
       .map(toolName => this.invokeToolDefinitionByName.get(toolName))
       .filter((definition): definition is ToolDefinition => definition !== undefined);
@@ -200,21 +204,10 @@ function buildInvokeToolNotFoundMessage(input: {
   ].join("\n");
 }
 
-function buildInvokeToolUnavailableMessage(input: {
-  tool: string;
-  state: string;
-  availableToolDefinitions: ToolDefinition[];
-}): string {
-  return [
-    `invoke 子工具 ${input.tool} 不能在当前状态 ${input.state} 下调用。`,
-    buildAvailableInvokeToolsDescription(input.availableToolDefinitions),
-  ].join("\n");
-}
-
 function normalizeInvokeFailureContent(input: {
   tool: string;
   content: string;
-  availableTools: string[];
+  availableTools: readonly string[];
   currentToolDefinition?: ToolDefinition;
 }): string {
   try {

--- a/apps/server/src/agent/runtime/root-agent/tools/state-tree-subtool-owner.ts
+++ b/apps/server/src/agent/runtime/root-agent/tools/state-tree-subtool-owner.ts
@@ -1,0 +1,67 @@
+import type {
+  AppManager,
+  InvokeSubtoolOwner,
+  SubtoolGuardResult,
+  ToolContext,
+  ToolDefinition,
+} from "@kagami/agent-runtime";
+import type { RootAgentSessionController } from "../session/root-agent-session.js";
+import { renderInvokeToolGuide } from "./invoke-tool-docs.js";
+
+type StateTreeOwnerToolContext = ToolContext & {
+  rootAgentSession?: RootAgentSessionController;
+};
+
+/**
+ * 状态树时代的 invoke 子工具的所有者。
+ *
+ * 拥有的工具范围："不被 AppManager 拥有的所有 invoke 子工具" —— 也就是 send_message /
+ * open_ithome_article / bash / read_bash_output 这些通过状态树节点暴露的旧工具。
+ * 用 "catch-all" 的方式定义比硬编码工具名集合更鲁棒（加新状态树工具不用同步改这里）。
+ *
+ * 是否能调由 RootAgentSession.getAvailableInvokeTools() 决定：当前焦点状态允许列表
+ * 里有就 ok，否则返回带 rich docs 的 NOT_AVAILABLE 错误（保留 Kagami 看可替代选项
+ * 的体验）。
+ */
+export function createStateTreeSubtoolOwner(deps: {
+  appManager: AppManager;
+  invokeToolDefinitionByName: ReadonlyMap<string, ToolDefinition>;
+}): InvokeSubtoolOwner {
+  return {
+    ownsTool: (toolName: string): boolean => !deps.appManager.ownsTool(toolName),
+    canInvokeNow: (toolName: string, ctx: ToolContext): SubtoolGuardResult => {
+      const session = (ctx as StateTreeOwnerToolContext).rootAgentSession;
+      if (!session) {
+        return {
+          ok: false,
+          error: "SESSION_UNAVAILABLE",
+          message: "当前会话不可用，暂时无法调用 invoke 子工具。",
+        };
+      }
+      const availableTools = session.getAvailableInvokeTools();
+      const isAllowed = (availableTools as readonly string[]).includes(toolName);
+      if (isAllowed) {
+        return { ok: true };
+      }
+
+      const focusedStateId = session.getState().focusedStateId;
+      const availableToolDefinitions = availableTools
+        .map(name => deps.invokeToolDefinitionByName.get(name))
+        .filter((definition): definition is ToolDefinition => definition !== undefined);
+      const availableMessage =
+        availableToolDefinitions.length === 0
+          ? "当前状态没有可用的 invoke 子工具。"
+          : `当前状态可用的 invoke 工具说明：\n${renderInvokeToolGuide(availableToolDefinitions)}`;
+
+      return {
+        ok: false,
+        error: "INVOKE_TOOL_NOT_AVAILABLE",
+        message: `invoke 子工具 ${toolName} 不能在当前状态 ${focusedStateId} 下调用。\n${availableMessage}`,
+        extras: {
+          state: focusedStateId,
+          availableTools,
+        },
+      };
+    },
+  };
+}

--- a/apps/server/src/app/agent-runtime.factory.ts
+++ b/apps/server/src/app/agent-runtime.factory.ts
@@ -1,10 +1,12 @@
 import {
   AppManager,
+  createAppSubtoolOwner,
   HELP_TOOL_NAME,
   HelpTool,
   ToolCatalog,
   type Queue,
 } from "@kagami/agent-runtime";
+import { createStateTreeSubtoolOwner } from "../agent/runtime/root-agent/tools/state-tree-subtool-owner.js";
 import type { Config } from "../config/config.loader.js";
 import type { Database } from "../db/client.js";
 import type { LlmClient } from "../llm/client.js";
@@ -244,6 +246,20 @@ export async function buildAgentRuntime({
     appManager,
     getCurrentApp: () => rootAgentSession.getCurrentApp(),
   });
+  // Invoke 子工具的所有者：App 工具走 AppManager，剩下的状态树工具走 catch-all。
+  // 顺序很重要：InvokeTool 用 owners.find 找第一个匹配的 owner，App 在前确保
+  // App 工具不会被 catch-all 抢走。
+  const invokeToolDefinitionByName = new Map(invokeSubtools.map(tool => [tool.name, tool.llmTool]));
+  const subtoolOwners = [
+    createAppSubtoolOwner({
+      appManager,
+      getCurrentApp: () => rootAgentSession.getCurrentApp(),
+    }),
+    createStateTreeSubtoolOwner({
+      appManager,
+      invokeToolDefinitionByName,
+    }),
+  ];
   const toolCatalog = new ToolCatalog([
     new EnterTool({ appManager }),
     new BackTool(),
@@ -254,7 +270,7 @@ export async function buildAgentRuntime({
     }),
     new InvokeTool({
       tools: invokeSubtools,
-      appManager,
+      owners: subtoolOwners,
     }),
     new SearchWebTool({
       webSearchTaskAgent,

--- a/apps/server/test/agent/invoke.tool.test.ts
+++ b/apps/server/test/agent/invoke.tool.test.ts
@@ -1,8 +1,14 @@
-import { AppManager } from "@kagami/agent-runtime";
+import {
+  AppManager,
+  createAppSubtoolOwner,
+  type ToolComponent,
+  type ToolContext,
+} from "@kagami/agent-runtime";
 import { describe, expect, it, vi } from "vitest";
 import { OpenIthomeArticleTool } from "../../src/agent/capabilities/news/tools/open-ithome-article.tool.js";
 import { SendMessageTool } from "../../src/agent/capabilities/messaging/tools/send-message.tool.js";
 import { InvokeTool } from "../../src/agent/runtime/root-agent/tools/invoke.tool.js";
+import { createStateTreeSubtoolOwner } from "../../src/agent/runtime/root-agent/tools/state-tree-subtool-owner.js";
 
 function createAgentMessageService() {
   return {
@@ -11,16 +17,51 @@ function createAgentMessageService() {
   };
 }
 
+/**
+ * 测试用 InvokeTool 工厂。模拟 factory 的 owners 装配：
+ *   - appOwner：用提供的 AppManager 控制
+ *   - stateTreeOwner：catch-all，依赖 ctx 里挂的 mock session 的
+ *     getAvailableInvokeTools
+ *
+ * 如果不传 appManager，默认建一个空的。
+ */
+function createTestInvokeTool(opts: {
+  tools: ToolComponent[];
+  appManager?: AppManager;
+}): InvokeTool {
+  const appManager = opts.appManager ?? new AppManager();
+  const invokeToolDefinitionByName = new Map(opts.tools.map(t => [t.name, t.llmTool]));
+  return new InvokeTool({
+    tools: opts.tools,
+    owners: [
+      createAppSubtoolOwner({
+        appManager,
+        getCurrentApp: (ctx: ToolContext) => {
+          const session = (
+            ctx as ToolContext & {
+              rootAgentSession?: { getCurrentApp(): string | undefined };
+            }
+          ).rootAgentSession;
+          return session?.getCurrentApp();
+        },
+      }),
+      createStateTreeSubtoolOwner({
+        appManager,
+        invokeToolDefinitionByName,
+      }),
+    ],
+  });
+}
+
 describe("invoke tool", () => {
   it("should expose flattened invoke parameters", () => {
-    const tool = new InvokeTool({
+    const tool = createTestInvokeTool({
       tools: [
         new SendMessageTool({
           agentMessageService: createAgentMessageService(),
         }),
         new OpenIthomeArticleTool(),
       ],
-      appManager: new AppManager(),
     });
 
     expect(tool.parameters).toEqual({
@@ -45,9 +86,8 @@ describe("invoke tool", () => {
   it("should invoke send_message in qq group state", async () => {
     const agentMessageService = createAgentMessageService();
     agentMessageService.sendGroupMessage.mockResolvedValue({ messageId: 9527 });
-    const tool = new InvokeTool({
+    const tool = createTestInvokeTool({
       tools: [new SendMessageTool({ agentMessageService })],
-      appManager: new AppManager(),
     });
 
     const result = await tool.execute(
@@ -87,9 +127,8 @@ describe("invoke tool", () => {
   it("should invoke send_message in qq private state", async () => {
     const agentMessageService = createAgentMessageService();
     agentMessageService.sendPrivateMessage.mockResolvedValue({ messageId: 9630 });
-    const tool = new InvokeTool({
+    const tool = createTestInvokeTool({
       tools: [new SendMessageTool({ agentMessageService })],
-      appManager: new AppManager(),
     });
 
     const result = await tool.execute(
@@ -128,9 +167,8 @@ describe("invoke tool", () => {
 
   it("should return agent-friendly message when subtool is unavailable in current state", async () => {
     const agentMessageService = createAgentMessageService();
-    const tool = new InvokeTool({
+    const tool = createTestInvokeTool({
       tools: [new SendMessageTool({ agentMessageService }), new OpenIthomeArticleTool()],
-      appManager: new AppManager(),
     });
 
     const result = await tool.execute(
@@ -169,12 +207,11 @@ describe("invoke tool", () => {
       kind: "ithome_article",
       articleId: 123,
     });
-    const tool = new InvokeTool({
+    const tool = createTestInvokeTool({
       tools: [
         new SendMessageTool({ agentMessageService: createAgentMessageService() }),
         new OpenIthomeArticleTool(),
       ],
-      appManager: new AppManager(),
     });
 
     const result = await tool.execute(
@@ -207,12 +244,11 @@ describe("invoke tool", () => {
   });
 
   it("should return agent-friendly message when ithome article does not exist", async () => {
-    const tool = new InvokeTool({
+    const tool = createTestInvokeTool({
       tools: [
         new SendMessageTool({ agentMessageService: createAgentMessageService() }),
         new OpenIthomeArticleTool(),
       ],
-      appManager: new AppManager(),
     });
 
     const result = await tool.execute(
@@ -251,12 +287,11 @@ describe("invoke tool", () => {
   });
 
   it("should describe available tools when invoke subtool does not exist", async () => {
-    const tool = new InvokeTool({
+    const tool = createTestInvokeTool({
       tools: [
         new SendMessageTool({ agentMessageService: createAgentMessageService() }),
         new OpenIthomeArticleTool(),
       ],
-      appManager: new AppManager(),
     });
 
     const result = await tool.execute(
@@ -294,7 +329,7 @@ describe("invoke tool", () => {
     appManager.register(new CalcApp());
 
     const calcTool = appManager.getApp("calc")!.tools[0];
-    const tool = new InvokeTool({
+    const tool = createTestInvokeTool({
       tools: [calcTool],
       appManager,
     });
@@ -325,7 +360,7 @@ describe("invoke tool", () => {
     appManager.register(new CalcApp());
 
     const calcTool = appManager.getApp("calc")!.tools[0];
-    const tool = new InvokeTool({
+    const tool = createTestInvokeTool({
       tools: [calcTool],
       appManager,
     });

--- a/packages/agent-runtime/src/app/app-subtool-owner.ts
+++ b/packages/agent-runtime/src/app/app-subtool-owner.ts
@@ -1,0 +1,34 @@
+import type { ToolContext } from "../tool/tool-component.js";
+import type { InvokeSubtoolOwner, SubtoolGuardResult } from "../tool/subtool-owner.js";
+import type { AppId, AppManager } from "./app.js";
+
+/**
+ * 把 AppManager + "如何拿到当前 App" 这个回调，包装成 InvokeSubtoolOwner。
+ *
+ * 这是 App 框架在 invoke 调度链上的适配层：
+ * - ownsTool 直接代理到 appManager.ownsTool
+ * - canInvokeNow 通过回调拿到 currentApp，再问 appManager.canInvoke
+ *
+ * getCurrentApp 通常由 host 拿 ctx 里挂的 session 来取（参考 helpTool 的写法），
+ * 但具体怎么取由 host 决定。agent-runtime 自己不关心 session 是什么样。
+ */
+export function createAppSubtoolOwner(deps: {
+  appManager: AppManager;
+  getCurrentApp: (ctx: ToolContext) => AppId | undefined;
+}): InvokeSubtoolOwner {
+  return {
+    ownsTool: (toolName: string): boolean => deps.appManager.ownsTool(toolName),
+    canInvokeNow: (toolName: string, ctx: ToolContext): SubtoolGuardResult => {
+      const currentApp = deps.getCurrentApp(ctx);
+      const result = deps.appManager.canInvoke(toolName, currentApp);
+      if (result.ok) {
+        return { ok: true };
+      }
+      return {
+        ok: false,
+        error: "INVOKE_TOOL_APP_GUARD",
+        message: result.reason,
+      };
+    },
+  };
+}

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -3,6 +3,7 @@ import type { LoopAgent } from "./loop-agent.js";
 import type { LoopAgentExtension } from "./loop-agent-extension.js";
 import type { Operation } from "./operation.js";
 import { AppManager, type App, type AppId, type CanInvokeResult } from "./app/app.js";
+import { createAppSubtoolOwner } from "./app/app-subtool-owner.js";
 import { HELP_TOOL_NAME, HelpTool, type HelpToolDeps } from "./app/help-tool.js";
 import { BaseLoopAgent } from "./base-loop-agent.js";
 import { InMemoryQueue, type Queue } from "./queue.js";
@@ -44,11 +45,13 @@ import {
   type ToolExecutionResult,
   type ToolKind,
 } from "./tool/tool-component.js";
+import type { InvokeSubtoolOwner, SubtoolGuardResult } from "./tool/subtool-owner.js";
 
 export {
   AppManager,
   BaseLoopAgent,
   BaseTaskAgent,
+  createAppSubtoolOwner,
   HELP_TOOL_NAME,
   HelpTool,
   InMemoryQueue,
@@ -63,6 +66,8 @@ export {
   type AppId,
   type CanInvokeResult,
   type HelpToolDeps,
+  type InvokeSubtoolOwner,
+  type SubtoolGuardResult,
   type Queue,
   type LoopAgent,
   type LoopAgentExtension,

--- a/packages/agent-runtime/src/tool/subtool-owner.ts
+++ b/packages/agent-runtime/src/tool/subtool-owner.ts
@@ -1,0 +1,49 @@
+import type { ToolContext } from "./tool-component.js";
+
+/**
+ * Invoke 子工具的所有者协议。
+ *
+ * 一个 invoke 子工具背后总有一个具体的所有者模块——某个 App、某个状态树节点、
+ * 未来某种全局服务。所有者负责两件事：
+ *
+ *   1. 声明它拥有哪些工具（ownsTool）
+ *   2. 在当前 runtime context 下判断这些工具能不能调用（canInvokeNow）
+ *
+ * InvokeTool 收到 invoke 请求时不再做任何 ad-hoc 检查，而是：
+ *   - 先用 ownsTool 在 owners 列表里找到所有者
+ *   - 让所有者通过 canInvokeNow 给出 gate 决策
+ *   - ok 就执行，not ok 就把所有者给的错误返回给 Kagami
+ *
+ * 这条 dispatcher 主路径取代了之前"两套并行 gate（状态树 availableTools +
+ * AppManager.canInvoke）按顺序串联检查"的 bolt-on 设计，避免不同所有者之间
+ * 的 gate 互相误挡。
+ */
+export interface InvokeSubtoolOwner {
+  /** 这个所有者是否拥有名为 toolName 的工具。 */
+  ownsTool(toolName: string): boolean;
+
+  /**
+   * 在当前 runtime context 下能否调用 toolName。
+   *
+   * 调用前提：调用方已经 confirmed ownsTool(toolName) 为 true。所有者可以信任
+   * 自己拥有这个工具，无需再 double-check。
+   */
+  canInvokeNow(toolName: string, ctx: ToolContext): SubtoolGuardResult;
+}
+
+/**
+ * 所有者对一次 invoke 请求的 gate 决策。
+ *
+ * - ok=true：可以执行
+ * - ok=false：拒绝。error 是错误代码（"INVOKE_TOOL_APP_GUARD" / "INVOKE_TOOL_NOT_AVAILABLE"
+ *   等），message 是给 Kagami 看的可操作提示，extras 是所有者想附加的诊断字段
+ *   （比如状态树会附 state、availableTools 给 Kagami 看可替代选项）
+ */
+export type SubtoolGuardResult =
+  | { ok: true }
+  | {
+      ok: false;
+      error: string;
+      message: string;
+      extras?: Record<string, unknown>;
+    };


### PR DESCRIPTION
## 动机

PR #63 的 if/else 分流是 bolt-on——把"状态树 availableTools"和 \"AppManager.canInvoke\" 两套并行 gate 用 \`ownsTool\` 切换。每加一类新所有者就要往 InvokeTool 里塞一个新分支，且两套 gate 互相误挡的 bug（之前那个 NOT_AVAILABLE 错挡 calc 工具）就是从这种结构出来的。

更本质的问法是：**这个 invoke 子工具该委派哪个模块来执行？** 答案是它的"所有者"。把所有者作为 first-class 抽象后，dispatch 只有一条主路径。

## 改动

### agent-runtime

- 加 \`InvokeSubtoolOwner\` 接口（\`packages/agent-runtime/src/tool/subtool-owner.ts\`），含：
  - \`ownsTool(name): boolean\`
  - \`canInvokeNow(name, ctx): SubtoolGuardResult\`
  - \`SubtoolGuardResult\` = \`{ ok: true } | { ok: false; error; message; extras? }\`，所有者通过 extras 附诊断字段（状态树会附 state / availableTools）

- \`createAppSubtoolOwner\` adapter 把 AppManager + 一个 \`getCurrentApp\` 回调包装成 owner

### apps/server

- \`createStateTreeSubtoolOwner\` 把 RootAgentSession 包装成 owner
  - \`ownsTool\` 用 \`!appManager.ownsTool\` 的 **catch-all**（不硬编码状态树工具名集合）
  - \`canInvokeNow\` 走原 \`getAvailableInvokeTools\` 判，错误格式保留 rich docs（state / availableTools / 可替代选项指南）

- \`InvokeTool\` 删 \`ownsTool\` / \`canInvoke\` 的 if/else 分流。主路径变成：
  \`\`\`ts
  const owner = this.owners.find(o => o.ownsTool(input.tool));
  if (!owner) return NO_OWNER;
  const guard = owner.canInvokeNow(input.tool, context);
  if (!guard.ok) return REJECTED(guard);
  return this.invokeToolSet.execute(...);
  \`\`\`

- factory 装配 \`[appOwner, stateTreeOwner]\` 传给 InvokeTool。顺序重要——App 在前确保 catch-all 不抢 App 工具。

### 测试

- \`createTestInvokeTool\` helper 模拟 factory 的 owners 装配，9 个 InvokeTool 构造换成 helper
- 现有所有测试（包括 PR #63 加的 2 个 calc 回归）继续通过

## 收益

1. **一条主路径**：dispatch 只有 find owner → ask owner → execute
2. **加新所有者不改 InvokeTool**：未来想加"多账号 QQ App owner"、"全局工具 owner"、"权限 owner" 都只需新增一个 owner，InvokeTool 零改动
3. **错误分类清晰**：所有者各自决定自己用什么 error code（\`INVOKE_TOOL_APP_GUARD\` / \`INVOKE_TOOL_NOT_AVAILABLE\` / 未来新加的）
4. **状态树和 App 不再互相误挡**：从根上消除两套 gate 串联的顺序 bug

## Test plan

- [x] \`pnpm build\` 全绿
- [x] \`pnpm typecheck\` 全绿
- [x] \`pnpm lint\` 全绿
- [x] \`pnpm format\` 全绿
- [x] \`pnpm --filter @kagami/server test\` 全绿（**439 / 439**）
- [x] 现有 invoke 测试 7 个全部通过（send_message、open_ithome_article、NOT_AVAILABLE、NOT_FOUND 等）
- [x] PR #63 加的 2 个 calc 回归测试（App 工具能绕过状态树 / 没 enter App 时 APP_GUARD）继续通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)