### PR TITLE
refactor(llm): Tool / JsonSchema 下沉到 @kagami/llm，消除重复定义

### DIFF
--- a/apps/server/src/agent/capabilities/story/runtime/tools/story-batch.tool-executor.ts
+++ b/apps/server/src/agent/capabilities/story/runtime/tools/story-batch.tool-executor.ts
@@ -1,7 +1,7 @@
 import {
   ToolCatalog,
   type ToolContext,
-  type ToolDefinition,
+  type Tool,
   type ToolExecutor,
   type ToolSetExecutionResult,
 } from "@kagami/agent-runtime";
@@ -20,9 +20,7 @@ import {
 } from "../../task-agent/tools/rewrite-story.tool.js";
 import type { StoryBatchSeqRange } from "../story-batch-preparer.js";
 
-export function createStoryBatchToolDefinitions(input: {
-  storyService: StoryService;
-}): ToolDefinition[] {
+export function createStoryBatchToolDefinitions(input: { storyService: StoryService }): Tool[] {
   return new ToolCatalog([
     new CreateStoryTool({
       storyService: input.storyService,
@@ -42,7 +40,7 @@ export function createStoryBatchToolDefinitions(input: {
 
 type StoryBatchToolExecutorDeps = {
   storyService: StoryService;
-  toolDefinitions: ToolDefinition[];
+  toolDefinitions: Tool[];
   getPendingBatchSeqRange: () => StoryBatchSeqRange | null;
 };
 
@@ -52,7 +50,7 @@ type StoryBatchToolExecutorDeps = {
  */
 export class StoryBatchToolExecutor implements ToolExecutor {
   private readonly storyService: StoryService;
-  private readonly toolDefinitions: ToolDefinition[];
+  private readonly toolDefinitions: Tool[];
   private readonly getPendingBatchSeqRange: () => StoryBatchSeqRange | null;
 
   public constructor({
@@ -65,7 +63,7 @@ export class StoryBatchToolExecutor implements ToolExecutor {
     this.getPendingBatchSeqRange = getPendingBatchSeqRange;
   }
 
-  public definitions(): ToolDefinition[] {
+  public definitions(): Tool[] {
     return this.toolDefinitions;
   }
 

--- a/apps/server/src/agent/capabilities/web-search/task-agent/web-search-subtool-owner.ts
+++ b/apps/server/src/agent/capabilities/web-search/task-agent/web-search-subtool-owner.ts
@@ -4,7 +4,7 @@ import {
   type SubtoolGuardResult,
   type ToolComponent,
   type ToolContext,
-  type ToolDefinition,
+  type Tool,
   type ToolExecutionResult,
   type ToolExecutor,
 } from "@kagami/agent-runtime";
@@ -21,7 +21,7 @@ export function createWebSearchSubtoolOwner(deps: {
   tools: readonly ToolComponent[];
 }): InvokeSubtoolOwner {
   const toolNames = deps.tools.map(tool => tool.name);
-  const definitions: readonly ToolDefinition[] = deps.tools.map(tool => tool.llmTool);
+  const definitions: readonly Tool[] = deps.tools.map(tool => tool.llmTool);
   const executor: ToolExecutor = new ToolCatalog([...deps.tools]).pick(toolNames);
 
   return {

--- a/apps/server/src/agent/runtime/root-agent/tools/invoke-tool-docs.ts
+++ b/apps/server/src/agent/runtime/root-agent/tools/invoke-tool-docs.ts
@@ -1,7 +1,7 @@
-import type { ToolDefinition } from "@kagami/agent-runtime";
+import type { Tool } from "@kagami/agent-runtime";
 import { isRecord } from "../../../../common/prisma-json.js";
 
-export function renderInvokeToolGuide(tools: readonly ToolDefinition[]): string {
+export function renderInvokeToolGuide(tools: readonly Tool[]): string {
   return tools
     .map(tool => {
       const lines = [`- \`${tool.name}\`: ${tool.description ?? "无说明。"}`];
@@ -21,7 +21,7 @@ export function renderInvokeToolGuide(tools: readonly ToolDefinition[]): string 
     .join("\n");
 }
 
-function renderInvokeToolParameterLines(tool: ToolDefinition): string[] {
+function renderInvokeToolParameterLines(tool: Tool): string[] {
   return Object.entries(tool.parameters.properties)
     .filter(([parameterName]) => parameterName !== "tool")
     .map(([parameterName, propertySchema]) => {

--- a/apps/server/src/agent/runtime/root-agent/tools/invoke.tool.ts
+++ b/apps/server/src/agent/runtime/root-agent/tools/invoke.tool.ts
@@ -3,7 +3,7 @@ import {
   type InvokeSubtoolOwner,
   type JsonSchema,
   type ToolContext,
-  type ToolDefinition,
+  type Tool,
   type ToolExecutionResult,
   type ToolKind,
   ZodToolComponent,
@@ -52,12 +52,12 @@ export class InvokeTool extends ZodToolComponent<typeof InvokeArgumentsSchema> {
 
   private readonly owners: readonly InvokeSubtoolOwner[];
   private readonly ownerByToolName: ReadonlyMap<string, InvokeSubtoolOwner>;
-  private readonly definitionByToolName: ReadonlyMap<string, ToolDefinition>;
+  private readonly definitionByToolName: ReadonlyMap<string, Tool>;
 
   public constructor({ owners }: { owners: readonly InvokeSubtoolOwner[] }) {
     super();
     const ownerByToolName = new Map<string, InvokeSubtoolOwner>();
-    const definitionByToolName = new Map<string, ToolDefinition>();
+    const definitionByToolName = new Map<string, Tool>();
     for (const owner of owners) {
       for (const definition of owner.listOwnedTools()) {
         if (ownerByToolName.has(definition.name)) {
@@ -114,8 +114,8 @@ export class InvokeTool extends ZodToolComponent<typeof InvokeArgumentsSchema> {
    * 这样「不存在」和「不允许调用」合并后，被拒的工具自然不会出现在清单里，
    * 不会出现"说它不存在却又列在可用里"的自相矛盾。
    */
-  private listInvocableDefinitions(context: ToolContext): readonly ToolDefinition[] {
-    const definitions: ToolDefinition[] = [];
+  private listInvocableDefinitions(context: ToolContext): readonly Tool[] {
+    const definitions: Tool[] = [];
     for (const owner of this.owners) {
       for (const definition of owner.listOwnedTools()) {
         if (owner.canInvokeNow(definition.name, context).ok) {
@@ -129,7 +129,7 @@ export class InvokeTool extends ZodToolComponent<typeof InvokeArgumentsSchema> {
 
 function buildInvokeToolNotFoundMessage(input: {
   tool: string;
-  availableToolDefinitions: readonly ToolDefinition[];
+  availableToolDefinitions: readonly Tool[];
 }): string {
   return [
     `invoke 子工具 ${input.tool} 不存在。`,
@@ -148,7 +148,7 @@ function buildInvokeToolNotFoundMessage(input: {
 function enrichSubtoolFailureContent(input: {
   tool: string;
   content: string;
-  currentToolDefinition?: ToolDefinition;
+  currentToolDefinition?: Tool;
 }): string {
   try {
     const parsed = JSON.parse(input.content) as Record<string, unknown>;
@@ -181,7 +181,7 @@ function buildInvokeSubtoolFailureMessage(input: {
   tool: string;
   error?: string;
   details: string[];
-  currentToolDefinition?: ToolDefinition;
+  currentToolDefinition?: Tool;
 }): string {
   if (input.error === "INVALID_ARGUMENTS") {
     const detailsText = input.details.length > 0 ? ` ${input.details.join("；")}` : "";
@@ -218,9 +218,7 @@ function buildInvokeSubtoolFailureMessage(input: {
   );
 }
 
-function buildAvailableInvokeToolsDescription(
-  availableToolDefinitions: readonly ToolDefinition[],
-): string {
+function buildAvailableInvokeToolsDescription(availableToolDefinitions: readonly Tool[]): string {
   if (availableToolDefinitions.length === 0) {
     return "当前没有可用的 invoke 子工具。";
   }
@@ -230,7 +228,7 @@ function buildAvailableInvokeToolsDescription(
 
 function appendInvokeToolDefinitionMessage(
   baseMessage: string,
-  currentToolDefinition?: ToolDefinition,
+  currentToolDefinition?: Tool,
 ): string {
   if (!currentToolDefinition) {
     return baseMessage;

--- a/apps/server/src/agent/runtime/root-agent/tools/state-tree-subtool-owner.ts
+++ b/apps/server/src/agent/runtime/root-agent/tools/state-tree-subtool-owner.ts
@@ -4,7 +4,7 @@ import {
   type SubtoolGuardResult,
   type ToolComponent,
   type ToolContext,
-  type ToolDefinition,
+  type Tool,
   type ToolExecutionResult,
   type ToolExecutor,
 } from "@kagami/agent-runtime";
@@ -31,10 +31,8 @@ export function createStateTreeSubtoolOwner(deps: {
   tools: readonly ToolComponent[];
 }): InvokeSubtoolOwner {
   const toolNames = deps.tools.map(tool => tool.name);
-  const definitions: readonly ToolDefinition[] = deps.tools.map(tool => tool.llmTool);
-  const definitionByName = new Map<string, ToolDefinition>(
-    deps.tools.map(tool => [tool.name, tool.llmTool]),
-  );
+  const definitions: readonly Tool[] = deps.tools.map(tool => tool.llmTool);
+  const definitionByName = new Map<string, Tool>(deps.tools.map(tool => [tool.name, tool.llmTool]));
   const executor: ToolExecutor = new ToolCatalog([...deps.tools]).pick(toolNames);
 
   return {
@@ -57,7 +55,7 @@ export function createStateTreeSubtoolOwner(deps: {
       const focusedStateId = session.getState().focusedStateId;
       const availableToolDefinitions = availableTools
         .map(name => definitionByName.get(name))
-        .filter((definition): definition is ToolDefinition => definition !== undefined);
+        .filter((definition): definition is Tool => definition !== undefined);
       const availableMessage =
         availableToolDefinitions.length === 0
           ? "当前状态没有可用的 invoke 子工具。"

--- a/apps/server/src/llm/types.ts
+++ b/apps/server/src/llm/types.ts
@@ -3,24 +3,23 @@ import type { LlmProviderId } from "../common/contracts/llm.js";
 // TMessage 泛型）。这里 import 后再 export，保持 server 侧既有 import 路径不变，
 // 同时避开 `export ... from` 的 re-export 限制。
 import type {
+  JsonSchema,
   LlmContentPart,
   LlmImageContentPart,
   LlmMessage,
   LlmTextContentPart,
   LlmToolCall,
+  Tool,
 } from "@kagami/llm";
 
-export type { LlmContentPart, LlmImageContentPart, LlmMessage, LlmTextContentPart, LlmToolCall };
-
-export type JsonSchema = {
-  type: "object";
-  properties: Record<string, unknown>;
-};
-
-export type Tool = {
-  name: string;
-  description?: string;
-  parameters: JsonSchema;
+export type {
+  JsonSchema,
+  LlmContentPart,
+  LlmImageContentPart,
+  LlmMessage,
+  LlmTextContentPart,
+  LlmToolCall,
+  Tool,
 };
 
 export type LlmToolChoice = "required" | "auto" | "none" | { tool_name: string };

--- a/packages/agent-runtime/src/app/app-subtool-owner.ts
+++ b/packages/agent-runtime/src/app/app-subtool-owner.ts
@@ -1,5 +1,5 @@
 import { ToolCatalog, type ToolExecutor } from "../tool/tool-catalog.js";
-import type { ToolContext, ToolDefinition, ToolExecutionResult } from "../tool/tool-component.js";
+import type { ToolContext, Tool, ToolExecutionResult } from "../tool/tool-component.js";
 import type { InvokeSubtoolOwner, SubtoolGuardResult } from "../tool/subtool-owner.js";
 import type { AppId, AppManager } from "./app.js";
 
@@ -22,7 +22,7 @@ export function createAppSubtoolOwner(deps: {
 }): InvokeSubtoolOwner {
   const appTools = deps.appManager.getAllApps().flatMap(app => [...app.tools]);
   const toolNames = appTools.map(tool => tool.name);
-  const definitions: readonly ToolDefinition[] = appTools.map(tool => tool.llmTool);
+  const definitions: readonly Tool[] = appTools.map(tool => tool.llmTool);
   const executor: ToolExecutor = new ToolCatalog(appTools).pick(toolNames);
 
   return {

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -66,7 +66,7 @@ import {
   type JsonSchema,
   type ToolComponent,
   type ToolContext,
-  type ToolDefinition,
+  type Tool,
   type ToolExecutionResult,
   type ToolKind,
 } from "./tool/tool-component.js";
@@ -133,7 +133,7 @@ export {
   type TaskAgentToolCall,
   type ToolComponent,
   type ToolContext,
-  type ToolDefinition,
+  type Tool,
   type ToolExecutionResult,
   type ToolExecutor,
   type ToolKind,

--- a/packages/agent-runtime/src/react-kernel.ts
+++ b/packages/agent-runtime/src/react-kernel.ts
@@ -1,7 +1,7 @@
 import type { LlmMessage } from "@kagami/llm";
 import type { EffectInterpreter } from "./effect.js";
 import type { ToolExecutor, ToolSetExecutionResult } from "./tool/tool-catalog.js";
-import type { ToolContext, ToolDefinition } from "./tool/tool-component.js";
+import type { ToolContext, Tool } from "./tool/tool-component.js";
 
 export type ReActToolCall = {
   id: string;
@@ -31,7 +31,7 @@ export interface ReActModel<
     request: {
       system?: string;
       messages: LlmMessage[];
-      tools: ToolDefinition[];
+      tools: Tool[];
       toolChoice: "required";
     },
     options: {

--- a/packages/agent-runtime/src/tool/out-of-scope-tool.ts
+++ b/packages/agent-runtime/src/tool/out-of-scope-tool.ts
@@ -2,7 +2,7 @@ import type {
   JsonSchema,
   ToolComponent,
   ToolContext,
-  ToolDefinition,
+  Tool,
   ToolExecutionResult,
   ToolKind,
 } from "./tool-component.js";
@@ -41,7 +41,7 @@ export class OutOfScopeTool implements ToolComponent {
     this.reason = reason;
   }
 
-  public get llmTool(): ToolDefinition {
+  public get llmTool(): Tool {
     return {
       name: this.name,
       description: this.description,

--- a/packages/agent-runtime/src/tool/subtool-owner.ts
+++ b/packages/agent-runtime/src/tool/subtool-owner.ts
@@ -1,4 +1,4 @@
-import type { ToolContext, ToolDefinition, ToolExecutionResult } from "./tool-component.js";
+import type { ToolContext, Tool, ToolExecutionResult } from "./tool-component.js";
 
 /**
  * Invoke 子工具的所有者协议。
@@ -28,7 +28,7 @@ export interface InvokeSubtoolOwner {
    *
    * 返回数组应当在 owner 生命周期内稳定——InvokeTool 只在构造期读一次建索引。
    */
-  listOwnedTools(): readonly ToolDefinition[];
+  listOwnedTools(): readonly Tool[];
 
   /**
    * 在当前 runtime context 下能否调 toolName。

--- a/packages/agent-runtime/src/tool/tool-catalog.ts
+++ b/packages/agent-runtime/src/tool/tool-catalog.ts
@@ -1,7 +1,7 @@
 import type {
   ToolComponent,
   ToolContext,
-  ToolDefinition,
+  Tool,
   ToolExecutionResult,
   ToolKind,
 } from "./tool-component.js";
@@ -11,7 +11,7 @@ export type ToolSetExecutionResult = ToolExecutionResult & {
 };
 
 export interface ToolExecutor {
-  definitions(): ToolDefinition[];
+  definitions(): Tool[];
   getKind(name: string): ToolKind | null;
   execute(
     name: string,
@@ -58,7 +58,7 @@ export class ToolSet implements ToolExecutor {
     this.componentsByName = new Map(components.map(component => [component.name, component]));
   }
 
-  public definitions(): ToolDefinition[] {
+  public definitions(): Tool[] {
     return this.orderedComponents.map(component => component.llmTool);
   }
 

--- a/packages/agent-runtime/src/tool/tool-component.ts
+++ b/packages/agent-runtime/src/tool/tool-component.ts
@@ -1,18 +1,10 @@
 import { z } from "zod";
-import type { LlmMessage } from "@kagami/llm";
+import type { JsonSchema, LlmMessage, Tool } from "@kagami/llm";
 import type { Effect } from "../effect.js";
 
-export type JsonSchema = {
-  type: "object";
-  properties: Record<string, unknown>;
-  additionalProperties?: boolean | Record<string, unknown>;
-};
-
-export type ToolDefinition = {
-  name: string;
-  description?: string;
-  parameters: JsonSchema;
-};
+// JsonSchema / Tool 是 LLM 协议层类型，定义在 @kagami/llm；这里 import 后再 export，
+// 让 agent-runtime 内部沿用 "从 tool-component 引入" 的习惯（避开 export...from 限制）。
+export type { JsonSchema, Tool };
 
 export type ToolKind = "business" | "control";
 
@@ -38,7 +30,7 @@ export interface ToolComponent {
   readonly description?: string;
   readonly parameters: JsonSchema;
   readonly kind: ToolKind;
-  readonly llmTool: ToolDefinition;
+  readonly llmTool: Tool;
   execute(
     argumentsValue: Record<string, unknown>,
     context: ToolContext,
@@ -75,7 +67,7 @@ export abstract class ZodToolComponent<TInput extends z.ZodTypeAny> implements T
   public abstract readonly kind: ToolKind;
   protected abstract readonly inputSchema: TInput;
 
-  public get llmTool(): ToolDefinition {
+  public get llmTool(): Tool {
     return {
       name: this.name,
       description: this.description,

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -30,3 +30,21 @@ export type LlmMessage =
   | { role: "user"; content: string | LlmContentPart[] }
   | { role: "assistant"; content: string; toolCalls: LlmToolCall[] }
   | { role: "tool"; toolCallId: string; content: string };
+
+/** 工具参数的 JSON Schema（仅支持 object 顶层）。 */
+export type JsonSchema = {
+  type: "object";
+  properties: Record<string, unknown>;
+  additionalProperties?: boolean | Record<string, unknown>;
+};
+
+/**
+ * 一个工具对 LLM 的定义（name / description / parameters）。这是 LLM 协议层的
+ * "工具定义"——Agent Runtime 的 kernel 把它塞进 chat 请求的 tools 字段，LLM
+ * 据此决定调哪个工具。不含执行逻辑（执行是 agent-runtime 的 ToolComponent）。
+ */
+export type Tool = {
+  name: string;
+  description?: string;
+  parameters: JsonSchema;
+};


### PR DESCRIPTION
## Summary

接 #82 的 `@kagami/llm` 下沉收尾。`ToolDefinition`（agent-runtime）和 `Tool`（server）结构完全相同，且在 `LlmClient` ↔ `ReActModel` 边界上本就互换使用；`JsonSchema` 也在两处重复定义。这次把这两个 LLM 协议层类型收到 `@kagami/llm` 单一来源，消除重复。

## 改动

- **`@kagami/llm`**：新增 `JsonSchema`（取 agent-runtime 的超集，带 `additionalProperties?`）和 `Tool`。
- **agent-runtime**：删除自有 `JsonSchema` / `ToolDefinition` 定义，改 import 自 `@kagami/llm`；统一命名为 `Tool`，去掉 `ToolDefinition` 这个别名。`tool-component` import-then-export，内部文件沿用"从 tool-component 引入"的习惯。
- **server `llm/types.ts`**：删除自有 `JsonSchema` / `Tool`，import-then-export 自 `@kagami/llm`，36 个调用点路径不变。
- **server**：5 个 import `ToolDefinition` 的文件改用 `Tool`。

现在 `JsonSchema` / `Tool` 全仓库**单一定义**（`@kagami/llm`），无重复。

## 备注

`LlmToolChoice` / `LlmUsage` 等其余 LLM 协议类型未下沉——它们不存在重复，留 server 即可。本 PR 只消除重复定义，不做更大的层边界搬迁。

## Test plan

- [x] `pnpm build` / `typecheck` / `lint` / `format` / `test`（92 文件 / 471 测试全绿）
- [x] 全仓库 `JsonSchema` / `Tool` 单一定义校验通过