### PR TITLE
fix(server): PG→SQLite 搬迁脚本补全所有表 + 分页防 OOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- server: PG→SQLite 搬迁脚本 `migrate-pg-to-sqlite.ts` 补全为**全量迁移所有表**（之前漏了 app_log / llm_chat_call / metric / napcat_event / napcat_qq_message 群消息历史等 8 张表）；大表按 id 分页流式读取避免 OOM；新增 `migrate-pg-remaining-append.ts` 用于在已上线的 SQLite 上「不清空、追加补迁」个别表
+
 ### Added
 
 - agent: 新增 `clock` App，提供 `view_time` 工具让 Agent 主动查询当前北京时间（精确到秒）；与 Wake Reminder 降频（[#77](https://github.com/KisinTheFlame/kagami/pull/77)）形成被动 + 主动的时间感知闭环（[#79](https://github.com/KisinTheFlame/kagami/pull/79)）

--- a/apps/server/scripts/migrate-pg-remaining-append.ts
+++ b/apps/server/scripts/migrate-pg-remaining-append.ts
@@ -1,0 +1,213 @@
+/**
+ * 一次性补迁：把首轮迁移中被丢弃的 8 张「瞬时表」（日志 / 指标 / 群消息历史 / LLM 历史 /
+ * 事件 / 用量快照 / oauth_state / 终端输出）从旧 PostgreSQL **追加**到当前 SQLite。
+ *
+ * 为什么是追加而非整库重灌：切换后生产已运行在 SQLite，ledger 等关键表比冻结的 PG 更新；
+ * 整库重灌会回滚这些表。故这里只动这 8 张表，且 **不清空**、**不指定 id**（自增追加，
+ * 保留切换后已写入的少量行）。这 8 张表都没有被其它表外键引用其 id。
+ *
+ * 内存安全：按 id 分页流式读 PG（每页 batch 行），逐页写入，绝不一次性把整表读进内存
+ * （llm_chat_call 单条 request_payload 可达 ~1MB）。
+ *
+ * 幂等：每表若 SQLite 现有行数已 >= PG 行数，视为已补迁、跳过；可安全重跑。
+ *
+ * 用法（先停 kagami-server）：
+ *   SOURCE_DATABASE_URL="postgres://..." pnpm --filter @kagami/server exec tsx scripts/migrate-pg-remaining-append.ts
+ */
+import pg from "pg";
+import { loadStaticConfig } from "../src/config/config.loader.js";
+import { createDbClient, closeDb } from "../src/db/client.js";
+import * as Prisma from "../src/generated/prisma/internal/prismaNamespace.js";
+
+/** Json 列：null/undefined 用 Prisma.DbNull 表示 SQL NULL，否则原样传对象。 */
+function j(value: unknown): unknown {
+  return value === null || value === undefined ? Prisma.DbNull : value;
+}
+
+type Delegate = {
+  count: () => Promise<number>;
+  createMany: (a: { data: unknown[] }) => Promise<unknown>;
+};
+
+type Spec = {
+  table: string;
+  batch: number;
+  delegate: Delegate;
+  map: (row: Record<string, unknown>) => Record<string, unknown>;
+};
+
+async function main(): Promise<void> {
+  const sourceUrl = process.env.SOURCE_DATABASE_URL;
+  if (!sourceUrl) {
+    throw new Error("缺少环境变量 SOURCE_DATABASE_URL（旧 PostgreSQL 连接串）");
+  }
+
+  const config = await loadStaticConfig();
+  const pgClient = new pg.Client({ connectionString: sourceUrl });
+  await pgClient.connect();
+  const database = createDbClient({ databaseUrl: config.server.databaseUrl });
+
+  const specs: Spec[] = [
+    {
+      table: "app_log",
+      batch: 500,
+      delegate: database.appLog,
+      map: r => ({
+        traceId: r.trace_id,
+        level: r.level,
+        message: r.message,
+        metadata: j(r.metadata),
+        createdAt: r.created_at,
+        updatedAt: r.updated_at,
+      }),
+    },
+    {
+      table: "llm_chat_call",
+      batch: 50,
+      delegate: database.llmChatCall,
+      map: r => ({
+        requestId: r.request_id,
+        seq: r.seq,
+        provider: r.provider,
+        model: r.model,
+        extension: j(r.extension),
+        status: r.status,
+        requestPayload: j(r.request_payload),
+        responsePayload: j(r.response_payload),
+        nativeRequestPayload: j(r.native_request_payload),
+        nativeResponsePayload: j(r.native_response_payload),
+        error: j(r.error),
+        nativeError: j(r.native_error),
+        latencyMs: r.latency_ms,
+        createdAt: r.created_at,
+      }),
+    },
+    {
+      table: "metric",
+      batch: 500,
+      delegate: database.metric,
+      map: r => ({
+        metricName: r.metric_name,
+        value: r.value,
+        tags: j(r.tags),
+        occurredAt: r.occurred_at,
+        createdAt: r.created_at,
+      }),
+    },
+    {
+      table: "napcat_event",
+      batch: 500,
+      delegate: database.napcatEvent,
+      map: r => ({
+        postType: r.post_type,
+        messageType: r.message_type,
+        subType: r.sub_type,
+        userId: r.user_id,
+        groupId: r.group_id,
+        eventTime: r.event_time,
+        payload: j(r.payload),
+        createdAt: r.created_at,
+      }),
+    },
+    {
+      table: "napcat_qq_message",
+      batch: 300,
+      delegate: database.napcatQqMessage,
+      map: r => ({
+        messageType: r.message_type,
+        subType: r.sub_type,
+        groupId: r.group_id,
+        userId: r.user_id,
+        nickname: r.nickname,
+        messageId: r.message_id,
+        message: j(r.message),
+        eventTime: r.event_time,
+        payload: j(r.payload),
+        createdAt: r.created_at,
+      }),
+    },
+    {
+      table: "auth_usage_snapshot",
+      batch: 500,
+      delegate: database.authUsageSnapshot,
+      map: r => ({
+        provider: r.provider,
+        accountId: r.account_id,
+        windowKey: r.window_key,
+        remainingPercent: r.remaining_percent,
+        resetAt: r.reset_at,
+        capturedAt: r.captured_at,
+      }),
+    },
+    {
+      table: "oauth_state",
+      batch: 500,
+      delegate: database.oauthState,
+      map: r => ({
+        state: r.state,
+        codeVerifier: r.code_verifier,
+        redirectUri: r.redirect_uri,
+        expiresAt: r.expires_at,
+        usedAt: r.used_at,
+        createdAt: r.created_at,
+      }),
+    },
+    {
+      table: "terminal_output",
+      batch: 500,
+      delegate: database.terminalOutput,
+      map: r => ({
+        outputId: r.output_id,
+        stdout: r.stdout,
+        stderr: r.stderr,
+        createdAt: r.created_at,
+      }),
+    },
+  ];
+
+  console.log("追加补迁 8 张瞬时表（分页流式、幂等、不清空、不指定 id）...\n");
+  try {
+    for (const spec of specs) {
+      await appendTable(pgClient, spec);
+    }
+  } finally {
+    await pgClient.end();
+    await closeDb(database);
+  }
+  console.log("\n补迁完成。");
+}
+
+async function appendTable(pgClient: pg.Client, spec: Spec): Promise<void> {
+  const pgCount = Number(
+    (await pgClient.query(`SELECT count(*)::int AS n FROM "${spec.table}"`)).rows[0].n,
+  );
+  const before = await spec.delegate.count();
+  if (before >= pgCount) {
+    console.log(`  ${spec.table}: 已补迁（SQLite ${before} >= PG ${pgCount}），跳过`);
+    return;
+  }
+
+  let lastId = 0;
+  let appended = 0;
+  for (;;) {
+    const page = await pgClient.query(
+      `SELECT * FROM "${spec.table}" WHERE id > $1 ORDER BY id ASC LIMIT $2`,
+      [lastId, spec.batch],
+    );
+    if (page.rows.length === 0) {
+      break;
+    }
+    await spec.delegate.createMany({ data: page.rows.map(spec.map) });
+    lastId = Number(page.rows[page.rows.length - 1].id);
+    appended += page.rows.length;
+  }
+
+  console.log(
+    `  ${spec.table}: 追加 ${appended} 行（PG ${pgCount}），SQLite ${before} → ${await spec.delegate.count()}`,
+  );
+}
+
+main().catch((error: unknown) => {
+  console.error("补迁失败：", error);
+  process.exitCode = 1;
+});

--- a/apps/server/scripts/migrate-pg-to-sqlite.ts
+++ b/apps/server/scripts/migrate-pg-to-sqlite.ts
@@ -1,5 +1,5 @@
 /**
- * 一次性数据搬迁：旧 PostgreSQL → 新 SQLite（停机迁移）。
+ * 一次性数据搬迁：旧 PostgreSQL → 新 SQLite（停机迁移，全量覆盖所有表）。
  *
  * 用法（先停服务）：
  *   SOURCE_DATABASE_URL="postgres://user:pass@localhost:5432/kagami" \
@@ -7,17 +7,41 @@
  *
  * - 源库（PG）连接串来自环境变量 SOURCE_DATABASE_URL（必填）。
  * - 目标库（SQLite）来自 config.yaml 的 server.databaseUrl（已切换为 file:）。
- * - 只搬迁关键有状态数据；日志 / 指标 / 事件等瞬时表不迁移。
- * - 目标表会先清空再导入，可重复执行。
+ * - **全量迁移 schema 里的所有表**（含日志 / 指标 / 群消息历史 / LLM 历史 / 事件等）。
+ * - 每张目标表先清空再导入，可重复执行；保留原始 id（与 PG 一一对应的镜像）。
  * - 写入统一走 Prisma Client，保证 DateTime / JSON 的存储格式与运行时读取一致。
+ * - 大表（含大 JSON payload，如 llm_chat_call）按 id 分页流式读 PG，避免一次性整表读进内存 OOM。
  * - story_memory_document 的 pgvector 向量以 `embedding::text` 取出后转存 JSON 字符串；
- *   首次启动时 HNSW 索引会从这些行重建。
+ *   embedding_cache 的 Float[] 同样转 JSON 字符串。首次启动时 HNSW 索引会从行内向量重建。
+ *
+ * 注意：本脚本会**清空目标表**，仅用于「空库 / 全量重灌」的停机迁移。若目标 SQLite 已在
+ * 生产运行、只想补迁个别表，请用 migrate-pg-remaining-append.ts（追加、不清空）。
  */
 import pg from "pg";
 import { loadStaticConfig } from "../src/config/config.loader.js";
 import { createDbClient, closeDb } from "../src/db/client.js";
+import * as Prisma from "../src/generated/prisma/internal/prismaNamespace.js";
 
-const BATCH_SIZE = 500;
+/** Json 列：null/undefined 用 Prisma.DbNull 表示 SQL NULL，否则原样传对象。 */
+function j(value: unknown): unknown {
+  return value === null || value === undefined ? Prisma.DbNull : value;
+}
+
+type Delegate = {
+  deleteMany: (args?: unknown) => Promise<unknown>;
+  createMany: (a: { data: unknown[] }) => Promise<unknown>;
+};
+
+type Spec = {
+  table: string;
+  /** SELECT 的列；默认 `*`。pgvector 等需要显式 `::text` 的列在此自定义。 */
+  columns?: string;
+  /** 是否按整型 id 分页（默认 true）。string 主键的小表（story / news_feed_cursor）置 false。 */
+  paginate?: boolean;
+  batch?: number;
+  delegate: Delegate;
+  map: (row: Record<string, unknown>) => Record<string, unknown>;
+};
 
 async function main(): Promise<void> {
   const sourceUrl = process.env.SOURCE_DATABASE_URL;
@@ -37,185 +61,290 @@ async function main(): Promise<void> {
 
   console.log(`源库: ${sourceUrl}`);
   console.log(`目标: ${targetUrl}`);
-  console.log("开始搬迁（目标表会先清空）...\n");
+  console.log("开始全量搬迁（目标表会先清空）...\n");
+
+  // story 必须先于 story_memory_document（外键）。
+  const specs: Spec[] = [
+    {
+      table: "story",
+      paginate: false,
+      delegate: database.story,
+      map: r => ({
+        id: r.id,
+        markdown: r.markdown,
+        sourceMessageSeqStart: r.source_message_seq_start,
+        sourceMessageSeqEnd: r.source_message_seq_end,
+        createdAt: r.created_at,
+        updatedAt: r.updated_at,
+      }),
+    },
+    {
+      table: "story_memory_document",
+      columns: `id, story_id, kind, content, embedding_model, embedding_dim, embedding::text AS embedding_text, created_at, updated_at`,
+      delegate: database.storyMemoryDocument,
+      map: r => ({
+        id: r.id,
+        storyId: r.story_id,
+        kind: r.kind,
+        content: r.content,
+        embeddingModel: r.embedding_model,
+        embeddingDim: r.embedding_dim,
+        embedding: normalizeVectorLiteral(r.embedding_text as string | null),
+        createdAt: r.created_at,
+        updatedAt: r.updated_at,
+      }),
+    },
+    {
+      table: "ledger",
+      delegate: database.linearMessageLedger,
+      map: r => ({
+        id: r.id,
+        runtimeKey: r.runtime_key,
+        message: j(r.message),
+        createdAt: r.created_at,
+      }),
+    },
+    {
+      table: "oauth_session",
+      delegate: database.oauthSession,
+      map: r => ({
+        id: r.id,
+        provider: r.provider,
+        accountId: r.account_id,
+        email: r.email,
+        accessToken: r.access_token,
+        refreshToken: r.refresh_token,
+        idToken: r.id_token,
+        expiresAt: r.expires_at,
+        lastRefreshAt: r.last_refresh_at,
+        status: r.status,
+        lastError: r.last_error,
+        createdAt: r.created_at,
+        updatedAt: r.updated_at,
+      }),
+    },
+    {
+      table: "root_agent_runtime_snapshot",
+      delegate: database.rootAgentRuntimeSnapshot,
+      map: r => ({
+        id: r.id,
+        runtimeKey: r.runtime_key,
+        schemaVersion: r.schema_version,
+        contextSnapshot: j(r.context_snapshot),
+        sessionSnapshot: j(r.session_snapshot),
+        lastWakeReminderAt: r.last_wake_reminder_at,
+        createdAt: r.created_at,
+        updatedAt: r.updated_at,
+      }),
+    },
+    {
+      table: "story_agent_runtime_snapshot",
+      delegate: database.storyAgentRuntimeSnapshot,
+      map: r => ({
+        id: r.id,
+        runtimeKey: r.runtime_key,
+        schemaVersion: r.schema_version,
+        contextSnapshot: j(r.context_snapshot),
+        lastProcessedMessageSeq: r.last_processed_message_seq,
+        createdAt: r.created_at,
+        updatedAt: r.updated_at,
+      }),
+    },
+    {
+      table: "news_article",
+      delegate: database.newsArticle,
+      map: r => ({
+        id: r.id,
+        sourceKey: r.source_key,
+        upstreamId: r.upstream_id,
+        title: r.title,
+        url: r.url,
+        publishedAt: r.published_at,
+        rssSummary: r.rss_summary,
+        rssPayload: j(r.rss_payload),
+        articleContent: r.article_content,
+        articleContentStatus: r.article_content_status,
+        articleContentFetchedAt: r.article_content_fetched_at,
+        createdAt: r.created_at,
+        updatedAt: r.updated_at,
+      }),
+    },
+    {
+      table: "news_feed_cursor",
+      paginate: false,
+      delegate: database.newsFeedCursor,
+      map: r => ({
+        sourceKey: r.source_key,
+        lastSeenArticleId: r.last_seen_article_id,
+        lastSeenPublishedAt: r.last_seen_published_at,
+        createdAt: r.created_at,
+        updatedAt: r.updated_at,
+      }),
+    },
+    {
+      table: "embedding_cache",
+      delegate: database.embeddingCache,
+      map: r => ({
+        id: r.id,
+        provider: r.provider,
+        model: r.model,
+        taskType: r.task_type,
+        outputDimensionality: r.output_dimensionality,
+        text: r.text,
+        textHash: r.text_hash,
+        // PG 的 Float[] 由 node-postgres 解析为数组，转存为 JSON 字符串。
+        embedding: JSON.stringify(r.embedding ?? []),
+        createdAt: r.created_at,
+      }),
+    },
+    {
+      table: "metric_chart",
+      delegate: database.metricChart,
+      map: r => ({
+        id: r.id,
+        chartName: r.chart_name,
+        metricName: r.metric_name,
+        aggregator: r.aggregator,
+        tagFilters: j(r.tag_filters),
+        groupByTag: r.group_by_tag,
+        createdAt: r.created_at,
+        updatedAt: r.updated_at,
+      }),
+    },
+    {
+      table: "terminal_state",
+      delegate: database.terminalState,
+      map: r => ({
+        id: r.id,
+        cwd: r.cwd,
+        createdAt: r.created_at,
+        updatedAt: r.updated_at,
+      }),
+    },
+    {
+      table: "app_log",
+      delegate: database.appLog,
+      map: r => ({
+        id: r.id,
+        traceId: r.trace_id,
+        level: r.level,
+        message: r.message,
+        metadata: j(r.metadata),
+        createdAt: r.created_at,
+        updatedAt: r.updated_at,
+      }),
+    },
+    {
+      table: "llm_chat_call",
+      batch: 50,
+      delegate: database.llmChatCall,
+      map: r => ({
+        id: r.id,
+        requestId: r.request_id,
+        seq: r.seq,
+        provider: r.provider,
+        model: r.model,
+        extension: j(r.extension),
+        status: r.status,
+        requestPayload: j(r.request_payload),
+        responsePayload: j(r.response_payload),
+        nativeRequestPayload: j(r.native_request_payload),
+        nativeResponsePayload: j(r.native_response_payload),
+        error: j(r.error),
+        nativeError: j(r.native_error),
+        latencyMs: r.latency_ms,
+        createdAt: r.created_at,
+      }),
+    },
+    {
+      table: "metric",
+      delegate: database.metric,
+      map: r => ({
+        id: r.id,
+        metricName: r.metric_name,
+        value: r.value,
+        tags: j(r.tags),
+        occurredAt: r.occurred_at,
+        createdAt: r.created_at,
+      }),
+    },
+    {
+      table: "napcat_event",
+      batch: 300,
+      delegate: database.napcatEvent,
+      map: r => ({
+        id: r.id,
+        postType: r.post_type,
+        messageType: r.message_type,
+        subType: r.sub_type,
+        userId: r.user_id,
+        groupId: r.group_id,
+        eventTime: r.event_time,
+        payload: j(r.payload),
+        createdAt: r.created_at,
+      }),
+    },
+    {
+      table: "napcat_qq_message",
+      batch: 300,
+      delegate: database.napcatQqMessage,
+      map: r => ({
+        id: r.id,
+        messageType: r.message_type,
+        subType: r.sub_type,
+        groupId: r.group_id,
+        userId: r.user_id,
+        nickname: r.nickname,
+        messageId: r.message_id,
+        message: j(r.message),
+        eventTime: r.event_time,
+        payload: j(r.payload),
+        createdAt: r.created_at,
+      }),
+    },
+    {
+      table: "auth_usage_snapshot",
+      delegate: database.authUsageSnapshot,
+      map: r => ({
+        id: r.id,
+        provider: r.provider,
+        accountId: r.account_id,
+        windowKey: r.window_key,
+        remainingPercent: r.remaining_percent,
+        resetAt: r.reset_at,
+        capturedAt: r.captured_at,
+      }),
+    },
+    {
+      table: "oauth_state",
+      delegate: database.oauthState,
+      map: r => ({
+        id: r.id,
+        state: r.state,
+        codeVerifier: r.code_verifier,
+        redirectUri: r.redirect_uri,
+        expiresAt: r.expires_at,
+        usedAt: r.used_at,
+        createdAt: r.created_at,
+      }),
+    },
+    {
+      table: "terminal_output",
+      delegate: database.terminalOutput,
+      map: r => ({
+        id: r.id,
+        outputId: r.output_id,
+        stdout: r.stdout,
+        stderr: r.stderr,
+        createdAt: r.created_at,
+      }),
+    },
+  ];
 
   try {
-    // 顺序遵循外键依赖：story 先于 story_memory_document。
-    await copyTable(pgClient, {
-      label: "story",
-      sourceSql: `SELECT id, markdown, source_message_seq_start, source_message_seq_end, created_at, updated_at FROM "story"`,
-      delegate: database.story,
-      mapRow: row => ({
-        id: row.id,
-        markdown: row.markdown,
-        sourceMessageSeqStart: row.source_message_seq_start,
-        sourceMessageSeqEnd: row.source_message_seq_end,
-        createdAt: row.created_at,
-        updatedAt: row.updated_at,
-      }),
-    });
-
-    await copyTable(pgClient, {
-      label: "story_memory_document",
-      sourceSql: `SELECT id, story_id, kind, content, embedding_model, embedding_dim, embedding::text AS embedding_text, created_at, updated_at FROM "story_memory_document"`,
-      delegate: database.storyMemoryDocument,
-      mapRow: row => ({
-        id: row.id,
-        storyId: row.story_id,
-        kind: row.kind,
-        content: row.content,
-        embeddingModel: row.embedding_model,
-        embeddingDim: row.embedding_dim,
-        embedding: normalizeVectorLiteral(row.embedding_text),
-        createdAt: row.created_at,
-        updatedAt: row.updated_at,
-      }),
-    });
-
-    await copyTable(pgClient, {
-      label: "ledger",
-      sourceSql: `SELECT id, runtime_key, message, created_at FROM "ledger"`,
-      delegate: database.linearMessageLedger,
-      mapRow: row => ({
-        id: row.id,
-        runtimeKey: row.runtime_key,
-        message: row.message,
-        createdAt: row.created_at,
-      }),
-    });
-
-    await copyTable(pgClient, {
-      label: "oauth_session",
-      sourceSql: `SELECT * FROM "oauth_session"`,
-      delegate: database.oauthSession,
-      mapRow: row => ({
-        id: row.id,
-        provider: row.provider,
-        accountId: row.account_id,
-        email: row.email,
-        accessToken: row.access_token,
-        refreshToken: row.refresh_token,
-        idToken: row.id_token,
-        expiresAt: row.expires_at,
-        lastRefreshAt: row.last_refresh_at,
-        status: row.status,
-        lastError: row.last_error,
-        createdAt: row.created_at,
-        updatedAt: row.updated_at,
-      }),
-    });
-
-    await copyTable(pgClient, {
-      label: "root_agent_runtime_snapshot",
-      sourceSql: `SELECT * FROM "root_agent_runtime_snapshot"`,
-      delegate: database.rootAgentRuntimeSnapshot,
-      mapRow: row => ({
-        id: row.id,
-        runtimeKey: row.runtime_key,
-        schemaVersion: row.schema_version,
-        contextSnapshot: row.context_snapshot,
-        sessionSnapshot: row.session_snapshot,
-        lastWakeReminderAt: row.last_wake_reminder_at,
-        createdAt: row.created_at,
-        updatedAt: row.updated_at,
-      }),
-    });
-
-    await copyTable(pgClient, {
-      label: "story_agent_runtime_snapshot",
-      sourceSql: `SELECT * FROM "story_agent_runtime_snapshot"`,
-      delegate: database.storyAgentRuntimeSnapshot,
-      mapRow: row => ({
-        id: row.id,
-        runtimeKey: row.runtime_key,
-        schemaVersion: row.schema_version,
-        contextSnapshot: row.context_snapshot,
-        lastProcessedMessageSeq: row.last_processed_message_seq,
-        createdAt: row.created_at,
-        updatedAt: row.updated_at,
-      }),
-    });
-
-    await copyTable(pgClient, {
-      label: "news_article",
-      sourceSql: `SELECT * FROM "news_article"`,
-      delegate: database.newsArticle,
-      mapRow: row => ({
-        id: row.id,
-        sourceKey: row.source_key,
-        upstreamId: row.upstream_id,
-        title: row.title,
-        url: row.url,
-        publishedAt: row.published_at,
-        rssSummary: row.rss_summary,
-        rssPayload: row.rss_payload,
-        articleContent: row.article_content,
-        articleContentStatus: row.article_content_status,
-        articleContentFetchedAt: row.article_content_fetched_at,
-        createdAt: row.created_at,
-        updatedAt: row.updated_at,
-      }),
-    });
-
-    await copyTable(pgClient, {
-      label: "news_feed_cursor",
-      sourceSql: `SELECT * FROM "news_feed_cursor"`,
-      delegate: database.newsFeedCursor,
-      mapRow: row => ({
-        sourceKey: row.source_key,
-        lastSeenArticleId: row.last_seen_article_id,
-        lastSeenPublishedAt: row.last_seen_published_at,
-        createdAt: row.created_at,
-        updatedAt: row.updated_at,
-      }),
-    });
-
-    await copyTable(pgClient, {
-      label: "embedding_cache",
-      sourceSql: `SELECT * FROM "embedding_cache"`,
-      delegate: database.embeddingCache,
-      mapRow: row => ({
-        id: row.id,
-        provider: row.provider,
-        model: row.model,
-        taskType: row.task_type,
-        outputDimensionality: row.output_dimensionality,
-        text: row.text,
-        textHash: row.text_hash,
-        // PG 的 Float[] 由 node-postgres 解析为数组，转存为 JSON 字符串。
-        embedding: JSON.stringify(row.embedding ?? []),
-        createdAt: row.created_at,
-      }),
-    });
-
-    await copyTable(pgClient, {
-      label: "metric_chart",
-      sourceSql: `SELECT * FROM "metric_chart"`,
-      delegate: database.metricChart,
-      mapRow: row => ({
-        id: row.id,
-        chartName: row.chart_name,
-        metricName: row.metric_name,
-        aggregator: row.aggregator,
-        tagFilters: row.tag_filters,
-        groupByTag: row.group_by_tag,
-        createdAt: row.created_at,
-        updatedAt: row.updated_at,
-      }),
-    });
-
-    await copyTable(pgClient, {
-      label: "terminal_state",
-      sourceSql: `SELECT * FROM "terminal_state"`,
-      delegate: database.terminalState,
-      mapRow: row => ({
-        id: row.id,
-        cwd: row.cwd,
-        createdAt: row.created_at,
-        updatedAt: row.updated_at,
-      }),
-    });
-
+    for (const spec of specs) {
+      await copyTable(pgClient, spec);
+    }
     console.log("\n搬迁完成。首次启动时 HNSW 向量索引会从 story_memory_document 自动重建。");
   } finally {
     await pgClient.end();
@@ -223,33 +352,41 @@ async function main(): Promise<void> {
   }
 }
 
-type CopyTableOptions = {
-  label: string;
-  sourceSql: string;
-  delegate: {
-    deleteMany: (args?: unknown) => Promise<unknown>;
-    createMany: (args: { data: unknown[] }) => Promise<unknown>;
-  };
-  mapRow: (row: Record<string, unknown>) => Record<string, unknown>;
-};
+async function copyTable(pgClient: pg.Client, spec: Spec): Promise<void> {
+  const columns = spec.columns ?? "*";
+  const batch = spec.batch ?? 500;
 
-async function copyTable(pgClient: pg.Client, options: CopyTableOptions): Promise<void> {
-  let rows: Record<string, unknown>[];
+  let total = 0;
   try {
-    const result = await pgClient.query(options.sourceSql);
-    rows = result.rows;
+    await spec.delegate.deleteMany({});
+
+    if (spec.paginate === false) {
+      const result = await pgClient.query(`SELECT ${columns} FROM "${spec.table}"`);
+      const rows = result.rows.map(spec.map);
+      for (let offset = 0; offset < rows.length; offset += batch) {
+        await spec.delegate.createMany({ data: rows.slice(offset, offset + batch) });
+      }
+      total = rows.length;
+    } else {
+      let lastId = 0;
+      for (;;) {
+        const page = await pgClient.query(
+          `SELECT ${columns} FROM "${spec.table}" WHERE id > $1 ORDER BY id ASC LIMIT $2`,
+          [lastId, batch],
+        );
+        if (page.rows.length === 0) {
+          break;
+        }
+        await spec.delegate.createMany({ data: page.rows.map(spec.map) });
+        lastId = Number(page.rows[page.rows.length - 1].id);
+        total += page.rows.length;
+      }
+    }
   } catch (error) {
-    console.warn(`  ${options.label}: 跳过（源表读取失败：${(error as Error).message}）`);
+    console.warn(`  ${spec.table}: 跳过（${(error as Error).message}）`);
     return;
   }
-
-  await options.delegate.deleteMany({});
-
-  const mapped = rows.map(options.mapRow);
-  for (let offset = 0; offset < mapped.length; offset += BATCH_SIZE) {
-    await options.delegate.createMany({ data: mapped.slice(offset, offset + BATCH_SIZE) });
-  }
-  console.log(`  ${options.label}: ${mapped.length} 行`);
+  console.log(`  ${spec.table}: ${total} 行`);
 }
 
 /** pgvector `::text` 形如 `[1,2,3]`，规范化为紧凑 JSON 字符串；null 透传。 */


### PR DESCRIPTION
## 背景

[#85](https://github.com/KisinTheFlame/kagami/pull/85) 的 `migrate-pg-to-sqlite.ts` 只迁了 11 张「关键表」，漏了 8 张被当成「瞬时数据」的表——但其中包含**群消息历史**（napcat_qq_message）、**LLM 调用历史**（llm_chat_call）、指标、事件、应用日志等，前端观测页都依赖它们。生产切换后这些页面全空了。

生产侧已用追加脚本即时补迁（所有 19 张表现已 SQLite ≥ PG、无缺失）。本 PR 把这个修正固化进仓库脚本。

## 改动

- **`migrate-pg-to-sqlite.ts`**：由 11 张表补全为**全部 19 张表**（新增 app_log / llm_chat_call / metric / napcat_event / napcat_qq_message / auth_usage_snapshot / oauth_state / terminal_output）。
- **分页防 OOM**：大表按整型 id 分页流式读 PG，不再一次性 `SELECT *` 整表读入内存（llm_chat_call 单条 request_payload 实测可达 ~1MB，整表读入会 exit 134 OOM）。`llm_chat_call` 批 50、napcat 批 300、其余 500。
- **保留原始 id + Json/DateTime 经 Prisma 写入**，与运行时读取格式一致。
- **新增 `migrate-pg-remaining-append.ts`**：在**已上线运行**的 SQLite 上「不清空、按 id 自增追加」补迁个别表（幂等：表行数已 ≥ PG 则跳过）。用于本次这种「整库已切换、只需补漏」的场景，避免整库重灌回滚掉切换后的新数据。

## 验证

- `pnpm lint` / `pnpm typecheck` / `pnpm format` 全绿。
- append 脚本已在生产实跑：8 张漏表共 ~5.5 万行全部补回，最终 19 张表 SQLite ≥ PG。

🤖 Generated with [Claude Code](https://claude.com/claude-code)