### PR TITLE
refactor(llm-history): 拆分 LLM 调用历史列表/详情接口，降低列表响应体大小

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,7 +295,7 @@ Agent 相关补充约定：
 - OAuth 与配额管理：`/auth/:provider/status`、`/auth/:provider/login-url`、`/auth/:provider/logout`、`/auth/:provider/refresh`、`/auth/:provider/usage-limits`、`/auth/:provider/usage-trend`
 - LLM Playground：`/llm/providers`、`/llm/playground-tools`、`/llm/chat`
 - Napcat 主动发送：`/napcat/group/send`
-- 观测与历史查询：`/app-log/query`、`/llm-chat-call/query`、`/napcat-event/query`、`/napcat-group-message/query`、`/story/query`
+- 观测与历史查询：`/app-log/query`、`/llm-chat-call/query`、`/llm-chat-call/:id`、`/napcat-event/query`、`/napcat-group-message/query`、`/story/query`
 - Agent 状态与指标：`/agent-dashboard/*`、`/metric-chart/*`
 
 ### 前端（`@kagami/web`）

--- a/apps/server/src/common/http/route.helper.ts
+++ b/apps/server/src/common/http/route.helper.ts
@@ -13,6 +13,18 @@ type QueryRouteDef<TQuerySchema extends z.ZodTypeAny, TResponseSchema extends z.
   }) => Promise<z.infer<TResponseSchema>> | z.infer<TResponseSchema>;
 };
 
+type ParamRouteDef<TParamSchema extends z.ZodTypeAny, TResponseSchema extends z.ZodTypeAny> = {
+  app: FastifyInstance;
+  path: string;
+  paramSchema: TParamSchema;
+  responseSchema: TResponseSchema;
+  execute: (params: {
+    params: z.infer<TParamSchema>;
+    request: FastifyRequest;
+    reply: FastifyReply;
+  }) => Promise<z.infer<TResponseSchema>> | z.infer<TResponseSchema>;
+};
+
 type CommandRouteDef<TBodySchema extends z.ZodTypeAny, TResponseSchema extends z.ZodTypeAny> = {
   app: FastifyInstance;
   path: string;
@@ -39,6 +51,23 @@ export function registerQueryRoute<
   app.get(path, async (request, reply) => {
     const query = querySchema.parse(request.query);
     const result = await execute({ query, request, reply });
+    return responseSchema.parse(result);
+  });
+}
+
+export function registerParamRoute<
+  TParamSchema extends z.ZodTypeAny,
+  TResponseSchema extends z.ZodTypeAny,
+>({
+  app,
+  path,
+  paramSchema,
+  responseSchema,
+  execute,
+}: ParamRouteDef<TParamSchema, TResponseSchema>): void {
+  app.get(path, async (request, reply) => {
+    const params = paramSchema.parse(request.params);
+    const result = await execute({ params, request, reply });
     return responseSchema.parse(result);
   });
 }

--- a/apps/server/src/llm/dao/impl/llm-chat-call.impl.dao.ts
+++ b/apps/server/src/llm/dao/impl/llm-chat-call.impl.dao.ts
@@ -5,6 +5,8 @@ import { AppLogger } from "../../../logger/logger.js";
 import type {
   LlmChatCallItem,
   LlmChatCallDao,
+  LlmChatCallStatus,
+  LlmChatCallSummary,
   QueryLlmChatCallListInput,
   RecordLlmChatCallErrorInput,
   RecordLlmChatCallSuccessInput,
@@ -29,13 +31,24 @@ export class PrismaLlmChatCallDao implements LlmChatCallDao {
     });
   }
 
-  public async listPage(input: QueryLlmChatCallListInput): Promise<LlmChatCallItem[]> {
+  public async listPage(input: QueryLlmChatCallListInput): Promise<LlmChatCallSummary[]> {
     const offset = (input.page - 1) * input.pageSize;
     const rows = await this.database.llmChatCall.findMany({
       where: toWhereInput(input),
       orderBy: [{ createdAt: "desc" }, { id: "desc" }],
       take: input.pageSize,
       skip: offset,
+      select: {
+        id: true,
+        requestId: true,
+        seq: true,
+        provider: true,
+        model: true,
+        extension: true,
+        status: true,
+        latencyMs: true,
+        createdAt: true,
+      },
     });
 
     return rows.map(item => ({
@@ -45,7 +58,28 @@ export class PrismaLlmChatCallDao implements LlmChatCallDao {
       provider: item.provider,
       model: item.model,
       extension: toOptionalJsonRecord(item.extension),
-      status: item.status as LlmChatCallItem["status"],
+      status: item.status as LlmChatCallStatus,
+      latencyMs: item.latencyMs,
+      createdAt: item.createdAt,
+    }));
+  }
+
+  public async findById(id: number): Promise<LlmChatCallItem | null> {
+    const item = await this.database.llmChatCall.findUnique({
+      where: { id },
+    });
+    if (item === null) {
+      return null;
+    }
+
+    return {
+      id: item.id,
+      requestId: item.requestId,
+      seq: item.seq,
+      provider: item.provider,
+      model: item.model,
+      extension: toOptionalJsonRecord(item.extension),
+      status: item.status as LlmChatCallStatus,
       requestPayload: toJsonRecord(item.requestPayload),
       responsePayload: toOptionalJsonRecord(item.responsePayload),
       nativeRequestPayload: toOptionalJsonRecord(item.nativeRequestPayload),
@@ -54,7 +88,7 @@ export class PrismaLlmChatCallDao implements LlmChatCallDao {
       nativeError: toOptionalJsonRecord(item.nativeError),
       latencyMs: item.latencyMs,
       createdAt: item.createdAt,
-    }));
+    };
   }
 
   public async recordSuccess(input: RecordLlmChatCallSuccessInput): Promise<void> {

--- a/apps/server/src/llm/dao/llm-chat-call.dao.ts
+++ b/apps/server/src/llm/dao/llm-chat-call.dao.ts
@@ -2,7 +2,7 @@ import type { LlmProviderId } from "../../common/contracts/llm.js";
 
 export type LlmChatCallStatus = "success" | "failed";
 
-export type LlmChatCallItem = {
+export type LlmChatCallSummary = {
   id: number;
   requestId: string;
   seq: number;
@@ -10,14 +10,17 @@ export type LlmChatCallItem = {
   model: string;
   extension: Record<string, unknown> | null;
   status: LlmChatCallStatus;
+  latencyMs: number | null;
+  createdAt: Date;
+};
+
+export type LlmChatCallItem = LlmChatCallSummary & {
   requestPayload: Record<string, unknown>;
   responsePayload: Record<string, unknown> | null;
   nativeRequestPayload: Record<string, unknown> | null;
   nativeResponsePayload: Record<string, unknown> | null;
   error: Record<string, unknown> | null;
   nativeError: Record<string, unknown> | null;
-  latencyMs: number | null;
-  createdAt: Date;
 };
 
 export type QueryLlmChatCallListInput = {
@@ -52,7 +55,8 @@ export type RecordLlmChatCallErrorInput = LlmChatCallBaseInput & {
 
 export interface LlmChatCallDao {
   countByQuery(input: QueryLlmChatCallListInput): Promise<number>;
-  listPage(input: QueryLlmChatCallListInput): Promise<LlmChatCallItem[]>;
+  listPage(input: QueryLlmChatCallListInput): Promise<LlmChatCallSummary[]>;
+  findById(id: number): Promise<LlmChatCallItem | null>;
   recordSuccess(input: RecordLlmChatCallSuccessInput): Promise<void>;
   recordError(input: RecordLlmChatCallErrorInput): Promise<void>;
 }

--- a/apps/server/src/ops/application/llm-chat-call-query.impl.service.ts
+++ b/apps/server/src/ops/application/llm-chat-call-query.impl.service.ts
@@ -1,10 +1,12 @@
 import {
+  type LlmChatCallDetailResponse,
   type LlmChatCallListQuery,
   type LlmChatCallListResponse,
 } from "@kagami/shared/schemas/llm-chat";
 import type { LlmChatCallDao } from "../../llm/dao/llm-chat-call.dao.js";
 import type { LlmChatCallQueryService } from "./llm-chat-call-query.service.js";
-import { mapLlmChatCallList } from "../mappers/llm-chat-call.mapper.js";
+import { mapLlmChatCallDetail, mapLlmChatCallList } from "../mappers/llm-chat-call.mapper.js";
+import { BizError } from "../../common/errors/biz-error.js";
 
 type DefaultLlmChatCallQueryServiceDeps = {
   llmChatCallDao: LlmChatCallDao;
@@ -29,5 +31,21 @@ export class DefaultLlmChatCallQueryService implements LlmChatCallQueryService {
       total,
       items,
     });
+  }
+
+  public async getDetail(id: number): Promise<LlmChatCallDetailResponse> {
+    const item = await this.llmChatCallDao.findById(id);
+    if (item === null) {
+      throw new BizError({
+        message: "LLM 调用记录不存在",
+        meta: {
+          reason: "LLM_CHAT_CALL_NOT_FOUND",
+          id,
+        },
+        statusCode: 404,
+      });
+    }
+
+    return mapLlmChatCallDetail(item);
   }
 }

--- a/apps/server/src/ops/application/llm-chat-call-query.service.ts
+++ b/apps/server/src/ops/application/llm-chat-call-query.service.ts
@@ -1,8 +1,10 @@
 import {
+  type LlmChatCallDetailResponse,
   type LlmChatCallListQuery,
   type LlmChatCallListResponse,
 } from "@kagami/shared/schemas/llm-chat";
 
 export interface LlmChatCallQueryService {
   queryList(query: LlmChatCallListQuery): Promise<LlmChatCallListResponse>;
+  getDetail(id: number): Promise<LlmChatCallDetailResponse>;
 }

--- a/apps/server/src/ops/http/llm-chat-call.handler.ts
+++ b/apps/server/src/ops/http/llm-chat-call.handler.ts
@@ -1,10 +1,19 @@
 import type { FastifyInstance } from "fastify";
+import { z } from "zod";
 import {
+  LlmChatCallDetailResponseSchema,
   LlmChatCallListQuerySchema,
   LlmChatCallListResponseSchema,
 } from "@kagami/shared/schemas/llm-chat";
 import type { LlmChatCallQueryService } from "../application/llm-chat-call-query.service.js";
-import { registerQueryRoute } from "../../common/http/route.helper.js";
+import { registerParamRoute, registerQueryRoute } from "../../common/http/route.helper.js";
+
+const LlmChatCallDetailParamSchema = z.object({
+  id: z.preprocess(
+    value => (typeof value === "string" ? Number.parseInt(value, 10) : value),
+    z.number().int().positive(),
+  ),
+});
 
 type LlmChatCallHandlerDeps = {
   llmChatCallQueryService: LlmChatCallQueryService;
@@ -26,6 +35,16 @@ export class LlmChatCallHandler {
       responseSchema: LlmChatCallListResponseSchema,
       execute: ({ query }) => {
         return this.llmChatCallQueryService.queryList(query);
+      },
+    });
+
+    registerParamRoute({
+      app,
+      path: `${this.prefix}/:id`,
+      paramSchema: LlmChatCallDetailParamSchema,
+      responseSchema: LlmChatCallDetailResponseSchema,
+      execute: ({ params }) => {
+        return this.llmChatCallQueryService.getDetail(params.id);
       },
     });
   }

--- a/apps/server/src/ops/mappers/llm-chat-call.mapper.ts
+++ b/apps/server/src/ops/mappers/llm-chat-call.mapper.ts
@@ -1,14 +1,18 @@
 import {
-  type LlmChatCallItem,
+  type LlmChatCallDetailResponse,
   type LlmChatCallListResponse,
+  type LlmChatCallSummary,
 } from "@kagami/shared/schemas/llm-chat";
-import type { LlmChatCallItem as LlmChatCallDaoItem } from "../../llm/dao/llm-chat-call.dao.js";
+import type {
+  LlmChatCallItem as LlmChatCallDaoItem,
+  LlmChatCallSummary as LlmChatCallDaoSummary,
+} from "../../llm/dao/llm-chat-call.dao.js";
 
 type MapLlmChatCallListInput = {
   page: number;
   pageSize: number;
   total: number;
-  items: LlmChatCallDaoItem[];
+  items: LlmChatCallDaoSummary[];
 };
 
 export function mapLlmChatCallList(input: MapLlmChatCallListInput): LlmChatCallListResponse {
@@ -18,11 +22,11 @@ export function mapLlmChatCallList(input: MapLlmChatCallListInput): LlmChatCallL
       pageSize: input.pageSize,
       total: input.total,
     },
-    items: input.items.map(mapLlmChatCallItem),
+    items: input.items.map(mapLlmChatCallSummary),
   };
 }
 
-export function mapLlmChatCallItem(item: LlmChatCallDaoItem): LlmChatCallItem {
+export function mapLlmChatCallSummary(item: LlmChatCallDaoSummary): LlmChatCallSummary {
   return {
     id: item.id,
     requestId: item.requestId,
@@ -31,13 +35,19 @@ export function mapLlmChatCallItem(item: LlmChatCallDaoItem): LlmChatCallItem {
     model: item.model,
     extension: item.extension,
     status: item.status,
+    latencyMs: item.latencyMs,
+    createdAt: item.createdAt.toISOString(),
+  };
+}
+
+export function mapLlmChatCallDetail(item: LlmChatCallDaoItem): LlmChatCallDetailResponse {
+  return {
+    ...mapLlmChatCallSummary(item),
     requestPayload: item.requestPayload,
     responsePayload: item.responsePayload,
     nativeRequestPayload: item.nativeRequestPayload,
     nativeResponsePayload: item.nativeResponsePayload,
     error: item.error,
     nativeError: item.nativeError,
-    latencyMs: item.latencyMs,
-    createdAt: item.createdAt.toISOString(),
   };
 }

--- a/apps/server/test/dao/llm-chat-call.impl.dao.test.ts
+++ b/apps/server/test/dao/llm-chat-call.impl.dao.test.ts
@@ -240,6 +240,78 @@ describe("PrismaLlmChatCallDao", () => {
       orderBy: [{ createdAt: "desc" }, { id: "desc" }],
       take: 10,
       skip: 10,
+      select: {
+        id: true,
+        requestId: true,
+        seq: true,
+        provider: true,
+        model: true,
+        extension: true,
+        status: true,
+        latencyMs: true,
+        createdAt: true,
+      },
+    });
+  });
+
+  it("findById should return null when prisma returns null", async () => {
+    const findUnique = vi.fn().mockResolvedValue(null);
+    const database = {
+      llmChatCall: {
+        findUnique,
+      },
+    } as unknown as Database;
+
+    const dao = new PrismaLlmChatCallDao({ database });
+    const result = await dao.findById(999);
+
+    expect(result).toBeNull();
+    expect(findUnique).toHaveBeenCalledWith({ where: { id: 999 } });
+  });
+
+  it("findById should map full record into LlmChatCallItem", async () => {
+    const findUnique = vi.fn().mockResolvedValue({
+      id: 42,
+      requestId: "req-42",
+      seq: 1,
+      provider: "openai",
+      model: "gpt-test",
+      extension: { metadata: { actualModel: "gpt-test-2026-03-17" } },
+      status: "success",
+      requestPayload: { messages: [] },
+      responsePayload: { ok: true },
+      nativeRequestPayload: { native: "req" },
+      nativeResponsePayload: { native: "resp" },
+      error: null,
+      nativeError: null,
+      latencyMs: 17,
+      createdAt: new Date("2026-04-01T00:00:00.000Z"),
+    });
+    const database = {
+      llmChatCall: {
+        findUnique,
+      },
+    } as unknown as Database;
+
+    const dao = new PrismaLlmChatCallDao({ database });
+    const result = await dao.findById(42);
+
+    expect(result).toEqual({
+      id: 42,
+      requestId: "req-42",
+      seq: 1,
+      provider: "openai",
+      model: "gpt-test",
+      extension: { metadata: { actualModel: "gpt-test-2026-03-17" } },
+      status: "success",
+      requestPayload: { messages: [] },
+      responsePayload: { ok: true },
+      nativeRequestPayload: { native: "req" },
+      nativeResponsePayload: { native: "resp" },
+      error: null,
+      nativeError: null,
+      latencyMs: 17,
+      createdAt: new Date("2026-04-01T00:00:00.000Z"),
     });
   });
 

--- a/apps/server/test/handler/llm-chat-call.handler.test.ts
+++ b/apps/server/test/handler/llm-chat-call.handler.test.ts
@@ -1,5 +1,6 @@
 import Fastify from "fastify";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 import type { LlmChatCallQueryService } from "../../src/ops/application/llm-chat-call-query.service.js";
 import { LlmChatCallHandler } from "../../src/ops/http/llm-chat-call.handler.js";
 
@@ -44,6 +45,7 @@ describe("LlmChatCallHandler", () => {
     const queryList = vi.fn().mockResolvedValue(result);
     const llmChatCallQueryService: LlmChatCallQueryService = {
       queryList,
+      getDetail: vi.fn(),
     };
 
     const handler = new LlmChatCallHandler({ llmChatCallQueryService });
@@ -86,6 +88,7 @@ describe("LlmChatCallHandler", () => {
     });
     const llmChatCallQueryService: LlmChatCallQueryService = {
       queryList,
+      getDetail: vi.fn(),
     };
 
     const handler = new LlmChatCallHandler({ llmChatCallQueryService });
@@ -117,6 +120,7 @@ describe("LlmChatCallHandler", () => {
     });
     const llmChatCallQueryService: LlmChatCallQueryService = {
       queryList,
+      getDetail: vi.fn(),
     };
 
     const handler = new LlmChatCallHandler({ llmChatCallQueryService });
@@ -136,5 +140,97 @@ describe("LlmChatCallHandler", () => {
         model: "gpt-5.4",
       }),
     );
+  });
+
+  it("should fetch detail by id via injected service", async () => {
+    const detail = {
+      id: 42,
+      requestId: "req-42",
+      seq: 1,
+      provider: "openai",
+      model: "gpt-test",
+      extension: null,
+      status: "success",
+      requestPayload: { messages: [] },
+      responsePayload: { ok: true },
+      nativeRequestPayload: null,
+      nativeResponsePayload: null,
+      error: null,
+      nativeError: null,
+      latencyMs: 12,
+      createdAt: new Date().toISOString(),
+    };
+    const getDetail = vi.fn().mockResolvedValue(detail);
+    const llmChatCallQueryService: LlmChatCallQueryService = {
+      queryList: vi.fn(),
+      getDetail,
+    };
+
+    const handler = new LlmChatCallHandler({ llmChatCallQueryService });
+    handler.register(app);
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/llm-chat-call/42",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      id: 42,
+      requestId: "req-42",
+      requestPayload: { messages: [] },
+      responsePayload: { ok: true },
+    });
+    expect(getDetail).toHaveBeenCalledWith(42);
+  });
+
+  it("should reject non-numeric :id without invoking service", async () => {
+    app.setErrorHandler((error, _request, reply) => {
+      if (error instanceof z.ZodError) {
+        return reply.code(400).send({ message: "请求参数不合法" });
+      }
+      throw error;
+    });
+    const getDetail = vi.fn();
+    const llmChatCallQueryService: LlmChatCallQueryService = {
+      queryList: vi.fn(),
+      getDetail,
+    };
+
+    const handler = new LlmChatCallHandler({ llmChatCallQueryService });
+    handler.register(app);
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/llm-chat-call/abc",
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(getDetail).not.toHaveBeenCalled();
+  });
+
+  it("should reject non-positive :id without invoking service", async () => {
+    app.setErrorHandler((error, _request, reply) => {
+      if (error instanceof z.ZodError) {
+        return reply.code(400).send({ message: "请求参数不合法" });
+      }
+      throw error;
+    });
+    const getDetail = vi.fn();
+    const llmChatCallQueryService: LlmChatCallQueryService = {
+      queryList: vi.fn(),
+      getDetail,
+    };
+
+    const handler = new LlmChatCallHandler({ llmChatCallQueryService });
+    handler.register(app);
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/llm-chat-call/0",
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(getDetail).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/test/llm/client.test.ts
+++ b/apps/server/test/llm/client.test.ts
@@ -30,6 +30,7 @@ function createLlmChatCallDaoMock(): LlmChatCallDao {
   return {
     countByQuery: vi.fn().mockResolvedValue(0),
     listPage: vi.fn().mockResolvedValue([]),
+    findById: vi.fn().mockResolvedValue(null),
     recordSuccess: vi.fn().mockResolvedValue(undefined),
     recordError: vi.fn().mockResolvedValue(undefined),
   };

--- a/apps/server/test/mapper/llm-chat-call.mapper.test.ts
+++ b/apps/server/test/mapper/llm-chat-call.mapper.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import type {
+  LlmChatCallItem as LlmChatCallDaoItem,
+  LlmChatCallSummary as LlmChatCallDaoSummary,
+} from "../../src/llm/dao/llm-chat-call.dao.js";
+import {
+  mapLlmChatCallDetail,
+  mapLlmChatCallSummary,
+} from "../../src/ops/mappers/llm-chat-call.mapper.js";
+
+describe("llm-chat-call mapper", () => {
+  it("mapLlmChatCallSummary should serialize createdAt and preserve summary fields", () => {
+    const item: LlmChatCallDaoSummary = {
+      id: 1,
+      requestId: "req-1",
+      seq: 7,
+      provider: "openai",
+      model: "gpt-test",
+      extension: { foo: "bar" },
+      status: "failed",
+      latencyMs: null,
+      createdAt: new Date("2026-04-02T03:04:05.000Z"),
+    };
+
+    expect(mapLlmChatCallSummary(item)).toEqual({
+      id: 1,
+      requestId: "req-1",
+      seq: 7,
+      provider: "openai",
+      model: "gpt-test",
+      extension: { foo: "bar" },
+      status: "failed",
+      latencyMs: null,
+      createdAt: "2026-04-02T03:04:05.000Z",
+    });
+  });
+
+  it("mapLlmChatCallDetail should include payload fields on top of the summary shape", () => {
+    const item: LlmChatCallDaoItem = {
+      id: 2,
+      requestId: "req-2",
+      seq: 1,
+      provider: "openai",
+      model: "gpt-test",
+      extension: null,
+      status: "success",
+      requestPayload: { messages: [] },
+      responsePayload: { ok: true },
+      nativeRequestPayload: { native: "req" },
+      nativeResponsePayload: null,
+      error: null,
+      nativeError: { status: 500 },
+      latencyMs: 9,
+      createdAt: new Date("2026-04-02T03:04:05.000Z"),
+    };
+
+    expect(mapLlmChatCallDetail(item)).toEqual({
+      id: 2,
+      requestId: "req-2",
+      seq: 1,
+      provider: "openai",
+      model: "gpt-test",
+      extension: null,
+      status: "success",
+      latencyMs: 9,
+      createdAt: "2026-04-02T03:04:05.000Z",
+      requestPayload: { messages: [] },
+      responsePayload: { ok: true },
+      nativeRequestPayload: { native: "req" },
+      nativeResponsePayload: null,
+      error: null,
+      nativeError: { status: 500 },
+    });
+  });
+});

--- a/apps/server/test/service/llm-chat-call-query.impl.service.test.ts
+++ b/apps/server/test/service/llm-chat-call-query.impl.service.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+import type { LlmChatCallDao, LlmChatCallItem } from "../../src/llm/dao/llm-chat-call.dao.js";
+import { DefaultLlmChatCallQueryService } from "../../src/ops/application/llm-chat-call-query.impl.service.js";
+import { BizError } from "../../src/common/errors/biz-error.js";
+
+function makeDao(overrides: Partial<LlmChatCallDao>): LlmChatCallDao {
+  return {
+    countByQuery: vi.fn(),
+    listPage: vi.fn(),
+    findById: vi.fn(),
+    recordSuccess: vi.fn(),
+    recordError: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("DefaultLlmChatCallQueryService", () => {
+  it("getDetail should throw BizError(404) when dao returns null", async () => {
+    const llmChatCallDao = makeDao({
+      findById: vi.fn().mockResolvedValue(null),
+    });
+
+    const service = new DefaultLlmChatCallQueryService({ llmChatCallDao });
+
+    await expect(service.getDetail(999)).rejects.toMatchObject({
+      name: "BizError",
+      statusCode: 404,
+      meta: {
+        reason: "LLM_CHAT_CALL_NOT_FOUND",
+        id: 999,
+      },
+    });
+    await expect(service.getDetail(999)).rejects.toBeInstanceOf(BizError);
+    expect(llmChatCallDao.findById).toHaveBeenCalledWith(999);
+  });
+
+  it("getDetail should return mapped detail when dao returns item", async () => {
+    const daoItem: LlmChatCallItem = {
+      id: 42,
+      requestId: "req-42",
+      seq: 1,
+      provider: "openai",
+      model: "gpt-test",
+      extension: { foo: "bar" },
+      status: "success",
+      requestPayload: { messages: [] },
+      responsePayload: { ok: true },
+      nativeRequestPayload: { native: "req" },
+      nativeResponsePayload: { native: "resp" },
+      error: null,
+      nativeError: null,
+      latencyMs: 12,
+      createdAt: new Date("2026-04-02T03:04:05.000Z"),
+    };
+    const llmChatCallDao = makeDao({
+      findById: vi.fn().mockResolvedValue(daoItem),
+    });
+
+    const service = new DefaultLlmChatCallQueryService({ llmChatCallDao });
+    const result = await service.getDetail(42);
+
+    expect(result).toEqual({
+      id: 42,
+      requestId: "req-42",
+      seq: 1,
+      provider: "openai",
+      model: "gpt-test",
+      extension: { foo: "bar" },
+      status: "success",
+      requestPayload: { messages: [] },
+      responsePayload: { ok: true },
+      nativeRequestPayload: { native: "req" },
+      nativeResponsePayload: { native: "resp" },
+      error: null,
+      nativeError: null,
+      latencyMs: 12,
+      createdAt: "2026-04-02T03:04:05.000Z",
+    });
+  });
+});

--- a/apps/web/src/lib/query.ts
+++ b/apps/web/src/lib/query.ts
@@ -29,6 +29,7 @@ export const queryKeys = {
     providers: () => ["llm", "providers"] as const,
     playgroundTools: () => ["llm", "playground-tools"] as const,
     historyList: (params: QueryParams) => ["llm-chat-call", "list", params] as const,
+    historyDetail: (id: number) => ["llm-chat-call", "detail", id] as const,
   },
   appLog: {
     historyList: (params: QueryParams) => ["app-log", "list", params] as const,

--- a/apps/web/src/pages/llm-history/LlmChatCallDetailPanel.tsx
+++ b/apps/web/src/pages/llm-history/LlmChatCallDetailPanel.tsx
@@ -1,7 +1,12 @@
-import { type LlmChatCallItem } from "@kagami/shared/schemas/llm-chat";
+import {
+  type LlmChatCallItem,
+  type LlmChatCallStatus,
+  type LlmChatCallSummary,
+} from "@kagami/shared/schemas/llm-chat";
 import { FlaskConical } from "lucide-react";
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useNavigate } from "react-router-dom";
+import { getApiErrorMessage } from "@/lib/api";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -18,9 +23,22 @@ import {
   type ParsedLlmRequestMessage,
   type ParsedLlmUserContentPart,
 } from "./llm-chat-call-detail-parser";
+import { useLlmChatCallDetail } from "./useLlmChatCallDetail";
 
 type LlmChatCallDetailPanelProps = {
-  item: LlmChatCallItem | null;
+  id: number | null;
+  summary: LlmChatCallSummary | null;
+};
+
+type DetailHeaderInfo = {
+  requestId: string;
+  seq: number;
+  provider: string;
+  model: string;
+  extension: Record<string, unknown> | null;
+  status: LlmChatCallStatus;
+  latencyMs: number | null;
+  createdAt: string;
 };
 
 type InputEntry =
@@ -34,13 +52,16 @@ type InputEntry =
       originalIndex: number;
     };
 
-export function LlmChatCallDetailPanel({ item }: LlmChatCallDetailPanelProps) {
+export function LlmChatCallDetailPanel({ id, summary }: LlmChatCallDetailPanelProps) {
   const navigate = useNavigate();
   const [inputOrder, setInputOrder] = useState<"asc" | "desc">("desc");
   const [activeCopyPanelKey, setActiveCopyPanelKey] = useState<string | null>(null);
   const [activeCopyItemId, setActiveCopyItemId] = useState<number | null>(null);
   const [copyStatus, setCopyStatus] = useState<JsonPanelCopyStatus>("idle");
   const copyFeedbackTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const detailQuery = useLlmChatCallDetail(id);
+  const item: LlmChatCallItem | null = detailQuery.data ?? null;
+  const headerInfo: DetailHeaderInfo | null = item ?? summary;
   const parsed = useMemo(() => (item ? parseLlmChatCallDetail(item) : null), [item]);
   const importDraft = useMemo(() => {
     if (item === null || !parsed?.request) {
@@ -165,7 +186,7 @@ export function LlmChatCallDetailPanel({ item }: LlmChatCallDetailPanelProps) {
     }, 1800);
   }
 
-  if (item === null || parsed === null) {
+  if (id === null) {
     return (
       <div className="flex h-full flex-col">
         <div className="flex flex-1 items-center justify-center px-6">
@@ -175,18 +196,43 @@ export function LlmChatCallDetailPanel({ item }: LlmChatCallDetailPanelProps) {
     );
   }
 
+  if (detailQuery.isError) {
+    return (
+      <div className="flex h-full flex-col">
+        <div className="flex flex-1 items-center justify-center px-6">
+          <p className="text-sm text-destructive">
+            加载详情失败：{getApiErrorMessage(detailQuery.error)}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (item === null || parsed === null || headerInfo === null) {
+    return (
+      <div className="flex h-full flex-col">
+        <div className="flex flex-1 items-center justify-center px-6">
+          <p className="text-sm text-muted-foreground">详情加载中…</p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex h-full flex-col">
       <div className="border-b px-5 py-4">
         <div className="grid grid-cols-1 gap-2 text-sm text-muted-foreground sm:grid-cols-2">
-          <MetaItem label="Request ID" value={item.requestId} mono />
-          <MetaItem label="Attempt Seq" value={`#${item.seq}`} mono />
-          <MetaItem label="Provider" value={item.provider} />
-          <MetaItem label="Model" value={item.model} />
-          <MetaItem label="实际 Model" value={readActualModel(item.extension) ?? "—"} />
-          <MetaItem label="状态" value={toStatusLabel(item.status)} />
-          <MetaItem label="延迟" value={item.latencyMs === null ? "—" : `${item.latencyMs} ms`} />
-          <MetaItem label="时间" value={formatDate(item.createdAt)} />
+          <MetaItem label="Request ID" value={headerInfo.requestId} mono />
+          <MetaItem label="Attempt Seq" value={`#${headerInfo.seq}`} mono />
+          <MetaItem label="Provider" value={headerInfo.provider} />
+          <MetaItem label="Model" value={headerInfo.model} />
+          <MetaItem label="实际 Model" value={readActualModel(headerInfo.extension) ?? "—"} />
+          <MetaItem label="状态" value={toStatusLabel(headerInfo.status)} />
+          <MetaItem
+            label="延迟"
+            value={headerInfo.latencyMs === null ? "—" : `${headerInfo.latencyMs} ms`}
+          />
+          <MetaItem label="时间" value={formatDate(headerInfo.createdAt)} />
         </div>
 
         <div className="mt-4 flex flex-wrap gap-2">
@@ -530,7 +576,7 @@ function formatDate(iso: string): string {
   });
 }
 
-function toStatusLabel(status: LlmChatCallItem["status"]): string {
+function toStatusLabel(status: LlmChatCallStatus): string {
   return status === "success" ? "成功" : "失败";
 }
 

--- a/apps/web/src/pages/llm-history/LlmHistoryPage.tsx
+++ b/apps/web/src/pages/llm-history/LlmHistoryPage.tsx
@@ -1,7 +1,7 @@
 import {
   LlmProviderListResponseSchema,
-  type LlmChatCallItem,
   type LlmChatCallStatus,
+  type LlmChatCallSummary,
 } from "@kagami/shared/schemas/llm-chat";
 import { useQuery } from "@tanstack/react-query";
 import { type FormEvent, useMemo } from "react";
@@ -29,7 +29,6 @@ import { createSchemaQueryOptions, queryKeys } from "@/lib/query";
 import { normalizeOptionalText, setIfNonEmpty } from "@/lib/search-params";
 import { cn } from "@/lib/utils";
 import { LlmChatCallDetailPanel } from "./LlmChatCallDetailPanel";
-import { parseLlmChatCallDetail } from "./llm-chat-call-detail-parser";
 import { useLlmChatCallList } from "./useLlmChatCallList";
 
 const PAGE_SIZE = 20;
@@ -90,17 +89,10 @@ export function LlmHistoryPage() {
   }, [formState.provider, providerOptions]);
   const total = data?.pagination.total ?? 0;
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
-  const rows = useMemo(
-    () =>
-      (data?.items ?? []).map(item => ({
-        item,
-        detailParse: parseLlmChatCallDetail(item),
-      })),
-    [data?.items],
-  );
-  const selectedItem = useMemo(
-    () => rows.find(row => row.item.id === selectedId)?.item ?? null,
-    [rows, selectedId],
+  const items = useMemo(() => data?.items ?? [], [data?.items]);
+  const selectedSummary = useMemo(
+    () => items.find(item => item.id === selectedId) ?? null,
+    [items, selectedId],
   );
 
   function handleFilterSubmit(event: FormEvent<HTMLFormElement>) {
@@ -249,14 +241,14 @@ export function LlmHistoryPage() {
                     加载中…
                   </TableCell>
                 </TableRow>
-              ) : rows.length === 0 ? (
+              ) : items.length === 0 ? (
                 <TableRow>
                   <TableCell colSpan={4} className="h-24 text-center text-muted-foreground">
                     暂无数据
                   </TableCell>
                 </TableRow>
               ) : (
-                rows.map(({ item, detailParse }) => (
+                items.map(item => (
                   <TableRow
                     key={item.id}
                     data-state={selectedId === item.id ? "selected" : undefined}
@@ -272,11 +264,6 @@ export function LlmHistoryPage() {
                       <Badge variant={item.status === "success" ? "default" : "destructive"}>
                         {toStatusLabel(item.status)}
                       </Badge>
-                      {detailParse.hasSchemaError ? (
-                        <Badge variant="outline" className="ml-2">
-                          解析失败
-                        </Badge>
-                      ) : null}
                     </TableCell>
                   </TableRow>
                 ))
@@ -291,17 +278,16 @@ export function LlmHistoryPage() {
             <div className="flex h-24 items-center justify-center rounded-md border text-sm text-muted-foreground">
               加载中…
             </div>
-          ) : rows.length === 0 ? (
+          ) : items.length === 0 ? (
             <div className="flex h-24 items-center justify-center rounded-md border text-sm text-muted-foreground">
               暂无数据
             </div>
           ) : (
             <div className="space-y-3">
-              {rows.map(({ item, detailParse }) => (
+              {items.map(item => (
                 <LlmHistoryMobileCard
                   key={item.id}
                   item={item}
-                  hasSchemaError={detailParse.hasSchemaError}
                   isSelected={selectedId === item.id}
                   onClick={() => handleSelectItem(item.id)}
                 />
@@ -310,8 +296,8 @@ export function LlmHistoryPage() {
           )}
         </div>
       }
-      detailPanel={<LlmChatCallDetailPanel item={selectedItem} />}
-      detailTitle={getDetailTitle(selectedItem)}
+      detailPanel={<LlmChatCallDetailPanel id={selectedId} summary={selectedSummary} />}
+      detailTitle={getDetailTitle(selectedSummary)}
       isMobile={isMobile}
       showMobileDetail={showMobileDetail}
       isError={isError}
@@ -388,7 +374,7 @@ function toStatusLabel(status: LlmChatCallStatus): string {
   return status === "success" ? "成功" : "失败";
 }
 
-function getDetailTitle(item: LlmChatCallItem | null): string {
+function getDetailTitle(item: LlmChatCallSummary | null): string {
   if (item === null) {
     return "LLM 调用详情";
   }
@@ -398,12 +384,10 @@ function getDetailTitle(item: LlmChatCallItem | null): string {
 
 function LlmHistoryMobileCard({
   item,
-  hasSchemaError,
   isSelected,
   onClick,
 }: {
-  item: LlmChatCallItem;
-  hasSchemaError: boolean;
+  item: LlmChatCallSummary;
   isSelected: boolean;
   onClick: () => void;
 }) {
@@ -418,7 +402,6 @@ function LlmHistoryMobileCard({
           <Badge variant={item.status === "success" ? "default" : "destructive"}>
             {toStatusLabel(item.status)}
           </Badge>
-          {hasSchemaError ? <Badge variant="outline">解析失败</Badge> : null}
         </div>
       </div>
 

--- a/apps/web/src/pages/llm-history/useLlmChatCallDetail.ts
+++ b/apps/web/src/pages/llm-history/useLlmChatCallDetail.ts
@@ -1,0 +1,20 @@
+import {
+  type LlmChatCallDetailResponse,
+  LlmChatCallDetailResponseSchema,
+} from "@kagami/shared/schemas/llm-chat";
+import { useQuery } from "@tanstack/react-query";
+import { createSchemaQueryOptions, queryKeys } from "@/lib/query";
+
+export function useLlmChatCallDetail(id: number | null) {
+  return useQuery({
+    ...createSchemaQueryOptions<
+      LlmChatCallDetailResponse,
+      ReturnType<typeof queryKeys.llm.historyDetail>
+    >({
+      queryKey: queryKeys.llm.historyDetail(id ?? 0),
+      path: `/llm-chat-call/${id ?? 0}`,
+      schema: LlmChatCallDetailResponseSchema,
+    }),
+    enabled: id !== null,
+  });
+}

--- a/packages/shared/src/schemas/llm-chat.ts
+++ b/packages/shared/src/schemas/llm-chat.ts
@@ -129,7 +129,7 @@ export const LlmChatCallListQuerySchema = PaginationQuerySchema.extend({
 
 export type LlmChatCallListQuery = z.infer<typeof LlmChatCallListQuerySchema>;
 
-export const LlmChatCallItemSchema = z.object({
+export const LlmChatCallSummarySchema = z.object({
   id: z.number().int().positive(),
   requestId: z.string().min(1),
   seq: z.number().int().positive(),
@@ -137,21 +137,31 @@ export const LlmChatCallItemSchema = z.object({
   model: z.string().min(1),
   extension: JsonRecordSchema.nullable(),
   status: LlmChatCallStatusSchema,
+  latencyMs: z.number().int().nullable(),
+  createdAt: z.string().datetime(),
+});
+
+export type LlmChatCallSummary = z.infer<typeof LlmChatCallSummarySchema>;
+
+export const LlmChatCallItemSchema = LlmChatCallSummarySchema.extend({
   requestPayload: JsonRecordSchema,
   responsePayload: JsonRecordSchema.nullable(),
   nativeRequestPayload: JsonRecordSchema.nullable(),
   nativeResponsePayload: JsonRecordSchema.nullable(),
   error: JsonRecordSchema.nullable(),
   nativeError: JsonRecordSchema.nullable(),
-  latencyMs: z.number().int().nullable(),
-  createdAt: z.string().datetime(),
 });
 
 export type LlmChatCallItem = z.infer<typeof LlmChatCallItemSchema>;
 
-export const LlmChatCallListResponseSchema = createPaginatedResponseSchema(LlmChatCallItemSchema);
+export const LlmChatCallListResponseSchema =
+  createPaginatedResponseSchema(LlmChatCallSummarySchema);
 
 export type LlmChatCallListResponse = z.infer<typeof LlmChatCallListResponseSchema>;
+
+export const LlmChatCallDetailResponseSchema = LlmChatCallItemSchema;
+
+export type LlmChatCallDetailResponse = z.infer<typeof LlmChatCallDetailResponseSchema>;
 
 export const LlmProviderOptionSchema = z
   .object({


### PR DESCRIPTION
## Summary

**问题**：前端请求 `/llm-chat-call/query` 列表接口性能很差。每条记录都返回 6 个大 JSON 字段（`requestPayload` / `responsePayload` / `nativeRequestPayload` / `nativeResponsePayload` / `error` / `nativeError`），但列表 UI 只用 4 列（时间 / Provider / Model / 状态）。性能瓶颈集中在序列化、Zod 校验和 TanStack Query structural sharing 全跑在大对象上。

**方案**：列表接口精简 + 新增 detail 接口按 id 取完整记录。

**Shared**
- `LlmChatCallSummarySchema`（9 个轻字段）/ `LlmChatCallItemSchema`（summary extend 6 个大字段）
- 新增 `LlmChatCallDetailResponseSchema`

**后端**
- DAO `listPage` 改返回 `LlmChatCallSummary[]`，Prisma 查询加 `select` 字段过滤
- DAO 新增 `findById(id)` 返回完整 `LlmChatCallItem`
- service 新增 `getDetail(id)`，未找到抛 `BizError(404)`
- 新增 `registerParamRoute` helper 支持 `:id` 路径
- handler 注册 `GET /llm-chat-call/:id`

**前端**
- 新增 `useLlmChatCallDetail(id)` hook，`enabled: id !== null`，react-query 按 id 缓存
- `LlmChatCallDetailPanel` props 由 `{ item }` 改为 `{ id, summary }`，内部 fetch；summary 占位避免切换时闪烁；loading / error / empty 状态分支
- `LlmHistoryPage` 移除行内 `parseLlmChatCallDetail` 与 \"解析失败\" 徽章（解析失败信息保留在详情面板）

## Test Coverage

新增 8 个测试（91 文件 / 464 用例 全绿）：

| 文件 | 用例 |
|------|------|
| `test/dao/llm-chat-call.impl.dao.test.ts` | findById null + happy path；listPage select 字段断言 |
| `test/service/llm-chat-call-query.impl.service.test.ts`（新） | getDetail 404 + happy path |
| `test/mapper/llm-chat-call.mapper.test.ts`（新） | summary / detail 形状 |
| `test/handler/llm-chat-call.handler.test.ts` | `:id` happy path + 非数字/非正数 400 |

**后端代码路径直接覆盖率 90%**（9/10）。`registerParamRoute` helper 通过 handler 间接覆盖；schemas 通过 `responseSchema.parse()` 间接覆盖。前端无测试基础设施（项目级历史，不在本次范围）。

Tests: 89 → 91 (+2 new files), 456 → 464 (+8 new cases)

## Pre-Landing Review

No issues found.

- SQL/数据安全：Prisma `findUnique({where:{id}})` 参数化；DB-side `select` 字段过滤；无 N+1
- 类型设计：`Item = Summary & {大字段}` 关系清晰，命名一致
- 路由顺序：Fastify `/llm-chat-call/query` 静态优先，`/llm-chat-call/:id` 不会拦截
- 错误流：`BizError(404)` 由 `server-runtime` 全局 errorHandler 转 HTTP；`ZodError` 转 400
- 前端缓存：`useLlmChatCallDetail` 用 `enabled: id !== null` 守门；同一行重复点击不会重复请求

## Documentation

- `AGENTS.md` 观测接口列表新增 `/llm-chat-call/:id`

## 性能影响

| 指标 | 改动前 | 改动后 |
|------|-------|--------|
| 单页响应体（20 条） | `20 * (9 轻字段 + 6 大 JSON)` | `20 * 9 轻字段` |
| DB→Server 网络 | 拉所有字段 | Prisma `select` 只拉轻字段 |
| 前端 Zod 校验对象 | 大对象 | 轻对象 |
| 详情数据 | 始终全量加载 | 按选中 id 单独拉，react-query 按 id 缓存 |

## Test plan

- [x] `pnpm build` 通过
- [x] `pnpm typecheck` 通过
- [x] `pnpm lint` 通过
- [x] `pnpm format` 通过
- [x] `pnpm --filter @kagami/server test -- --run` 91/91 文件、464/464 用例 全绿