### PR TITLE
feat(agent): Per-App config schema 自注册

### DIFF
--- a/apps/server/src/agent/apps/calc/calc.app.ts
+++ b/apps/server/src/agent/apps/calc/calc.app.ts
@@ -1,28 +1,56 @@
-import type { App } from "@kagami/agent-runtime";
+import { z } from "zod";
+import type { App, AppStartupContext } from "@kagami/agent-runtime";
 import { CalculateTool } from "./tools/calculate.tool.js";
 
 export const CALC_APP_ID = "calc";
 
+const CalcConfigSchema = z
+  .object({
+    /**
+     * 计算结果保留的小数位数。未配置 / null 表示不做四舍五入，直接返回 JS 浮点结果。
+     * 配置后，App 内的 calculate 工具在产出 number 时会调用 toFixed(precision)
+     * 再解析回 number。
+     */
+    precision: z.number().int().min(0).max(20).optional(),
+  })
+  .default({});
+
+type CalcConfig = z.infer<typeof CalcConfigSchema>;
+
 /**
  * Calculator App。Phase 2 验证 App 框架可行性的最小 App。
  *
- * - 无状态，无后台，无生命周期工作
+ * - 无内部状态，无后台
  * - 只有一个工具 calculate(a, op, b)
  * - canInvoke 永远返回 true（App 内部没有 view，工具一直可用）
+ * - 支持 `precision` 配置：作为 App 自注册 config schema 的示范，演示
+ *   onStartup 把强类型 config 存进 App，再以闭包的方式喂给工具。
  */
-export class CalcApp implements App {
+export class CalcApp implements App<CalcConfig> {
   public readonly id = CALC_APP_ID;
   public readonly displayName = "计算器";
-  public readonly tools = [new CalculateTool()];
+  public readonly configSchema = CalcConfigSchema;
+  public readonly tools: readonly CalculateTool[];
+
+  private config: CalcConfig = {};
+
+  public constructor() {
+    this.tools = [new CalculateTool({ getPrecision: () => this.config.precision })];
+  }
 
   public canInvoke(): boolean {
     return true;
   }
 
   public async help(): Promise<string> {
+    const precisionLine =
+      this.config.precision === undefined
+        ? "结果不做小数位截断（按 JS 浮点直接返回）。"
+        : `结果保留 ${this.config.precision} 位小数。`;
     return [
       "你在 calc App 里。当前可调用工具：",
       "  - calculate(a, op, b): 对两个有限实数做一次二元四则运算。op 取值: +, -, *, /",
+      `  ${precisionLine}`,
       "",
       "需要复合运算（例如 1 + 2 * 3）时，按运算优先级分多次调用：",
       '  1. calculate(a=2, op="*", b=3) → 6',
@@ -30,5 +58,9 @@ export class CalcApp implements App {
       "",
       "调 back_to_portal 退出本 App 回到桌面。",
     ].join("\n");
+  }
+
+  public async onStartup(ctx: AppStartupContext<CalcConfig>): Promise<void> {
+    this.config = ctx.config;
   }
 }

--- a/apps/server/src/agent/apps/calc/tools/calculate.tool.ts
+++ b/apps/server/src/agent/apps/calc/tools/calculate.tool.ts
@@ -12,6 +12,16 @@ const CalculateArgumentsSchema = z.object({
   b: z.number().finite(),
 });
 
+type CalculateToolDeps = {
+  /**
+   * 返回当前 calc App 配置中的 precision。undefined 表示不做四舍五入。
+   *
+   * 用闭包而不是直接传 number 是为了让 calc App 可以在 onStartup 之后修改自身
+   * 配置（理论上未来若加 reload），而工具不必重建。
+   */
+  getPrecision: () => number | undefined;
+};
+
 /**
  * 二元四则运算工具。Calc App 内唯一的工具。
  *
@@ -19,6 +29,7 @@ const CalculateArgumentsSchema = z.object({
  * - 单次调用只做一次二元运算。需要复合表达式（如 1+2*3）时，Kagami 自己组合多次调用。
  * - 严格只接受有限 number；NaN / Infinity 由 zod .finite() 提前挡掉。
  * - 除零返回结构化 error tool_result，不抛异常。
+ * - precision 来自 CalcApp 的 config 闭包，undefined 表示不截断。
  */
 export class CalculateTool extends ZodToolComponent<typeof CalculateArgumentsSchema> {
   public readonly name = CALCULATE_TOOL_NAME;
@@ -34,10 +45,20 @@ export class CalculateTool extends ZodToolComponent<typeof CalculateArgumentsSch
   public readonly kind: ToolKind = "business";
   protected readonly inputSchema = CalculateArgumentsSchema;
 
+  private readonly getPrecision: () => number | undefined;
+
+  public constructor({ getPrecision }: CalculateToolDeps) {
+    super();
+    this.getPrecision = getPrecision;
+  }
+
   protected async executeTyped(input: z.infer<typeof CalculateArgumentsSchema>): Promise<string> {
     const result = computeBinaryOp(input.a, input.op, input.b);
     if (result.ok) {
-      return JSON.stringify({ ok: true, result: result.value });
+      return JSON.stringify({
+        ok: true,
+        result: applyPrecision(result.value, this.getPrecision()),
+      });
     }
     return JSON.stringify({ ok: false, error: result.error, message: result.message });
   }
@@ -65,4 +86,11 @@ function computeBinaryOp(
       }
       return { ok: true, value: a / b };
   }
+}
+
+function applyPrecision(value: number, precision: number | undefined): number {
+  if (precision === undefined) {
+    return value;
+  }
+  return Number(value.toFixed(precision));
 }

--- a/apps/server/src/app/agent-runtime.factory.ts
+++ b/apps/server/src/app/agent-runtime.factory.ts
@@ -198,10 +198,12 @@ export async function buildAgentRuntime({
   });
   await terminalService.initialize();
 
-  // App 框架：先建 AppManager 并注册 Apps，再把它们的 tools 拼进 invokeSubtools。
-  // 这个顺序保证 App 的工具能被 InvokeTool 调度到。
+  // App 框架：先建 AppManager 并注册 Apps，再按各 App 自带的 configSchema
+  // 校验 config.server.apps 的对应切片并调用 onStartup，最后把它们的 tools 拼
+  // 进 invokeSubtools。这个顺序保证 App 在贡献工具前已经完成自己的初始化。
   const appManager = new AppManager();
   appManager.register(new CalcApp());
+  await appManager.startupAll(config.server.apps);
 
   const invokeSubtools = [
     new SendMessageTool({

--- a/apps/server/src/config/config.loader.ts
+++ b/apps/server/src/config/config.loader.ts
@@ -360,6 +360,11 @@ const ConfigSchema = z.object({
         qq: StringLikeSchema,
       }),
     }),
+    /**
+     * 每个 App 的配置切片，key 是 App.id。结构由各 App 自己的 configSchema 在
+     * AppManager.startupAll 阶段校验，loader 这一层不解读。
+     */
+    apps: z.record(z.string(), z.unknown()).default({}),
   }),
 });
 

--- a/apps/server/test/agent/app-manager-startup.test.ts
+++ b/apps/server/test/agent/app-manager-startup.test.ts
@@ -1,0 +1,113 @@
+import { AppManager, type App, type AppStartupContext } from "@kagami/agent-runtime";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+const CalcLikeConfigSchema = z
+  .object({
+    precision: z.number().int().min(0).max(20).optional(),
+  })
+  .default({});
+
+type CalcLikeConfig = z.infer<typeof CalcLikeConfigSchema>;
+
+class FakeConfiguredApp implements App<CalcLikeConfig> {
+  public readonly id: string;
+  public readonly displayName: string;
+  public readonly tools = [] as const;
+  public readonly configSchema = CalcLikeConfigSchema;
+
+  public received: CalcLikeConfig | "not-called" = "not-called";
+
+  public constructor(id: string) {
+    this.id = id;
+    this.displayName = id;
+  }
+
+  public canInvoke(): boolean {
+    return true;
+  }
+
+  public async help(): Promise<string> {
+    return "";
+  }
+
+  public async onStartup(ctx: AppStartupContext<CalcLikeConfig>): Promise<void> {
+    this.received = ctx.config;
+  }
+}
+
+class FakeUnconfiguredApp implements App {
+  public readonly id: string;
+  public readonly displayName: string;
+  public readonly tools = [] as const;
+
+  public received: unknown = "not-called";
+
+  public constructor(id: string) {
+    this.id = id;
+    this.displayName = id;
+  }
+
+  public canInvoke(): boolean {
+    return true;
+  }
+
+  public async help(): Promise<string> {
+    return "";
+  }
+
+  public async onStartup(ctx: AppStartupContext): Promise<void> {
+    this.received = ctx.config;
+  }
+}
+
+describe("AppManager.startupAll", () => {
+  it("passes parsed config slice to onStartup when schema present", async () => {
+    const manager = new AppManager();
+    const app = new FakeConfiguredApp("calc-like");
+    manager.register(app);
+
+    await manager.startupAll({ "calc-like": { precision: 4 } });
+
+    expect(app.received).toEqual({ precision: 4 });
+  });
+
+  it("falls back to schema defaults when raw slice is missing", async () => {
+    const manager = new AppManager();
+    const app = new FakeConfiguredApp("calc-like");
+    manager.register(app);
+
+    await manager.startupAll({});
+
+    expect(app.received).toEqual({});
+  });
+
+  it("passes undefined config when App has no schema", async () => {
+    const manager = new AppManager();
+    const app = new FakeUnconfiguredApp("no-config");
+    manager.register(app);
+
+    await manager.startupAll({ "no-config": { ignored: true } });
+
+    expect(app.received).toBeUndefined();
+  });
+
+  it("throws with App id when raw slice violates schema", async () => {
+    const manager = new AppManager();
+    manager.register(new FakeConfiguredApp("calc-like"));
+
+    await expect(manager.startupAll({ "calc-like": { precision: -1 } })).rejects.toThrow(
+      /calc-like/,
+    );
+  });
+
+  it("works with default empty rawAppsConfig", async () => {
+    const manager = new AppManager();
+    const app = new FakeConfiguredApp("calc-like");
+    manager.register(app);
+
+    await manager.startupAll();
+
+    expect(app.received).toEqual({});
+  });
+});

--- a/apps/server/test/agent/apps/calc/calculate.tool.test.ts
+++ b/apps/server/test/agent/apps/calc/calculate.tool.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { CalculateTool } from "../../../../src/agent/apps/calc/tools/calculate.tool.js";
 
+function makeTool(precision?: number) {
+  return new CalculateTool({ getPrecision: () => precision });
+}
+
 describe("calc App / calculate tool", () => {
   it.each([
     [1, "+", 2, 3],
@@ -8,14 +12,14 @@ describe("calc App / calculate tool", () => {
     [4, "*", 6, 24],
     [10, "/", 4, 2.5],
   ])("calculate(%s %s %s) = %s", async (a, op, b, expected) => {
-    const tool = new CalculateTool();
+    const tool = makeTool();
     const result = await tool.execute({ a, op, b }, {});
 
     expect(JSON.parse(result.content)).toEqual({ ok: true, result: expected });
   });
 
   it("should reject division by zero", async () => {
-    const tool = new CalculateTool();
+    const tool = makeTool();
     const result = await tool.execute({ a: 1, op: "/", b: 0 }, {});
 
     expect(JSON.parse(result.content)).toMatchObject({
@@ -25,7 +29,7 @@ describe("calc App / calculate tool", () => {
   });
 
   it("should reject invalid operator via schema", async () => {
-    const tool = new CalculateTool();
+    const tool = makeTool();
     const result = await tool.execute({ a: 1, op: "%", b: 2 }, {});
 
     expect(JSON.parse(result.content)).toMatchObject({
@@ -35,12 +39,47 @@ describe("calc App / calculate tool", () => {
   });
 
   it("should reject non-finite numbers via schema", async () => {
-    const tool = new CalculateTool();
+    const tool = makeTool();
     const result = await tool.execute({ a: Infinity, op: "+", b: 1 }, {});
 
     expect(JSON.parse(result.content)).toMatchObject({
       ok: false,
       error: "INVALID_ARGUMENTS",
+    });
+  });
+
+  describe("precision config", () => {
+    it("undefined precision keeps full float result", async () => {
+      const tool = makeTool(undefined);
+      const result = await tool.execute({ a: 1, op: "/", b: 3 }, {});
+
+      expect(JSON.parse(result.content)).toEqual({ ok: true, result: 1 / 3 });
+    });
+
+    it("precision 2 rounds to 2 decimal places", async () => {
+      const tool = makeTool(2);
+      const result = await tool.execute({ a: 1, op: "/", b: 3 }, {});
+
+      expect(JSON.parse(result.content)).toEqual({ ok: true, result: 0.33 });
+    });
+
+    it("precision 0 rounds to integer", async () => {
+      const tool = makeTool(0);
+      const result = await tool.execute({ a: 7, op: "/", b: 2 }, {});
+
+      expect(JSON.parse(result.content)).toEqual({ ok: true, result: 4 });
+    });
+
+    it("precision reads at execute-time so app config changes take effect", async () => {
+      let precision: number | undefined = undefined;
+      const tool = new CalculateTool({ getPrecision: () => precision });
+
+      const before = await tool.execute({ a: 1, op: "/", b: 3 }, {});
+      expect(JSON.parse(before.content)).toEqual({ ok: true, result: 1 / 3 });
+
+      precision = 4;
+      const after = await tool.execute({ a: 1, op: "/", b: 3 }, {});
+      expect(JSON.parse(after.content)).toEqual({ ok: true, result: 0.3333 });
     });
   });
 });

--- a/apps/server/test/service/napcat-gateway.test-helper.ts
+++ b/apps/server/test/service/napcat-gateway.test-helper.ts
@@ -211,6 +211,7 @@ export function createConfigManager(): ConfigManager {
           qq: "10000",
         },
       },
+      apps: {},
     },
   };
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -110,3 +110,9 @@ server:
     creator:
       name: "创造者"
       qq: "10000"
+  # 每个 App 的配置切片。key 是 App.id，结构由各 App 自己的 configSchema 校验。
+  # 没列出来的 App 走 schema 默认值；schema 不接受的字段会在启动时报错。
+  apps:
+    calc:
+      # 计算结果保留的小数位数（0–20）。省略 / null 表示不做四舍五入。
+      precision: 6

--- a/packages/agent-runtime/src/app/app.ts
+++ b/packages/agent-runtime/src/app/app.ts
@@ -1,3 +1,4 @@
+import type { z } from "zod";
 import type { ToolComponent } from "../tool/tool-component.js";
 
 /** App 的唯一标识符。 */
@@ -10,8 +11,13 @@ export type AppId = string;
  * 框架不窥探 App 内部状态。所有 view focus、缓存、计时器等都由 App 自己管理。
  *
  * 设计依据见仓库根 CLAUDE.md "工具组织：InvokeTool 是顶层工具集的稳定壳"。
+ *
+ * 泛型参数 TConfig 让 App 可以声明自己的配置 schema（zod），框架在 startup
+ * 时按 schema 解析 `config.apps.<id>` 段落，并把验证后的强类型 config 传给
+ * onStartup。无 config 的 App 使用默认 TConfig=void，onStartup 拿到的
+ * config 是 undefined。
  */
-export interface App {
+export interface App<TConfig = void> {
   /** 唯一短串识别符，用作 Registry key 与外部 enter 目标 id。 */
   readonly id: AppId;
 
@@ -25,6 +31,17 @@ export interface App {
    * 友好的"稳定前缀"原则。
    */
   readonly tools: readonly ToolComponent[];
+
+  /**
+   * App 自己的配置 schema。框架在 startup 时按 `config.apps.<id>` 段落解析。
+   * 缺省（schema 未声明）时表示 App 不需要 config，onStartup 的 ctx.config
+   * 为 undefined。
+   *
+   * 解析失败会在 startup 阶段抛错并附 App id，避免运行时才发现配置错误。
+   */
+  // 输入侧用 unknown：rawAppsConfig 的切片是 unknown，且允许 z.object().default({})
+  // 这类 schema（输入侧带 undefined）作为合法的 configSchema 写法。
+  readonly configSchema?: z.ZodType<TConfig, z.ZodTypeDef, unknown>;
 
   /**
    * 由 AppManager 在分发某个本 App 拥有的工具之前调用。
@@ -41,11 +58,20 @@ export interface App {
    */
   help(): Promise<string>;
 
-  /** 进程启动时调用一次。App 可以在这里做初始化 / 起后台 timer。 */
-  onStartup?(): Promise<void>;
+  /**
+   * 进程启动时调用一次。App 可以在这里做初始化 / 起后台 timer。
+   * ctx.config 是按 configSchema 解析后的强类型配置；未声明 schema 的 App
+   * 拿到的是 undefined。
+   */
+  onStartup?(ctx: AppStartupContext<TConfig>): Promise<void>;
 
   /** 进程关停时反向调用一次。App 应在这里清理 timer / 连接。 */
   onShutdown?(): Promise<void>;
+}
+
+/** App.onStartup 的入参，目前只含解析后的配置。未来可能扩展（logger / 共享服务等）。 */
+export interface AppStartupContext<TConfig = void> {
+  readonly config: TConfig;
 }
 
 /** AppManager.canInvoke 的返回。 */
@@ -59,11 +85,12 @@ export type CanInvokeResult = { ok: true } | { ok: false; reason: string };
  * RootAgentSession）持有并以参数形式传入。
  */
 export class AppManager {
-  private readonly apps = new Map<AppId, App>();
-  private readonly toolOwners = new Map<string, App>();
+  // 内部存的是 App<unknown>，泛型擦除。各 App 实例自己负责 TConfig 的类型安全。
+  private readonly apps = new Map<AppId, App<unknown>>();
+  private readonly toolOwners = new Map<string, App<unknown>>();
 
   /** 注册一个 App。同 id 重复注册会抛错。 */
-  public register(app: App): void {
+  public register<TConfig>(app: App<TConfig>): void {
     if (this.apps.has(app.id)) {
       throw new Error(`App "${app.id}" 已注册`);
     }
@@ -75,17 +102,18 @@ export class AppManager {
         );
       }
     }
-    this.apps.set(app.id, app);
+    const erased = app as App<unknown>;
+    this.apps.set(app.id, erased);
     for (const tool of app.tools) {
-      this.toolOwners.set(tool.name, app);
+      this.toolOwners.set(tool.name, erased);
     }
   }
 
-  public getApp(id: AppId): App | undefined {
+  public getApp(id: AppId): App<unknown> | undefined {
     return this.apps.get(id);
   }
 
-  public getAllApps(): readonly App[] {
+  public getAllApps(): readonly App<unknown>[] {
     return [...this.apps.values()];
   }
 
@@ -130,10 +158,31 @@ export class AppManager {
     return { ok: true };
   }
 
-  /** 顺序调用所有 App 的 onStartup。 */
-  public async startupAll(): Promise<void> {
+  /**
+   * 顺序调用所有 App 的 onStartup，并按 configSchema 解析对应配置切片。
+   *
+   * rawAppsConfig 通常来自 config.yaml 的 `server.apps` 段落（结构 unknown，
+   * 由 App 自己的 schema 校验）。某 App 不在 raw 里时按空对象处理，让 schema
+   * 的默认值生效。
+   *
+   * 校验失败的 App 会以包含 App id 的错误信息抛出，避免运行时才发现配置错误。
+   */
+  public async startupAll(rawAppsConfig: Record<string, unknown> = {}): Promise<void> {
     for (const app of this.apps.values()) {
-      await app.onStartup?.();
+      const raw = rawAppsConfig[app.id] ?? {};
+      let config: unknown = undefined;
+      if (app.configSchema) {
+        const parsed = app.configSchema.safeParse(raw);
+        if (!parsed.success) {
+          throw new Error(
+            `App "${app.id}" 配置不合法（config.apps.${app.id}）：${parsed.error.message}`,
+          );
+        }
+        config = parsed.data;
+      }
+      // App<unknown> 的 onStartup 期望 ctx.config: unknown，cast 是必要的。
+      // 每个 App 自己的 TConfig 类型由它的实现保证（register<TConfig> 时类型已校验）。
+      await app.onStartup?.({ config });
     }
   }
 

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -2,7 +2,13 @@ import type { AgentRuntime, TaskAgent } from "./agent-runtime.js";
 import type { LoopAgent } from "./loop-agent.js";
 import type { LoopAgentExtension } from "./loop-agent-extension.js";
 import type { Operation } from "./operation.js";
-import { AppManager, type App, type AppId, type CanInvokeResult } from "./app/app.js";
+import {
+  AppManager,
+  type App,
+  type AppId,
+  type AppStartupContext,
+  type CanInvokeResult,
+} from "./app/app.js";
 import { createAppSubtoolOwner } from "./app/app-subtool-owner.js";
 import { HELP_TOOL_NAME, HelpTool, type HelpToolDeps } from "./app/help-tool.js";
 import { BaseLoopAgent } from "./base-loop-agent.js";
@@ -63,6 +69,7 @@ export {
   type AgentRuntime,
   type App,
   type AppId,
+  type AppStartupContext,
   type CanInvokeResult,
   type HelpToolDeps,
   type InvokeSubtoolOwner,


### PR DESCRIPTION
## Summary

把 App 框架升级为「每个 App 自带 zod 配置 schema」：

- **agent-runtime 内核**：`App<TConfig>` 接口加可选 `configSchema?: z.ZodType<TConfig, ZodTypeDef, unknown>`；`AppManager.startupAll(rawAppsConfig)` 在启动期按 schema 解析每个 App 的切片并把强类型 config 喂给 `onStartup(ctx)`；缺切片走 schema 默认值，校验失败抛带 App id 的错误；未声明 schema 的 App ctx.config 为 undefined。
- **配置链路打通**：`config.loader` 加 `server.apps: Record<string, unknown>`，loader 不解读结构。`agent-runtime.factory` 在 `appManager.register(...)` 之后调用 `await appManager.startupAll(config.server.apps)`，修复 onStartup 之前一直没被调的死代码。
- **CalcApp 作为自注册示范**：声明 `configSchema { precision?: int[0,20] }`，`onStartup` 把强类型 config 存进 App；`CalculateTool` 接 `getPrecision` 闭包，结果按 precision 走 `toFixed → Number` 四舍五入；undefined 时保持原值。`config.yaml.example` 加 `server.apps.calc.precision` 示范段。

## 不变量与 KV 缓存

- 工具集合在 startup 一次性确定，仍走 InvokeTool 子工具；本次改动不动顶层 tool 列表，也不动 system prompt，符合「稳定前缀」原则。
- onStartup 是冷启动阶段动作，运行期不会再被调用，不会污染消息尾部。

## Test plan

- [x] `pnpm typecheck` 全绿
- [x] `pnpm build` 全绿
- [x] `pnpm lint` 干净
- [x] `pnpm format` 干净
- [x] `pnpm test` 88 文件 / 448 用例全绿，含新增 5 个 `AppManager.startupAll` 用例与 4 个 `CalculateTool` precision 用例

## 风险

- 配置 schema 校验失败会在启动阶段直接抛错，避免运行时才发现配置错。如果 `config.yaml` 里 `server.apps.<id>` 写错，进程不会起来，但错误信息会带具体 App id，定位成本低。
- `App<TConfig>` 是泛型升级，旧的 `implements App`（默认 `TConfig=void`）保持二进制兼容；未声明 onStartup 的 App 不受影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)