### PR TITLE
perf(agent): wake reminder 由每分钟降频为每半小时一次

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Changed
 
+- agent: Wake Reminder 由每分钟降频为每半小时一次，同一半小时窗口（00 / 30 分桶）内的多轮 round 共享去重 key、不再重复追加；展示的时间值仍是真实触发时刻；长会话尾部 `system_reminder` 噪声减少约 30 倍，对 KV 缓存更友好（[#77](https://github.com/KisinTheFlame/kagami/pull/77)）
 - build/config: `config.loader.ts` 与 `scripts/read-config.mjs` 在 git worktree 内找不到 `config.yaml` 时，自动通过 `.git` 文件解析主仓库根目录并读取其中的 `config.yaml`，让 worktree 不再需要拷贝 / symlink 配置即可跑 `pnpm db:generate` / `pnpm build`
 - agent: `wait` 工具在连续第 3 次调用时短路返回 `<wait_blocked>` 提醒，不再阻塞事件队列，让 Agent 在长时间无外部事件时被迫跳出空等死循环、转去复盘 story / 读新闻 / 主动发起话题（[#74](https://github.com/KisinTheFlame/kagami/pull/74)）
 - llm-history: 拆分 LLM 调用历史列表 / 详情接口，`/llm-chat-call/query` 列表只返回 summary 字段，新增 `GET /llm-chat-call/:id` 详情接口；前端列表改为按选中 id 单独 fetch detail，降低列表响应体大小（[#72](https://github.com/KisinTheFlame/kagami/pull/72)）

--- a/apps/server/src/agent/runtime/root-agent/root-agent-runtime.ts
+++ b/apps/server/src/agent/runtime/root-agent/root-agent-runtime.ts
@@ -317,7 +317,7 @@ class RootAgentHost implements RootAgentExtensionHost {
   public async appendWakeReminderIfNeeded(): Promise<void> {
     const now = this.now();
     await this.mutationExecutor.submit(async () => {
-      if (isSameWakeReminderMinute(this.lastWakeReminderAt, now)) {
+      if (isSameWakeReminderBucket(this.lastWakeReminderAt, now)) {
         return;
       }
 
@@ -726,15 +726,15 @@ function shouldPersistAssistantMessage(message: AssistantMessage): boolean {
   return message.content.trim().length > 0 || message.toolCalls.length > 0;
 }
 
-function isSameWakeReminderMinute(previous: Date | null, current: Date): boolean {
+function isSameWakeReminderBucket(previous: Date | null, current: Date): boolean {
   if (previous === null) {
     return false;
   }
 
-  return createWakeReminderMinuteKey(previous) === createWakeReminderMinuteKey(current);
+  return createWakeReminderBucketKey(previous) === createWakeReminderBucketKey(current);
 }
 
-function createWakeReminderMinuteKey(now: Date): string {
+function createWakeReminderBucketKey(now: Date): string {
   const parts = new Intl.DateTimeFormat("zh-CN", {
     timeZone: "Asia/Shanghai",
     year: "numeric",
@@ -746,7 +746,10 @@ function createWakeReminderMinuteKey(now: Date): string {
   }).formatToParts(now);
   const values = Object.fromEntries(parts.map(part => [part.type, part.value]));
 
-  return [values.year, values.month, values.day, values.hour, values.minute].join("-");
+  const minuteNumber = Number.parseInt(values.minute, 10);
+  const bucketedMinute = minuteNumber < 30 ? "00" : "30";
+
+  return [values.year, values.month, values.day, values.hour, bucketedMinute].join("-");
 }
 
 function cloneDate(value: Date | null): Date | null {


### PR DESCRIPTION
## 改动

把 `RootAgentHost.appendWakeReminderIfNeeded` 的去重 key 粒度，从「年-月-日-时-分」改为「年-月-日-时-30 分钟桶」（minute < 30 → "00"，>= 30 → "30"）。

只动了 [apps/server/src/agent/runtime/root-agent/root-agent-runtime.ts](apps/server/src/agent/runtime/root-agent/root-agent-runtime.ts) 一个文件（+8 / -5）：
- `createWakeReminderMinuteKey` → `createWakeReminderBucketKey`：minute 字段量化到 30 分钟桶。
- `isSameWakeReminderMinute` → `isSameWakeReminderBucket`：同步改名以避免"按分钟"的旧语义误导。
- `appendWakeReminderIfNeeded` 内部调用同步换名。

## 动机

`WakeReminderExtension` 在 Agent 每一轮 round 开始前都会检查并追加一条 `<system_reminder>当前时间…</system_reminder>`。原本去重 key 精确到分钟，导致**每进入新的一分钟、Agent 任意一次 round 触发时都会插入一条新的时间提醒**。

频率过高带来的问题：
- 长会话里时间提醒占满消息列表尾部，污染上下文。
- 对 KV 缓存命中率没有任何帮助 —— 反而每分钟在尾部追加一段"几乎相同但又不完全相同"的固定噪声，本来可以更稀疏。

降频到 30 分钟后：
- 同一半小时窗口（如 13:00–13:29 / 13:30–13:59）内的多轮 round 共享同一个去重 key，不重复追加。
- 时间提醒约每半小时一条，长会话里时间噪声 token 减少 ~30 倍。
- 展示的时间值依然是 round 实际触发时刻的真实北京时间（例如 `13:31`，而不是规整化的 `13:30`），Agent 拿到的是当下时间，没有失真。

## KV 缓存影响

按 `CLAUDE.md` 的「稳定前缀 + 易变尾部」自检：
- 不动 system prompt，不动 InvokeTool 描述 / 子工具索引，不动历史消息序列化格式。前缀稳定性不受影响。
- 仅减少了追加到尾部的时间提醒频率，是正向收益。
- 不引入新的 `replaceMessages` 调用路径。

## 验证

- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm format`
- [x] `pnpm --filter @kagami/server test` —— 91 个 test files / 473 个 tests 全部通过

## 后续

`CHANGELOG.md` 的 `[Unreleased]` 段会用 follow-up commit 补一条记录（含本 PR 号），保持与历史条目格式一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)