### PR TITLE
refactor(agent): 移除 wait 工具的连续调用短路防御

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@
 
 - agent: Wake Reminder 由每分钟降频为每半小时一次，同一半小时窗口（00 / 30 分桶）内的多轮 round 共享去重 key、不再重复追加；展示的时间值仍是真实触发时刻；长会话尾部 `system_reminder` 噪声减少约 30 倍，对 KV 缓存更友好（[#77](https://github.com/KisinTheFlame/kagami/pull/77)）
 - build/config: `config.loader.ts` 与 `scripts/read-config.mjs` 在 git worktree 内找不到 `config.yaml` 时，自动通过 `.git` 文件解析主仓库根目录并读取其中的 `config.yaml`，让 worktree 不再需要拷贝 / symlink 配置即可跑 `pnpm db:generate` / `pnpm build`
-- agent: `wait` 工具在连续第 3 次调用时短路返回 `<wait_blocked>` 提醒，不再阻塞事件队列，让 Agent 在长时间无外部事件时被迫跳出空等死循环、转去复盘 story / 读新闻 / 主动发起话题（[#74](https://github.com/KisinTheFlame/kagami/pull/74)）
 - llm-history: 拆分 LLM 调用历史列表 / 详情接口，`/llm-chat-call/query` 列表只返回 summary 字段，新增 `GET /llm-chat-call/:id` 详情接口；前端列表改为按选中 id 单独 fetch detail，降低列表响应体大小（[#72](https://github.com/KisinTheFlame/kagami/pull/72)）
 
 ## 2026-05

--- a/apps/server/src/agent/runtime/root-agent/tools/wait.tool.ts
+++ b/apps/server/src/agent/runtime/root-agent/tools/wait.tool.ts
@@ -10,20 +10,14 @@ import type { RootAgentEffect } from "../../effect/root-agent-effect.js";
 
 export const WAIT_TOOL_NAME = "wait";
 const DEFAULT_MAX_WAIT_MS = 10 * 60 * 1000;
-export const CONSECUTIVE_WAIT_BLOCK_THRESHOLD = 3;
 
 const WaitArgumentsSchema = z.object({});
 
 /**
  * 暂停当前 Agent 主循环、等待事件。
  *
- * 两层逻辑：
- *
- * 1. **死循环防御**：扫 `context.messages` 末尾连续 wait 调用数（PR #74）。
- *    达到阈值就返 `<wait_blocked>` 错误内容，**不产 Effect**——本回合不阻塞，
- *    Agent 被迫重新决策。
- * 2. **正常等待（Effect 模型阶段 6）**：返 `wait_for_event` Effect 让
- *    Interpreter 接管挂起语义。工具自己不阻塞、不持事件队列。
+ * 返 `wait_for_event` Effect 让 Interpreter 接管挂起语义。工具自己不阻塞、
+ * 不持事件队列。
  *
  * 设计依据：[docs/effect-model.md](docs/effect-model.md) 阶段 6。
  */
@@ -46,23 +40,11 @@ export class WaitTool extends ZodToolComponent<typeof WaitArgumentsSchema, LlmMe
 
   protected async executeTyped(
     _input: z.infer<typeof WaitArgumentsSchema>,
-    context: ToolContext<LlmMessage>,
+    _context: ToolContext<LlmMessage>,
   ): Promise<ToolExecutionResult> {
     void _input;
 
-    // 死循环防御：context.messages 在工具执行时只包含本轮 assistant message 之前
-    // 的历史，当前这次 wait 调用本身还没进消息列表。所以连续次数 = 历史尾部
-    // wait 数 + 1。
-    const trailingWaitCount = countTrailingWaitToolCalls(context.messages ?? []);
-    const consecutiveWaitCount = trailingWaitCount + 1;
-    if (consecutiveWaitCount >= CONSECUTIVE_WAIT_BLOCK_THRESHOLD) {
-      // 短路：不产 wait_for_event Effect，content 直接给 Agent "请做别的事"提示。
-      return {
-        content: buildWaitBlockedContent(consecutiveWaitCount),
-      };
-    }
-
-    // 正常路径：产 wait_for_event Effect。Interpreter 接管阻塞——本工具不再持
+    // 产 wait_for_event Effect。Interpreter 接管阻塞——本工具不再持
     // eventQueue、不再 await waitNonEmpty。content 是占位 tool_result（ReAct 协议
     // 要求每个 tool_call 都跟一个 tool_result）。真正"事件来了"的描述由后续
     // LoopAgent 主循环消费事件时产出（state.handleEvent → append_message）。
@@ -72,39 +54,6 @@ export class WaitTool extends ZodToolComponent<typeof WaitArgumentsSchema, LlmMe
       effects,
     };
   }
-}
-
-export function countTrailingWaitToolCalls(messages: readonly LlmMessage[]): number {
-  let count = 0;
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const message = messages[i];
-    // 跳过 tool result 和 user message：它们是环境状态，不是 Agent 的决策，
-    // 不应该打断"连续 wait"的连续性。
-    if (message.role !== "assistant") {
-      continue;
-    }
-    if (message.toolCalls.length === 0) {
-      // 一次没调任何工具的 assistant 回合也算"做了别的事"——打断连续性。
-      return count;
-    }
-    for (let j = message.toolCalls.length - 1; j >= 0; j--) {
-      if (message.toolCalls[j].name === WAIT_TOOL_NAME) {
-        count += 1;
-      } else {
-        return count;
-      }
-    }
-  }
-  return count;
-}
-
-function buildWaitBlockedContent(consecutiveWaitCount: number): string {
-  return [
-    "<wait_blocked>",
-    `你已经连续选择了 ${consecutiveWaitCount} 次 wait，本次 wait 已被系统短路、没有真的等待。`,
-    "你的生活不止有等待 —— 现在请做一件别的事，例如：复盘最近的 story 记忆、看看 IThome 有没有新文章值得评论、主动在群里发起话题，或者整理一下你正在做的事。",
-    "</wait_blocked>",
-  ].join("\n");
 }
 
 function formatWaitDuration(durationMs: number): string {

--- a/apps/server/test/agent/wait.tool.test.ts
+++ b/apps/server/test/agent/wait.tool.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { LlmMessage, LlmToolCall } from "../../src/llm/types.js";
-import {
-  CONSECUTIVE_WAIT_BLOCK_THRESHOLD,
-  WaitTool,
-  countTrailingWaitToolCalls,
-} from "../../src/agent/runtime/root-agent/tools/wait.tool.js";
+import { WaitTool } from "../../src/agent/runtime/root-agent/tools/wait.tool.js";
 
 function makeToolCall(name: string, id = `${name}-${Math.random()}`): LlmToolCall {
   return { id, name, arguments: {} };
@@ -16,10 +12,6 @@ function assistantWith(...toolCalls: LlmToolCall[]): LlmMessage {
 
 function toolResult(toolCallId: string, content = "ok"): LlmMessage {
   return { role: "tool", toolCallId, content };
-}
-
-function userMessage(content = "ping"): LlmMessage {
-  return { role: "user", content };
 }
 
 function createWaitTool(): WaitTool {
@@ -36,79 +28,8 @@ function executeWait(tool: WaitTool, messages: LlmMessage[]): ReturnType<WaitToo
   );
 }
 
-describe("countTrailingWaitToolCalls", () => {
-  it("returns 0 for empty messages", () => {
-    expect(countTrailingWaitToolCalls([])).toBe(0);
-  });
-
-  it("returns 0 when last assistant call is not wait", () => {
-    const messages: LlmMessage[] = [assistantWith(makeToolCall("invoke", "t1"))];
-    expect(countTrailingWaitToolCalls(messages)).toBe(0);
-  });
-
-  it("counts a single trailing wait", () => {
-    const messages: LlmMessage[] = [
-      assistantWith(makeToolCall("invoke", "t1")),
-      toolResult("t1"),
-      assistantWith(makeToolCall("wait", "t2")),
-      toolResult("t2", "休息结束了"),
-    ];
-    expect(countTrailingWaitToolCalls(messages)).toBe(1);
-  });
-
-  it("counts two trailing waits across separate assistant turns", () => {
-    const messages: LlmMessage[] = [
-      assistantWith(makeToolCall("invoke", "t1")),
-      toolResult("t1"),
-      assistantWith(makeToolCall("wait", "t2")),
-      toolResult("t2", "休息结束了"),
-      assistantWith(makeToolCall("wait", "t3")),
-      toolResult("t3", "休息结束了"),
-    ];
-    expect(countTrailingWaitToolCalls(messages)).toBe(2);
-  });
-
-  it("ignores user messages and tool results when counting", () => {
-    const messages: LlmMessage[] = [
-      assistantWith(makeToolCall("wait", "t1")),
-      toolResult("t1", "休息结束了"),
-      userMessage("新消息进来"),
-      assistantWith(makeToolCall("wait", "t2")),
-      toolResult("t2", "休息结束了"),
-    ];
-    expect(countTrailingWaitToolCalls(messages)).toBe(2);
-  });
-
-  it("stops at the first non-wait tool call from the tail", () => {
-    const messages: LlmMessage[] = [
-      assistantWith(makeToolCall("wait", "t1")),
-      toolResult("t1"),
-      assistantWith(makeToolCall("invoke", "t2")),
-      toolResult("t2"),
-      assistantWith(makeToolCall("wait", "t3")),
-      toolResult("t3"),
-    ];
-    expect(countTrailingWaitToolCalls(messages)).toBe(1);
-  });
-
-  it("treats an assistant turn with no tool calls as a break", () => {
-    const messages: LlmMessage[] = [
-      assistantWith(makeToolCall("wait", "t1")),
-      toolResult("t1"),
-      { role: "assistant", content: "随便说一句", toolCalls: [] },
-      assistantWith(makeToolCall("wait", "t2")),
-      toolResult("t2"),
-    ];
-    expect(countTrailingWaitToolCalls(messages)).toBe(1);
-  });
-});
-
 describe("WaitTool", () => {
-  it("threshold is 3", () => {
-    expect(CONSECUTIVE_WAIT_BLOCK_THRESHOLD).toBe(3);
-  });
-
-  it("produces wait_for_event Effect on first wait (no prior wait)", async () => {
+  it("produces wait_for_event Effect with the configured maxWaitMs", async () => {
     const tool = createWaitTool();
     const result = await executeWait(tool, []);
     // Effect 模型阶段 6：工具自己不阻塞，产 wait_for_event Effect 让 Interpreter 接管。
@@ -116,59 +37,18 @@ describe("WaitTool", () => {
     expect(result.content).toBe("休息结束了");
   });
 
-  it("produces wait_for_event Effect on the 2nd consecutive wait", async () => {
-    const tool = createWaitTool();
-    const messages: LlmMessage[] = [
-      assistantWith(makeToolCall("wait", "t1")),
-      toolResult("t1", "休息结束了"),
-    ];
-    const result = await executeWait(tool, messages);
-    expect(result.effects).toEqual([{ type: "wait_for_event", maxWaitMs: 1_000 }]);
-    expect(result.content).toBe("休息结束了");
-  });
-
-  it("short-circuits on the 3rd consecutive wait without producing wait_for_event", async () => {
+  it("produces wait_for_event Effect even after many consecutive waits", async () => {
     const tool = createWaitTool();
     const messages: LlmMessage[] = [
       assistantWith(makeToolCall("wait", "t1")),
       toolResult("t1", "休息结束了"),
       assistantWith(makeToolCall("wait", "t2")),
       toolResult("t2", "休息结束了"),
-    ];
-    const result = await executeWait(tool, messages);
-    // 短路路径：不产 Effect，Interpreter 不接管阻塞，content 直接返提示。
-    expect(result.effects).toBeUndefined();
-    expect(result.content).toContain("<wait_blocked>");
-    expect(result.content).toContain("3");
-  });
-
-  it("still short-circuits if waits are interleaved with napcat user messages", async () => {
-    const tool = createWaitTool();
-    const messages: LlmMessage[] = [
-      assistantWith(makeToolCall("wait", "t1")),
-      toolResult("t1", "休息结束了"),
-      userMessage("外部刺激"),
-      assistantWith(makeToolCall("wait", "t2")),
-      toolResult("t2", "休息结束了"),
-      userMessage("再来一条"),
-    ];
-    const result = await executeWait(tool, messages);
-    expect(result.effects).toBeUndefined();
-    expect(result.content).toContain("<wait_blocked>");
-  });
-
-  it("does not short-circuit when a non-wait tool call breaks the streak", async () => {
-    const tool = createWaitTool();
-    const messages: LlmMessage[] = [
-      assistantWith(makeToolCall("wait", "t1")),
-      toolResult("t1", "休息结束了"),
-      assistantWith(makeToolCall("invoke", "t2")),
-      toolResult("t2"),
       assistantWith(makeToolCall("wait", "t3")),
       toolResult("t3", "休息结束了"),
     ];
     const result = await executeWait(tool, messages);
-    // streak 中断，连续计数从 0 重新开始。本次 wait 是新的第 1 次。
+    // 连续调用短路防御已删除：无论历史里有多少次连续 wait，本次仍正常产 Effect。
     expect(result.effects).toEqual([{ type: "wait_for_event", maxWaitMs: 1_000 }]);
     expect(result.content).toBe("休息结束了");
   });


### PR DESCRIPTION
## 改动

移除 `wait` 工具的「连续调用短路」防御机制（[#74](https://github.com/KisinTheFlame/kagami/pull/74) 引入的死循环防御）。

- **`wait.tool.ts`**：删除 `CONSECUTIVE_WAIT_BLOCK_THRESHOLD`、`countTrailingWaitToolCalls()`、`buildWaitBlockedContent()`，以及 `executeTyped` 中「连续第 3 次短路返回 `<wait_blocked>`」的分支。`wait` 现在无条件产出 `wait_for_event` Effect，由 Interpreter 接管挂起。
- **`wait.tool.test.ts`**：删除 `countTrailingWaitToolCalls` 测试组与所有短路用例；保留 Effect 行为测试，新增「连续多次 wait 仍正常产 Effect」的回归测试，防止机制悄悄复活。
- **`CHANGELOG.md`**：撤销 #74 在 `Unreleased` 段的引入记录。该机制尚未随版本发布，移除后净效果是它对最终用户从未存在，故一并撤销其 changelog 痕迹。

## 行为变更

Agent 连续选择 `wait` 时不再在第 3 次被强制打断。`wait` 仍受 `maxWaitMs` 上限约束、由 Interpreter 接管挂起，到期自然结束、有新事件即唤醒——因此不是无界死循环，只是去掉了「连续空等到阈值就塞一条 `<wait_blocked>` 提示逼它转去做别的事」的纠偏逻辑。

## 验证

- `pnpm build` ✓
- `pnpm typecheck` ✓
- `pnpm test` ✓ 92 文件 / 467 用例全过
- `pnpm lint` ✓
- `pnpm format` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)