### PR TITLE
test(agent-runtime): 为核心包补 vitest 基建与 26 条不变量测试

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,7 @@ pnpm --filter @kagami/shared <script>
 - 当前仓库没有统一的根目录 `pnpm dev` 脚本。
 - `apps/server` 当前提供 `build`、`typecheck`、`test`、`test:watch`、`db:*` 脚本。
 - `apps/web` 当前提供 `build`、`typecheck` 脚本。
-- `packages/agent-runtime` 当前提供 `build`、`typecheck` 脚本。
+- `packages/agent-runtime` 当前提供 `build`、`typecheck`、`test`、`test:watch` 脚本。
 - `packages/shared` 当前提供 `build`、`typecheck` 脚本。
 - 因此前后端联调时，需要按实际情况分别启动或补充本地开发脚本，不要假设仓库已经内置一键 dev 流程。
 
@@ -148,7 +148,7 @@ pnpm --filter @kagami/server test:watch # 以后端 watch 模式运行测试
 
 补充说明：
 
-- 当前只有 `@kagami/server` 声明了测试脚本。
+- 当前 `@kagami/server` 与 `@kagami/agent-runtime` 声明了测试脚本（后者用 vitest 直接测源码，覆盖 Effect / 队列 / 串行执行器 / 工具组件的不变量）。
 
 ## 数据库与配置
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Added
 
+- agent-runtime: 为此前零测试的核心包 `@kagami/agent-runtime` 补上 vitest 测试基建，新增 26 条不变量测试，直接测源码、不依赖构建；覆盖 Effect 解释器（`ReplaceLeadingMessages` 唯一前缀重建路径且传副本、无匹配 / Noop 收到 effect 即抛绝不静默吞）、事件队列（FIFO、一次 enqueue 唤醒全部 waiter）、串行执行器（严格串行不交错、单任务抛错隔离）、`ZodToolComponent`（非法参数永不进 `executeTyped`、业务抛错转结构化结果）；根目录 `pnpm test` 现已覆盖该包（[#87](https://github.com/KisinTheFlame/kagami/pull/87)）
 - agent: 新增 `clock` App，提供 `view_time` 工具让 Agent 主动查询当前北京时间（精确到秒）；与 Wake Reminder 降频（[#77](https://github.com/KisinTheFlame/kagami/pull/77)）形成被动 + 主动的时间感知闭环（[#79](https://github.com/KisinTheFlame/kagami/pull/79)）
 
 ### Changed

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -13,7 +13,9 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@kagami/llm": "workspace:*",
@@ -21,6 +23,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.10.1",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/agent-runtime/test/effect.test.ts
+++ b/packages/agent-runtime/test/effect.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+import type { LlmMessage } from "@kagami/llm";
+import type {
+  Effect,
+  EffectHandler,
+  ReplaceLeadingMessagesEffect,
+  ReplaceLeadingMessagesTarget,
+} from "../src/effect.js";
+import {
+  HandlerEffectInterpreter,
+  NoopEffectInterpreter,
+  REPLACE_LEADING_MESSAGES_EFFECT_TYPE,
+  ReplaceLeadingMessagesHandler,
+} from "../src/effect.js";
+
+function userMessage(text: string): LlmMessage {
+  return { role: "user", content: text };
+}
+
+function recordingHandler(
+  type: string,
+  output: { appended?: LlmMessage[]; control?: string } = {},
+): EffectHandler<string> & { calls: Effect[] } {
+  const calls: Effect[] = [];
+  return {
+    calls,
+    matches(effect) {
+      return effect.type === type;
+    },
+    async handle(effect) {
+      calls.push(effect);
+      const result: { appendedMessages?: LlmMessage[]; control?: string } = {};
+      if (output.appended) {
+        result.appendedMessages = output.appended;
+      }
+      if (output.control !== undefined) {
+        result.control = output.control;
+      }
+      return result;
+    },
+  };
+}
+
+describe("NoopEffectInterpreter", () => {
+  it("接收空 effect 列表时返回空 appendedMessages", async () => {
+    await expect(new NoopEffectInterpreter().apply([])).resolves.toEqual({
+      appendedMessages: [],
+    });
+  });
+
+  it("收到任何 effect 都抛错——绝不静默吞掉", async () => {
+    await expect(new NoopEffectInterpreter().apply([{ type: "switch_app" }])).rejects.toThrow(
+      /received effects/,
+    );
+  });
+});
+
+describe("HandlerEffectInterpreter", () => {
+  it("每个 effect 路由到第一个 matches 的 handler", async () => {
+    const first = recordingHandler("a");
+    const second = recordingHandler("a");
+    const interpreter = new HandlerEffectInterpreter<string>([first, second]);
+
+    await interpreter.apply([{ type: "a" }]);
+
+    expect(first.calls).toHaveLength(1);
+    expect(second.calls).toHaveLength(0);
+  });
+
+  it("没有 handler 匹配时抛错——不静默丢弃 effect", async () => {
+    const interpreter = new HandlerEffectInterpreter<string>([recordingHandler("a")]);
+
+    await expect(interpreter.apply([{ type: "unhandled" }])).rejects.toThrow(
+      /No EffectHandler matched/,
+    );
+  });
+
+  it("按顺序累积所有 handler 产出的 appendedMessages", async () => {
+    const interpreter = new HandlerEffectInterpreter<string>([
+      recordingHandler("a", { appended: [userMessage("m1")] }),
+      recordingHandler("b", { appended: [userMessage("m2")] }),
+    ]);
+
+    const result = await interpreter.apply([{ type: "a" }, { type: "b" }]);
+
+    expect(result.appendedMessages).toEqual([userMessage("m1"), userMessage("m2")]);
+  });
+
+  it("control 取最后一个产出 control 的 handler（覆盖语义）", async () => {
+    const interpreter = new HandlerEffectInterpreter<string>([
+      recordingHandler("a", { control: "first" }),
+      recordingHandler("b", { control: "last" }),
+    ]);
+
+    const result = await interpreter.apply([{ type: "a" }, { type: "b" }]);
+
+    expect(result.control).toBe("last");
+  });
+
+  it("没有任何 handler 产出 control 时结果不带 control 字段", async () => {
+    const interpreter = new HandlerEffectInterpreter<string>([
+      recordingHandler("a", { appended: [userMessage("m1")] }),
+    ]);
+
+    const result = await interpreter.apply([{ type: "a" }]);
+
+    expect("control" in result).toBe(false);
+  });
+});
+
+describe("ReplaceLeadingMessagesHandler", () => {
+  function createTarget(): {
+    target: ReplaceLeadingMessagesTarget;
+    calls: Array<{ count: number; replacement: LlmMessage[] }>;
+  } {
+    const calls: Array<{ count: number; replacement: LlmMessage[] }> = [];
+    return {
+      calls,
+      target: {
+        async replaceLeadingMessages(count, replacement) {
+          calls.push({ count, replacement });
+        },
+      },
+    };
+  }
+
+  it("只匹配 replace_leading_messages 类型", () => {
+    const { target } = createTarget();
+    const handler = new ReplaceLeadingMessagesHandler(target);
+
+    expect(handler.matches({ type: REPLACE_LEADING_MESSAGES_EFFECT_TYPE })).toBe(true);
+    expect(handler.matches({ type: "append_message" })).toBe(false);
+  });
+
+  it("把 count 与 replacement 透传给 target，并返回空结果（不走追加协议）", async () => {
+    const { target, calls } = createTarget();
+    const handler = new ReplaceLeadingMessagesHandler(target);
+    const replacement = [userMessage("summary")];
+    const effect: ReplaceLeadingMessagesEffect = {
+      type: REPLACE_LEADING_MESSAGES_EFFECT_TYPE,
+      count: 7,
+      replacement,
+    };
+
+    const result = await handler.handle(effect);
+
+    expect(result).toEqual({});
+    expect(calls).toHaveLength(1);
+    expect(calls[0].count).toBe(7);
+    expect(calls[0].replacement).toEqual(replacement);
+  });
+
+  it("传给 target 的是 replacement 的副本，而非原数组引用（防别名 mutation）", async () => {
+    const { target, calls } = createTarget();
+    const handler = new ReplaceLeadingMessagesHandler(target);
+    const replacement = [userMessage("summary")];
+
+    await handler.handle({
+      type: REPLACE_LEADING_MESSAGES_EFFECT_TYPE,
+      count: 1,
+      replacement,
+    });
+
+    expect(calls[0].replacement).not.toBe(replacement);
+  });
+});

--- a/packages/agent-runtime/test/queue.test.ts
+++ b/packages/agent-runtime/test/queue.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryQueue } from "../src/queue.js";
+
+/** 等一个微任务 tick，让已 resolve 的 promise 回调跑完，再断言唤醒状态。 */
+function flushMicrotasks(): Promise<void> {
+  return Promise.resolve();
+}
+
+describe("InMemoryQueue", () => {
+  it("严格 FIFO：dequeue 顺序等于 enqueue 顺序", () => {
+    const queue = new InMemoryQueue<string>();
+    queue.enqueue("a");
+    queue.enqueue("b");
+    queue.enqueue("c");
+
+    expect(queue.dequeue()).toBe("a");
+    expect(queue.dequeue()).toBe("b");
+    expect(queue.dequeue()).toBe("c");
+  });
+
+  it("enqueue 返回入队后的长度", () => {
+    const queue = new InMemoryQueue<string>();
+
+    expect(queue.enqueue("a")).toBe(1);
+    expect(queue.enqueue("b")).toBe(2);
+  });
+
+  it("空队列 dequeue 返回 null", () => {
+    const queue = new InMemoryQueue<string>();
+
+    expect(queue.dequeue()).toBeNull();
+  });
+
+  it("clear 清空并返回被清掉的数量", () => {
+    const queue = new InMemoryQueue<string>();
+    queue.enqueue("a");
+    queue.enqueue("b");
+
+    expect(queue.clear()).toBe(2);
+    expect(queue.size()).toBe(0);
+    expect(queue.dequeue()).toBeNull();
+  });
+
+  it("take 在队列非空时立即返回，且保持 FIFO", async () => {
+    const queue = new InMemoryQueue<string>();
+    queue.enqueue("a");
+    queue.enqueue("b");
+
+    await expect(queue.take()).resolves.toBe("a");
+    await expect(queue.take()).resolves.toBe("b");
+  });
+
+  it("take 在队列为空时挂起，直到 enqueue 才 resolve", async () => {
+    const queue = new InMemoryQueue<string>();
+
+    let resolved = false;
+    const taken = queue.take().then(value => {
+      resolved = true;
+      return value;
+    });
+
+    await flushMicrotasks();
+    expect(resolved).toBe(false);
+
+    queue.enqueue("x");
+    await expect(taken).resolves.toBe("x");
+  });
+
+  it("一次 enqueue 唤醒全部挂起的 waiter（wake-all 语义）", async () => {
+    const queue = new InMemoryQueue<string>();
+
+    let woken = 0;
+    const w1 = queue.waitNonEmpty().then(() => {
+      woken += 1;
+    });
+    const w2 = queue.waitNonEmpty().then(() => {
+      woken += 1;
+    });
+
+    await flushMicrotasks();
+    expect(woken).toBe(0);
+
+    queue.enqueue("x");
+    await Promise.all([w1, w2]);
+    expect(woken).toBe(2);
+  });
+
+  it("waitNonEmpty 在队列已非空时立即 resolve", async () => {
+    const queue = new InMemoryQueue<string>();
+    queue.enqueue("a");
+
+    await expect(queue.waitNonEmpty()).resolves.toBeUndefined();
+  });
+});

--- a/packages/agent-runtime/test/serial-executor.test.ts
+++ b/packages/agent-runtime/test/serial-executor.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { SerialExecutor } from "../src/serial-executor.js";
+
+describe("SerialExecutor", () => {
+  it("严格串行：任务按提交顺序执行且不交错", async () => {
+    const executor = new SerialExecutor();
+    const order: string[] = [];
+
+    const makeTask = (id: string) => async () => {
+      order.push(`start-${id}`);
+      // 多个微任务 tick，给交错留出机会；串行保证下一个任务不会在此期间插入。
+      await Promise.resolve();
+      await Promise.resolve();
+      order.push(`end-${id}`);
+      return id;
+    };
+
+    const results = await Promise.all([
+      executor.submit(makeTask("a")),
+      executor.submit(makeTask("b")),
+      executor.submit(makeTask("c")),
+    ]);
+
+    expect(order).toEqual(["start-a", "end-a", "start-b", "end-b", "start-c", "end-c"]);
+    expect(results).toEqual(["a", "b", "c"]);
+  });
+
+  it("submit 返回的 promise resolve 为该任务的返回值", async () => {
+    const executor = new SerialExecutor();
+
+    await expect(executor.submit(async () => 42)).resolves.toBe(42);
+  });
+
+  it("一个任务抛错只影响它自己的 caller，不影响后续任务", async () => {
+    const executor = new SerialExecutor();
+    const order: string[] = [];
+
+    const failing = executor.submit(async () => {
+      order.push("failing");
+      throw new Error("boom");
+    });
+    const following = executor.submit(async () => {
+      order.push("following");
+      return "ok";
+    });
+
+    await expect(failing).rejects.toThrow("boom");
+    await expect(following).resolves.toBe("ok");
+    expect(order).toEqual(["failing", "following"]);
+  });
+
+  it("队列排空后再 submit 能重新启动 worker", async () => {
+    const executor = new SerialExecutor();
+
+    await expect(executor.submit(async () => "first")).resolves.toBe("first");
+    expect(executor.size()).toBe(0);
+
+    await expect(executor.submit(async () => "second")).resolves.toBe("second");
+  });
+});

--- a/packages/agent-runtime/test/tool-component.test.ts
+++ b/packages/agent-runtime/test/tool-component.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { ZodToolComponent } from "../src/tool/tool-component.js";
+import type {
+  JsonSchema,
+  ToolContext,
+  ToolExecutionResult,
+  ToolKind,
+} from "../src/tool/tool-component.js";
+
+const echoSchema = z.object({ value: z.string() });
+
+const ECHO_PARAMETERS: JsonSchema = {
+  type: "object",
+  properties: { value: { type: "string" } },
+};
+
+/** 记录 executeTyped 是否被调用、以何种输入调用，用来验证参数校验门控。 */
+class EchoTool extends ZodToolComponent<typeof echoSchema> {
+  public readonly name = "echo";
+  public readonly description = "echo back the value";
+  public readonly parameters: JsonSchema = ECHO_PARAMETERS;
+  public readonly kind: ToolKind = "business";
+  protected readonly inputSchema = echoSchema;
+
+  public typedCalls: Array<z.infer<typeof echoSchema>> = [];
+
+  protected executeTyped(input: z.infer<typeof echoSchema>): string {
+    this.typedCalls.push(input);
+    return `echo:${input.value}`;
+  }
+}
+
+class StructuredTool extends ZodToolComponent<typeof echoSchema> {
+  public readonly name = "structured";
+  public readonly description = "returns a structured result";
+  public readonly parameters: JsonSchema = ECHO_PARAMETERS;
+  public readonly kind: ToolKind = "business";
+  protected readonly inputSchema = echoSchema;
+
+  protected executeTyped(): ToolExecutionResult {
+    return {
+      content: "done",
+      effects: [{ type: "switch_app" }],
+    };
+  }
+}
+
+class ThrowingTool extends ZodToolComponent<typeof echoSchema> {
+  public readonly name = "throwing";
+  public readonly description = "always throws";
+  public readonly parameters: JsonSchema = ECHO_PARAMETERS;
+  public readonly kind: ToolKind = "business";
+  protected readonly inputSchema = echoSchema;
+
+  protected executeTyped(): string {
+    throw new Error("kaboom");
+  }
+}
+
+const EMPTY_CONTEXT: ToolContext = {};
+
+describe("ZodToolComponent", () => {
+  it("参数校验不通过时绝不调用 executeTyped，返回 INVALID_ARGUMENTS", async () => {
+    const tool = new EchoTool();
+
+    const result = await tool.execute({ value: 123 }, EMPTY_CONTEXT);
+
+    expect(tool.typedCalls).toHaveLength(0);
+    expect(JSON.parse(result.content)).toMatchObject({
+      ok: false,
+      error: "INVALID_ARGUMENTS",
+    });
+  });
+
+  it("参数合法时调用 executeTyped，string 返回值被包成 { content }", async () => {
+    const tool = new EchoTool();
+
+    const result = await tool.execute({ value: "hi" }, EMPTY_CONTEXT);
+
+    expect(tool.typedCalls).toEqual([{ value: "hi" }]);
+    expect(result).toEqual({ content: "echo:hi" });
+  });
+
+  it("executeTyped 返回结构化结果时原样透传（含 effects）", async () => {
+    const tool = new StructuredTool();
+
+    const result = await tool.execute({ value: "hi" }, EMPTY_CONTEXT);
+
+    expect(result).toEqual({
+      content: "done",
+      effects: [{ type: "switch_app" }],
+    });
+  });
+
+  it("executeTyped 抛错被接住并转成结构化错误，而不是冒泡打断 loop", async () => {
+    const tool = new ThrowingTool();
+
+    const result = await tool.execute({ value: "hi" }, EMPTY_CONTEXT);
+
+    expect(JSON.parse(result.content)).toEqual({
+      ok: false,
+      error: "kaboom",
+    });
+  });
+});

--- a/packages/agent-runtime/vitest.config.ts
+++ b/packages/agent-runtime/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+    clearMocks: true,
+    restoreMocks: true,
+    maxWorkers: 4,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,6 +206,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@24.11.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/llm:
     devDependencies:


### PR DESCRIPTION
## 概述

为此前**零测试**的核心包 `@kagami/agent-runtime` 补上 vitest 测试基建，并新增 26 条不变量测试。测试放在包内、直接测源码（`../src/*.js`，vitest 解析到 `.ts`，不依赖 `pnpm build`）。根目录 `pnpm test` 现已自动覆盖该包。

挑选了四个当前零测试、且不变量最锋利的核心单元，每条都对应一个"坏了会静默出大事"的性质：

| 单元 | 钉死的不变量 |
|---|---|
| `effect.ts` | `ReplaceLeadingMessages` 是唯一前缀重建路径且传**副本**（防别名 mutation）；`NoopEffectInterpreter` 收到 effect 即抛、`HandlerEffectInterpreter` 无匹配 handler 即抛——**绝不静默吞 effect**；appendedMessages 按序累积、control 取最后一个 |
| `queue.ts` | 严格 FIFO；一次 `enqueue` **唤醒全部** waiter；空队列 dequeue 返回 null |
| `serial-executor.ts` | 严格串行不交错；单任务抛错**只炸自己的 caller**；排空后能重启 worker |
| `tool-component.ts` | 非法参数**永不进** `executeTyped`；业务抛错被接住转结构化结果而非冒泡打断 loop |

`ProsToolCatalog` 已有 server 端 `catalog.test.ts` 覆盖，未重复。

## 测试覆盖

纯新增测试代码，无生产逻辑改动。新增 4 个测试文件 / 26 条用例，全部直接测源码。
- `effect.test.ts`（10）· `queue.test.ts`（8）· `serial-executor.test.ts`（4）· `tool-component.test.ts`（4）
- 测试均确定性（微任务 flush，无真实定时器 / 墙钟），无 flakiness。

## 验证

- `pnpm --filter @kagami/agent-runtime test`：**26 passed**
- `pnpm test`（全量）：server **483 passed** + agent-runtime **26 passed**
- `pnpm build` / `pnpm typecheck` / `pnpm lint` / `pnpm format`：全绿

## Pre-Landing Review

Test-only 追加改动，无 SQL / LLM 信任边界 / 生产逻辑。已就测试代码的两类真实风险（flakiness、假置信）自审：测试全确定性、断言均为真实行为而非 `toBeDefined()` 式空断言。无问题。

## 文档

同步 `AGENTS.md`：修正"只有 @kagami/server 声明测试脚本"的过时表述，补上 `agent-runtime` 现有 `test` / `test:watch` 脚本。

🤖 Generated with [Claude Code](https://claude.com/claude-code)