### PR TITLE
docs: 新增 ARCHITECTURE.md / CHANGELOG.md / TODOS.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,5 @@ build
 coverage
 .DS_Store
 .vscode
-TODOS.md
 apps/server/src/generated/prisma
 .claude/worktrees

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,171 @@
+# Architecture
+
+本文档描述 Kagami 仓库的代码组织、模块依赖与关键设计决策。项目理念（Agent as a life）见 [README](./README.md)；面向 LLM agent 的协作指引见 [AGENTS.md](./AGENTS.md)。
+
+## Workspace 拓扑
+
+pnpm workspace 由 4 个包组成，依赖关系单向（apps → packages）：
+
+```
+apps/server  ─┐
+              ├──→  packages/agent-runtime  ──→  packages/shared
+apps/web    ──┘                                 ↑
+                                                │
+                       apps/web ────────────────┘
+```
+
+| 包                      | 角色                                                                                                        |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `@kagami/server`        | Fastify 后端、Agent 业务装配、NapCat 网关、HTTP/ops 接口、Prisma DAO                                        |
+| `@kagami/web`           | React 19 + Vite 管理台                                                                                      |
+| `@kagami/agent-runtime` | 与 Kagami 项目语义无关的通用 Agent 内核（AgentRuntime / TaskAgentRuntime / Operation / Tool / ToolCatalog） |
+| `@kagami/shared`        | Zod schema、DTO、前后端共用工具                                                                             |
+
+## 后端模块 DAG
+
+后端采用「扁平模块 + 模块内分层」结构，顶层目录直接位于 `apps/server/src/<module>`，模块按 DAG 单向依赖。
+
+```
+                       app                        最高层装配：Fastify 注册、模块 wiring、启动补水
+                        │
+        ┌───────────────┼───────────────┐
+        ↓               ↓               ↓
+       ops          agent           napcat       业务/能力层
+        │               │               │
+        └──────┬────────┴──────┬────────┘
+               ↓               ↓
+              llm           news / metric
+               │
+        auth / logger / db / config
+                       │
+                     common         无业务语义的公共契约 / errors / http helper / runtime utils
+```
+
+每个模块内部按需分层：
+
+- `domain/` — 实体、值对象、模块内 port、纯规则
+- `application/` — use case / service / query / command
+- `infra/` — Prisma、HTTP、外部系统适配
+- `http/` — Fastify handler 与路由注册
+
+非每个模块都补全四层；以实际复杂度为准。模块之间禁止循环依赖。
+
+### 关键模块速览
+
+| 模块        | 职责                                                                                                     |
+| ----------- | -------------------------------------------------------------------------------------------------------- |
+| `common`    | `BizError`、`toHttpErrorResponse`、`registerQueryRoute` / `registerParamRoute` 等路由 helper、跨模块契约 |
+| `config`    | `config.yaml` 加载、Zod 校验、运行时配置管理                                                             |
+| `db`        | Prisma client、事务封装                                                                                  |
+| `auth`      | OAuth（Claude Code / Codex 等）回调、secret store、usage cache / trend                                   |
+| `llm`       | LLM provider 封装、chat client、embedding、调用历史 DAO                                                  |
+| `napcat`    | NapCat gateway、入站事件归一化、消息发送                                                                 |
+| `news`      | RSS 等资讯源轮询，给 Agent 提供「读新闻」这种生活输入                                                    |
+| `metric`    | 运行时指标采集与可视化数据接口                                                                           |
+| `agent`     | Kagami 业务层：RootAgent、capabilities、事件适配、上下文压缩、Story 记忆、RAG                            |
+| `ops`       | 后台观测接口：app-log、llm-chat-call、embedding-cache、Story、Agent Dashboard、napcat history            |
+| `scheduler` | 后台定时任务（数据保留清理等）                                                                           |
+| `app`       | 模块装配、Fastify 路由注册、健康检查、启动上下文补水                                                     |
+
+### Agent 子结构
+
+```
+apps/server/src/agent/
+├── runtime/          Kagami 定制运行时：RootAgentRuntime、session、事件队列、上下文渲染
+├── capabilities/     按能力聚合的实现
+│   ├── messaging/      QQ 群消息收发（NapCat 是事件源，不向 runtime 泄漏）
+│   ├── story/          长期记忆 / RAG 检索 / Story 写入
+│   ├── news/           RSS 抓取、文章阅读
+│   ├── vision/         图片理解
+│   ├── web-search/     独立子 Agent，多轮搜索结果只回传摘要
+│   ├── context-summary/ 上下文压缩 Operation（唯一允许 replaceMessages 的路径）
+│   └── terminal/       终端能力 App
+└── apps/             App 框架（Per-App config schema 自注册）
+```
+
+通用 Agent Runtime 内核位于 `packages/agent-runtime`；Kagami 项目语义不下沉到该包。
+
+## 前端结构
+
+```
+apps/web/src/
+├── pages/
+│   ├── agent-dashboard/         默认入口，Agent 总览
+│   ├── auth/                    OAuth 与配额
+│   ├── llm-playground/          手工触发 LLM 调用
+│   ├── llm-history/             LLM 调用历史
+│   ├── app-log-history/         应用日志
+│   ├── napcat-event-history/    NapCat 事件
+│   ├── napcat-group-message-history/  群消息
+│   ├── story-history/           Story 记忆
+│   ├── main-agent-context/      主 Agent 当前上下文
+│   ├── metric-charts/           运行时指标图表
+│   └── scheduler-tasks/         后台任务面板
+├── components/layout/           跨页面布局（HistoryListPageLayout、MobileDetailHeader 等）
+├── components/ui/               基于 shadcn 的原子组件
+└── lib/                         api 客户端、query keys、工具
+```
+
+技术栈：React 19、React Router、TanStack Query 5、Tailwind 3、shadcn。组件优先用 shadcn，缺失时通过 shadcn CLI 引入。
+
+## 数据流与生命周期
+
+### 输入：事件源
+
+Agent 不区分输入来源；所有外部信号都归一为「生活输入」：
+
+```
+NapCat 群消息 ─┐
+RSS 轮询      ─┼─→  事件队列  ─→  RootAgentRuntime  ─→  ReAct 循环  ─→  Tool 调用 / 输出
+定时任务       │
+系统通知       ─┘
+```
+
+`messaging`、`news`、`scheduler` 等模块负责把各自的事件归一为内部事件结构投入队列。runtime 不知道也不应该知道它们的具体协议。
+
+### 推理：稳定前缀 + 易变尾部
+
+LLM 消息列表分三段：
+
+1. **稳定前缀** — system prompt、工具定义、历史对话。只追加，不修改。
+2. **易变尾部** — 当轮新事件、召回注入、tool result。可变但只影响最后一段。
+3. **计划性重建** — 仅上下文压缩允许 `replaceMessages`，一次性把旧前缀换成更短的新前缀，作为新的稳定前缀继续生长。
+
+对应到代码：`AgentContext` 只暴露两个消息变更入口：`appendMessages`（保留前缀）与 `replaceMessages`（明确破坏前缀）。
+
+### 工具系统：InvokeTool 顶层壳
+
+LLM API 暴露的顶层 tools 集合永远只包含少量结构性元能力（`enter` / `back-to-portal` / `wait` / `invoke` / `help`），不随 capability / App 数量增长。具体能力通过 `invoke(name, args)` 间接调用，可选 App 模式下还可通过 `enter(<appId>)` + `help` 在运行时按需披露子工具。
+
+设计目的：避免新增能力让顶层 tools 列表变化、把 KV 缓存命中率降到零。详见 AGENTS.md「开发原则：KV 缓存命中率优先」。
+
+## 持久化
+
+- **PostgreSQL**（生产 / 开发统一）通过 Prisma ORM 访问
+- Schema 源文件 `apps/server/prisma/schema.prisma`，迁移落在 `apps/server/prisma/migrations/`
+- 通过 `pnpm db:migrate:dev` / `db:migrate:deploy` 管理
+- DAO 接口定义在模块内 `dao/`，实现在 `dao/impl/`
+
+## HTTP 接口入口
+
+| 类别            | 路径                                                                                                                                 |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| 健康检查        | `/health`                                                                                                                            |
+| OAuth / 配额    | `/auth/:provider/status` \| `login-url` \| `logout` \| `refresh` \| `usage-limits` \| `usage-trend`                                  |
+| LLM Playground  | `/llm/providers`、`/llm/playground-tools`、`/llm/chat`                                                                               |
+| NapCat 主动发送 | `/napcat/group/send`                                                                                                                 |
+| 观测查询        | `/app-log/query`、`/llm-chat-call/query`、`/llm-chat-call/:id`、`/napcat-event/query`、`/napcat-group-message/query`、`/story/query` |
+| Agent / 指标    | `/agent-dashboard/*`、`/main-agent-context/recent`、`/metric-chart/*`                                                                |
+
+## 部署
+
+- PM2（`ecosystem.config.cjs`）托管两个进程：`kagami-server`（Fastify，默认 20003）+ `kagami-web`（静态 + 反代 `/api/*`，默认 20004）
+- `pnpm app:deploy` 串起 build → Prisma migrate deploy → PM2 reload → `pm2 save`
+- PostgreSQL 与 NapCat 作为宿主机外部依赖运行；`config.yaml` 一般用 `localhost` 访问
+
+## 进一步阅读
+
+- [README.md](./README.md) — 项目理念与使用入口
+- [AGENTS.md](./AGENTS.md) — 面向 LLM agent 的协作指引（KV 缓存优先、capability 设计原则、代码规范、命令清单）
+- [CHANGELOG.md](./CHANGELOG.md) — 变更记录
+- [TODOS.md](./TODOS.md) — 待办清单

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,72 @@
+# Changelog
+
+本项目所有重要变更记录在此文件。
+
+格式参考 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)。
+本仓库目前以日期分节，未启用语义化版本号；`package.json` 中的 `version` 字段长期保持 `0.0.0`，仅为 npm 字段合法性而存在。新条目按提交时间倒序追加在 `## [Unreleased]` 下，定期归档到具体日期分节。
+
+## [Unreleased]
+
+### Changed
+
+- llm-history: 拆分 LLM 调用历史列表 / 详情接口，`/llm-chat-call/query` 列表只返回 summary 字段，新增 `GET /llm-chat-call/:id` 详情接口；前端列表改为按选中 id 单独 fetch detail，降低列表响应体大小（[#72](https://github.com/KisinTheFlame/kagami/pull/72)）
+
+## 2026-05
+
+### Added
+
+- agent: Per-App config schema 自注册（#67）
+- agent: Portal 展示已装 App 列表（#62）
+- agent: Phase 2 — `BackToPortalTool` / `EnterTool` App 入口，落地第一个 App `calc`（#61）
+- agent: Phase 1 App 框架抽象就位（空 `AppManager` + `HelpTool`）（#58）
+
+### Changed
+
+- agent/ops: 砍 dashboard 死代码并把 endpoint 重命名为 `/main-agent-context/recent`（#70）
+- agent/apps: `terminal` capability 迁成 `TerminalApp`（#69）
+- agent: `WebSearchTaskAgent` 复用主 Agent prefix，命中 prompt cache（#68）
+- web: 拆 Agent 仪表盘为两个独立页面（#66）
+- agent: `InvokeTool` 改成 owner-driven dispatch（#65）
+- agent: 主 Agent / 子 Agent `toolChoice` 回到 `required`（#64）
+- agent: 移除神游（zone_out）状态与子工具（#59）
+- agent: 子 Agent / 召回 / 主 Agent 上下文摘要切换为 `auto` toolChoice（#57）
+- agent-runtime: 主 Agent 切换为 `auto` toolChoice（#56）
+- agent/story: 拆分 `StoryAgentHost` 为三段独立组件
+- agent: 拆分 `RootAgentSession` 状态机为独立子类
+
+### Performance
+
+- agent/story: `StoryRecall` 异步化，主 Agent 不再为召回等待（#60）
+
+### Fixed
+
+- agent: `InvokeTool` 分流 App 工具与状态树工具（#63）
+- agent/story: 修复 review 发现的 `BatchPreparer` 不变量降级与字段漂移
+
+## 2026-04
+
+### Added
+
+- scheduler: 新增统一周期任务调度框架与历史表自动清理
+- agent: 新增 `terminal` 状态节点与 `bash` 子工具
+
+### Changed
+
+- agent-runtime: 抽通用 `Queue` 与 `SerialExecutor` 替代 mutation 链
+- agent: 抽出 root-agent 扩展并加固 `getSnapshot` 隔离
+- scheduler: `llm_chat_call` 保留期 7 天 → 3 天
+- app: 调整后台轮询启动时机
+- app: 拆分 Agent runtime 装配
+- auth: 抽取通用 OAuth 刷新调度器并对齐 Codex
+- docs: README 英文化并新增中文版链接
+
+### Fixed
+
+- auth: 兼容 Claude Code 用量返回新增字段
+- agent: 修复 `terminal cd ~/path` 解析、`saveCwd` 竞态及 `persistOutput` 重复
+
+## 更早
+
+更早的提交未在此文件归档；可通过 `git log` 查阅完整历史。
+
+[Unreleased]: https://github.com/KisinTheFlame/kagami/compare/master...HEAD

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,45 @@
+# TODOs
+
+待办事项清单。按模块 / 主题分组，组内按优先级 P0 → P3 排序。完成的项移到底部 `## Completed`。
+
+**优先级语义**：
+
+| 级别 | 含义 |
+|------|------|
+| P0 | 阻塞性问题，必须立刻处理 |
+| P1 | 重要但不阻塞，应当尽快安排 |
+| P2 | 改进项，时间允许时处理 |
+| P3 | 想法 / 长期项，可能永远不做 |
+
+**条目格式**：
+
+```markdown
+### <一句话标题>
+
+- **Priority:** P{0-3}
+- **Status:** open | in-progress
+- **Context:** 为什么这件事值得做、依赖、约束（可选）
+- **Notes:** 链接、相关文件、相关 issue/PR（可选）
+```
+
+---
+
+## scheduler
+
+### `news_article` / `news_feed_cursor` 的清理策略
+
+- **Priority:** P1
+- **Status:** open
+- **Context:** 当前 `apps/server/src/scheduler/tasks/data-retention/retention-tasks.ts` 显式把 `news_article` 与 `news_feed_cursor` 排除在每日清理之外（[retention-tasks.ts:41](apps/server/src/scheduler/tasks/data-retention/retention-tasks.ts:41)）。RSS 文章既不像日志那样安全按时间清掉，也不像 Story 记忆那样需要永久保留 —— 需要单独想清楚保留窗口、与 Agent 召回路径的关系、以及 `news_feed_cursor` 在重置后如何避免重新拉取已读旧文章。
+- **Notes:** 决策前不要简单地把它加进 `RETENTION_TASKS`。
+
+---
+
+## Completed
+
+<!-- 完成后的条目按完成日期倒序，附 PR 链接。例：
+### 拆分 LLM 调用历史列表/详情接口
+
+- **Priority:** P1
+- **Completed:** 2026-05-23, [#72](https://github.com/KisinTheFlame/kagami/pull/72)
+-->


### PR DESCRIPTION
## Summary

新增三份顶层文档骨架（基于仓库现有状态推出的内容，骨架为主，方便后续补充）。

### ARCHITECTURE.md

从 AGENTS.md 提炼出面向开发者的架构事实文档，去掉了原本针对 LLM agent 的指示性语言，保留可验证的事实。包含：

- Workspace 拓扑（4 个包的依赖方向）
- 后端模块 DAG + 关键模块速览
- Agent 子结构（`runtime` + `capabilities/*`）
- 前端页面分布、技术栈
- 数据流：事件源 → 队列 → ReAct 循环 → tool / 输出
- 稳定前缀 / 易变尾部 / 计划性重建三段模型
- InvokeTool 顶层壳设计与目的
- 持久化（Prisma + Postgres）与部署（PM2）

### CHANGELOG.md

Keep a Changelog 风格。说明仓库暂不启用 SemVer、`package.json.version` 长期保持 `0.0.0` 的现状。

- `## [Unreleased]` 顶部列入 [#72](https://github.com/KisinTheFlame/kagami/pull/72) 的 llm-history API 拆分
- 按月归档近 30 条 commit，按 Added / Changed / Performance / Fixed 分组

### TODOS.md

轻量骨架：优先级 P0–P3、Status、Context、Notes 字段说明。首批一项真实条目：

- `news_article` / `news_feed_cursor` 的清理策略 — `apps/server/src/scheduler/tasks/data-retention/retention-tasks.ts` 注释已显式指向 TODOS.md，但该文件原本被 `.gitignore` 排除，新加入的开发者看不到这条线索。本 PR 把它正式入仓。

### .gitignore

移除 `TODOS.md` 一行，反转 `a0a6c5f`（"更新 gitignore 中 todo 文件名"）把 TODOS.md 当本地 scratchpad 的旧决策。

## Test plan

- [x] `pnpm format` 通过（prettier 整理过 ARCHITECTURE.md 的表格列宽）
- [x] 文档间内部链接正确（README ↔ ARCHITECTURE ↔ AGENTS ↔ CHANGELOG ↔ TODOS）
- [x] CHANGELOG `[Unreleased]` compare link 指向 master...HEAD