### PR TITLE
feat(agent): 新增 clock App，提供 view_time 工具

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage
 .vscode
 apps/server/src/generated/prisma
 .claude/worktrees
+.gstack

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,4 @@ build
 coverage
 apps/server/src/generated/prisma
 apps/server/static/**/*.hbs
+.gstack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- agent: 新增 `clock` App，提供 `view_time` 工具让 Agent 主动查询当前北京时间（精确到秒）；与 Wake Reminder 降频（[#77](https://github.com/KisinTheFlame/kagami/pull/77)）形成被动 + 主动的时间感知闭环（[#79](https://github.com/KisinTheFlame/kagami/pull/79)）
+
 ### Changed
 
 - agent: Wake Reminder 由每分钟降频为每半小时一次，同一半小时窗口（00 / 30 分桶）内的多轮 round 共享去重 key、不再重复追加；展示的时间值仍是真实触发时刻；长会话尾部 `system_reminder` 噪声减少约 30 倍，对 KV 缓存更友好（[#77](https://github.com/KisinTheFlame/kagami/pull/77)）

--- a/apps/server/src/agent/apps/clock/clock.app.ts
+++ b/apps/server/src/agent/apps/clock/clock.app.ts
@@ -1,0 +1,35 @@
+import type { App } from "@kagami/agent-runtime";
+import { ViewTimeTool } from "./tools/view-time.tool.js";
+
+export const CLOCK_APP_ID = "clock";
+
+/**
+ * Clock App。Agent 主动查询当前时间的最小 App。
+ *
+ * - 无内部状态、无后台、无 config
+ * - 唯一工具 view_time()，返回当前北京时间（精确到秒）
+ * - 与 wake reminder 配套：被动提醒每半小时一次给"大致几点了"，主动调
+ *   view_time 给"精确到秒的当前时间"，不在稳定前缀里堆任何东西
+ */
+export class ClockApp implements App {
+  public readonly id = CLOCK_APP_ID;
+  public readonly displayName = "时钟";
+  public readonly tools: readonly ViewTimeTool[];
+
+  public constructor() {
+    this.tools = [new ViewTimeTool()];
+  }
+
+  public canInvoke(): boolean {
+    return true;
+  }
+
+  public async help(): Promise<string> {
+    return [
+      "你在时钟 App 里。当前可调用工具：",
+      "  - view_time(): 查看当前北京时间（精确到秒）。",
+      "",
+      "调 back_to_portal 退出本 App 回到桌面。",
+    ].join("\n");
+  }
+}

--- a/apps/server/src/agent/apps/clock/tools/view-time.tool.ts
+++ b/apps/server/src/agent/apps/clock/tools/view-time.tool.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+import { ZodToolComponent, type JsonSchema, type ToolKind } from "@kagami/agent-runtime";
+
+export const VIEW_TIME_TOOL_NAME = "view_time";
+
+const BEIJING_TIME_ZONE = "Asia/Shanghai";
+
+const ViewTimeArgumentsSchema = z.object({});
+
+/**
+ * 查看当前北京时间（精确到秒）。Clock App 内唯一的工具。
+ *
+ * - 无参数
+ * - 返回 JSON 字符串 { ok: true, time: "YYYY 年 M 月 D 日 HH:MM:SS", timezone: "Asia/Shanghai" }
+ * - 时区强制为 Asia/Shanghai，与 wake reminder（context-message-factory.ts）保持一致
+ */
+export class ViewTimeTool extends ZodToolComponent<typeof ViewTimeArgumentsSchema> {
+  public readonly name = VIEW_TIME_TOOL_NAME;
+  public readonly description = "查看当前北京时间（精确到秒）。";
+  public readonly parameters: JsonSchema = {
+    type: "object",
+    properties: {},
+  };
+  public readonly kind: ToolKind = "business";
+  protected readonly inputSchema = ViewTimeArgumentsSchema;
+
+  protected async executeTyped(): Promise<string> {
+    const now = new Date();
+    const parts = new Intl.DateTimeFormat("zh-CN", {
+      timeZone: BEIJING_TIME_ZONE,
+      year: "numeric",
+      month: "numeric",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: false,
+    }).formatToParts(now);
+    const values = Object.fromEntries(parts.map(part => [part.type, part.value]));
+    const time = `${values.year} 年 ${values.month} 月 ${values.day} 日 ${values.hour}:${values.minute}:${values.second}`;
+
+    return JSON.stringify({ ok: true, time, timezone: BEIJING_TIME_ZONE });
+  }
+}

--- a/apps/server/src/app/agent-runtime.factory.ts
+++ b/apps/server/src/app/agent-runtime.factory.ts
@@ -80,6 +80,7 @@ import {
   SEARCH_MEMORY_TOOL_NAME,
 } from "../agent/capabilities/story/tools/search-memory.tool.js";
 import { CalcApp } from "../agent/apps/calc/calc.app.js";
+import { ClockApp } from "../agent/apps/clock/clock.app.js";
 
 type BuildAgentRuntimeInput = {
   config: Config;
@@ -199,6 +200,7 @@ export async function buildAgentRuntime({
   appManager.register(new CalcApp());
   appManager.register(new TerminalApp({ terminalStateDao, terminalOutputDao }));
   appManager.register(new IthomeApp({ ithomeNewsService }));
+  appManager.register(new ClockApp());
   await appManager.startupAll(config.server.apps);
 
   // 状态树时代的子工具：明确列出，作为 createStateTreeSubtoolOwner 的输入。

--- a/apps/server/test/agent/apps/clock/view-time.tool.test.ts
+++ b/apps/server/test/agent/apps/clock/view-time.tool.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ViewTimeTool } from "../../../../src/agent/apps/clock/tools/view-time.tool.js";
+
+describe("clock App / view_time tool", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns Beijing time formatted to seconds", async () => {
+    vi.setSystemTime(new Date("2026-05-26T15:45:12Z")); // UTC → 北京 23:45:12
+    const tool = new ViewTimeTool();
+    const result = await tool.execute({}, {});
+
+    expect(JSON.parse(result.content)).toEqual({
+      ok: true,
+      time: "2026 年 5 月 26 日 23:45:12",
+      timezone: "Asia/Shanghai",
+    });
+  });
+
+  it("rolls over the date when UTC crosses midnight in Beijing", async () => {
+    vi.setSystemTime(new Date("2026-05-26T16:30:00Z")); // UTC → 北京 5/27 00:30:00
+    const tool = new ViewTimeTool();
+    const result = await tool.execute({}, {});
+
+    expect(JSON.parse(result.content)).toMatchObject({
+      ok: true,
+      time: "2026 年 5 月 27 日 00:30:00",
+    });
+  });
+
+  it("always reports timezone as Asia/Shanghai", async () => {
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    const tool = new ViewTimeTool();
+    const result = await tool.execute({}, {});
+
+    expect(JSON.parse(result.content)).toMatchObject({
+      timezone: "Asia/Shanghai",
+    });
+  });
+});


### PR DESCRIPTION
## 改动

新增一个最小的 `clock` App，挂一个 `view_time` 工具，让 Agent 主动查询当前北京时间（精确到秒）。

```
enter("clock") → invoke("view_time") → { ok, time: "YYYY 年 M 月 D 日 HH:MM:SS", timezone: "Asia/Shanghai" }
```

## 动机

上一个 PR [#77](https://github.com/KisinTheFlame/kagami/pull/77) 把 wake reminder 由每分钟降频为每半小时一次。降频之后 Agent 在两次提醒之间无法精确知道当前时间——这个 PR 是配套的补强：

- **被动**（wake reminder，每半小时一次）：给 Agent "大致几点了" 的感知。
- **主动**（clock App `view_time`，按需调）：Agent 需要精确分秒时主动查。

两者配合，前缀里不必塞任何时间信息，符合「InvokeTool 是稳定壳 + App 渐进式披露」原则。

## 文件清单

- `apps/server/src/agent/apps/clock/clock.app.ts` —— ClockApp 主类，纯工具集合，无 `configSchema` / `onStartup` / `onFocus` / `onBlur`
- `apps/server/src/agent/apps/clock/tools/view-time.tool.ts` —— `view_time` 工具，无参，输出 JSON 字符串；时区强制 `Asia/Shanghai`
- `apps/server/test/agent/apps/clock/view-time.tool.test.ts` —— 3 个单测：北京时间格式、跨日期翻转（UTC 16:30 → 北京次日 00:30）、时区强制
- `apps/server/src/app/agent-runtime.factory.ts` —— import + `appManager.register(new ClockApp())` 一行注册

顺手 chore：把 `.gstack/`（gstack 工具的本地产出目录，主要是 `/land-and-deploy` 的 deploy report）加入 `.gitignore` / `.prettierignore`，让它不再绊到 `pnpm format`。

## KV 缓存影响

按 CLAUDE.md「稳定前缀 + 易变尾部」自检：

- 新 App 的工具描述 / help 文本**只在 Agent 主动 `enter("clock")` 之后才进上下文**，对所有在飞会话的稳定前缀零影响。
- 不动 system prompt、不动 InvokeTool 描述、不动顶层工具集、不改任何历史消息序列化格式。
- 完全符合 App 框架设计意图：「加一个 App 不会让任何会话的 KV cache 失效」。

## 验证

- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm format`
- [x] `pnpm --filter @kagami/server test` —— 92 个 test files / 476 个 tests 全部通过（新增 3 个 view-time 测试）

## 后续

CHANGELOG.md 的 `[Unreleased]` 段会用 follow-up commit 补一条记录（含本 PR 号）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)