### PR TITLE
fix(agent): 后台子状态变化不再追加焦点 reminder

### DIFF
--- a/apps/server/src/agent/runtime/root-agent/session/root-agent-session.ts
+++ b/apps/server/src/agent/runtime/root-agent/session/root-agent-session.ts
@@ -601,21 +601,10 @@ export class RootAgentSession implements RootAgentSessionController, RootAgentSt
     }
 
     // 触发下一轮：state.handleEvent 产了 append_message Effect 就跑。
-    let shouldTriggerRound = effectMessages.length > 0;
+    const shouldTriggerRound = effectMessages.length > 0;
 
     if (result.stateChanged) {
       const isFocused = focusedStateId === targetStateId;
-      const focusedState = this.requireState(focusedStateId);
-      const needsReminderRefresh =
-        isFocused ||
-        (await this.hasDescendantState({
-          state: focusedState,
-          targetStateId,
-        }));
-      if (needsReminderRefresh) {
-        this.pendingIncomingMessages.push(await this.createStateReminderMessage(focusedStateId));
-        shouldTriggerRound = true;
-      }
 
       // Push cross-state notification for non-focused state changes.
       // Skip when focused on portal (portal reminder already shows unread).
@@ -754,28 +743,5 @@ export class RootAgentSession implements RootAgentSessionController, RootAgentSt
       },
     });
     return createQqPrivateStateId(privateChatState.userId);
-  }
-
-  private async hasDescendantState(input: {
-    state: RootAgentState;
-    targetStateId: RootAgentStateId;
-  }): Promise<boolean> {
-    const children = await input.state.listChildren();
-    for (const child of children) {
-      if (child.getId() === input.targetStateId) {
-        return true;
-      }
-
-      if (
-        (await this.hasDescendantState({
-          state: child,
-          targetStateId: input.targetStateId,
-        })) === true
-      ) {
-        return true;
-      }
-    }
-
-    return false;
   }
 }

--- a/apps/server/test/agent/root-agent-session.test.ts
+++ b/apps/server/test/agent/root-agent-session.test.ts
@@ -207,7 +207,7 @@ describe("RootAgentSession", () => {
     ).toBe(true);
   });
 
-  it("should refresh portal reminder when background child state changes", async () => {
+  it("should not refresh portal reminder when background child state changes", async () => {
     const context = new DefaultAgentContext({
       systemPromptFactory: () => "system-prompt",
     });
@@ -218,10 +218,10 @@ describe("RootAgentSession", () => {
     const flushResult = await session.flushPendingIncomingEffects();
 
     expect(consumeResult).toEqual({
-      shouldTriggerRound: true,
+      shouldTriggerRound: false,
     });
     expect(flushResult).toEqual({
-      shouldTriggerRound: true,
+      shouldTriggerRound: false,
     });
 
     const snapshot = await context.getSnapshot();
@@ -229,7 +229,9 @@ describe("RootAgentSession", () => {
       message =>
         typeof message.content === "string" && message.content.includes("<system_reminder>"),
     );
-    expect(reminderMessages.at(-1)?.content).toContain("未读 1 条消息");
+    // 只有 initialize 时那条门户 reminder；后台子状态变化不再追加任何新的 reminder。
+    expect(reminderMessages).toHaveLength(1);
+    expect(reminderMessages[0]?.content).not.toContain("未读 1 条消息");
   });
 
   // NOTE: wait-overlay tests removed. Under the new event-driven model the
@@ -486,11 +488,12 @@ describe("RootAgentSession", () => {
     );
     const flushResult = await session.flushPendingIncomingEffects();
 
+    // 焦点在门户时，后台私聊子状态变化不再刷新 reminder，也就不触发轮次。
     expect(consumeResult).toEqual({
-      shouldTriggerRound: true,
+      shouldTriggerRound: false,
     });
     expect(flushResult).toEqual({
-      shouldTriggerRound: true,
+      shouldTriggerRound: false,
     });
 
     const dashboard = await session.getStateView();


### PR DESCRIPTION
## 背景

排查「你进入了 门户 节点」这条 system reminder 是否存在一次性重复追加的风险时确认：`consumeIncomingEventInActiveState` 在每个非焦点子状态变化时都会 push 一条 `createStateReminderMessage(focusedStateId)`。`consumePendingEvents` / `hydrateStartupEvents` 按事件逐条循环消费，攒进 `pendingIncomingMessages` 后一次性 append——焦点停在门户时，同批 N 条群/私聊消息会向上下文重复灌入 N 条逐字相同的门户 reminder，既污染上下文又破坏 KV 缓存前缀（启动补水场景尤其严重）。

## 改动

- 移除 `consumeIncomingEventInActiveState` 中的焦点 reminder 刷新块（`needsReminderRefresh` 判断 + 重复 push）。非焦点子状态变化不再追加任何 reminder。
- 删除随之变成死代码的私有方法 `hasDescendantState`。
- `shouldTriggerRound` 不再被重新赋值，改为 `const`。
- 跨状态通知（`notificationAccumulator`）逻辑保持不变。

## 行为变化

焦点停在门户时，后台群/私聊消息不再触发轮次（消息仍照常累积进各状态 unread，下次 `enter` 时可见）。

## 验证

- `tsc --noEmit` 通过；ESLint、Prettier 通过。
- 相关测试全过：`root-agent-session`、`enter.tool`、`back.tool`、`notification-accumulator`。其中一条断言旧刷新行为的用例已改写为新行为的回归保护。

🤖 Generated with [Claude Code](https://claude.com/claude-code)