### PR TITLE
build(prisma): generate 解耦 config.yaml，build / typecheck 不再依赖运行时配置

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Changed
 
+- build/config: `prisma generate`（及 `pnpm build` / `typecheck`）不再依赖 `config.yaml`——`scripts/prisma.sh` 对 `generate` 子命令改用占位 `DATABASE_URL`，让纯代码生成 / 类型检查与运行时配置解耦；连库命令（`migrate` / `db push` 等）仍读真实 `server.databaseUrl`，缺失即报错不静默兜底。便于 CI / 全新 clone 在没有 `config.yaml` 时直接跑 build / typecheck（[#91](https://github.com/KisinTheFlame/kagami/pull/91)）
 - agent: 顶层 `news` 模块塌缩为 `ithome` capability，消除"多源资讯"泛化。抓取 / 存储 / 轮询本体迁入 `agent/capabilities/ithome`（对标 `terminal` 范式的能力本体 + App 壳分层），App 壳保留在 `agent/apps/ithome`；删除 `source_key` 多源抽象：`IthomeNewsService`→`IthomeService`、表 `news_article` / `news_feed_cursor`→`ithome_article` / `ithome_feed_cursor`（游标退化为单行表）、事件 `news_article_ingested`→`ithome_article_ingested`、配置 `server.news.ithome`→`server.ithome`；迁移 `collapse_news_into_ithome` 以 rename + `INSERT SELECT` 保留已抓取文章与已读游标
 - server: 数据库由外部 PostgreSQL + pgvector 迁移到**进程内 SQLite + hnswlib-node**，宿主机不再需要运行独立数据库。ORM 仍是 Prisma（adapter 换 `@prisma/adapter-better-sqlite3`）；schema 去掉 PG 专有类型，`EmbeddingCache.embedding` 与向量列改 `String`(JSON)；向量检索改进程内 HNSW（SQLite 为唯一事实来源、启动时重建）；metric / napcat / app-log 的原生 SQL 改写为 SQLite 方言；持久化数据统一进 `data/`（`sqlite/`、`vector/`）；重建 Prisma 迁移基线；旧 PostgreSQL 数据经一次性脚本搬迁（脚本不随仓库留存）（[#85](https://github.com/KisinTheFlame/kagami/pull/85)）
 - agent: Wake Reminder 由每分钟降频为每半小时一次，同一半小时窗口（00 / 30 分桶）内的多轮 round 共享去重 key、不再重复追加；展示的时间值仍是真实触发时刻；长会话尾部 `system_reminder` 噪声减少约 30 倍，对 KV 缓存更友好（[#77](https://github.com/KisinTheFlame/kagami/pull/77)）

--- a/scripts/prisma.sh
+++ b/scripts/prisma.sh
@@ -3,20 +3,27 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SERVER_DIR="$ROOT_DIR/apps/server"
-DATABASE_URL="$(node "$ROOT_DIR/scripts/read-config.mjs" server.databaseUrl)"
-
-# SQLite：确保库文件父目录存在，否则 prisma migrate/db push 会因目录缺失失败。
-if [[ "$DATABASE_URL" == file:* ]]; then
-  db_file="${DATABASE_URL#file:}"
-  if [ "$db_file" != ":memory:" ]; then
-    mkdir -p "$(dirname "$db_file")"
-  fi
-fi
 
 if [ "$#" -eq 0 ]; then
   echo "Usage: scripts/prisma.sh <prisma args...>"
   echo "Example: scripts/prisma.sh migrate status"
   exit 1
+fi
+
+# prisma generate 是纯代码生成、不连库——它只要求 DATABASE_URL 有值（schema
+# datasource 走 env("DATABASE_URL")）。用占位 URL 跳过 config.yaml，让 build /
+# typecheck 与运行时配置解耦；连库命令（migrate / db push 等）仍读真实配置。
+if [ "$1" = "generate" ]; then
+  DATABASE_URL="file:./.prisma-generate-placeholder"
+else
+  DATABASE_URL="$(node "$ROOT_DIR/scripts/read-config.mjs" server.databaseUrl)"
+  # SQLite：确保库文件父目录存在，否则 prisma migrate/db push 会因目录缺失失败。
+  if [[ "$DATABASE_URL" == file:* ]]; then
+    db_file="${DATABASE_URL#file:}"
+    if [ "$db_file" != ":memory:" ]; then
+      mkdir -p "$(dirname "$db_file")"
+    fi
+  fi
 fi
 
 prisma_args=("$@")


### PR DESCRIPTION
## 概述

`prisma generate` 是纯代码生成、**不连数据库**,它只要求 `DATABASE_URL` 这个环境变量**有值**(schema datasource 走 `env("DATABASE_URL")`)。但此前 `scripts/prisma.sh` 对所有子命令(含 generate)都先从 `config.yaml` 读 `server.databaseUrl`,而 `config.yaml` 被 gitignore——导致 `pnpm build` / `typecheck`(都会跑 `db:generate`)在没有 `config.yaml` 的环境(CI、全新 clone)里直接报 `未找到 config.yaml`。

本 PR 把 `generate` 子命令改用占位 `DATABASE_URL`、跳过 `config.yaml` 读取,让**纯代码生成 / 类型检查与运行时配置解耦**。

## 改动

- `scripts/prisma.sh`:`generate` → 占位 `DATABASE_URL=file:./.prisma-generate-placeholder`(占位库永不被创建,因为 generate 不连接);其余命令(`migrate` / `db push` 等)**不变**,仍读真实 `server.databaseUrl`,**缺失即报错、不静默兜底**。
- 顺带把 usage 检查提前到读配置之前(之前无参数也会先读一次 config)。

## 为什么修在这里

`prisma.sh` 是唯一同时知道"当前是哪个子命令" + "config 在哪"的组件,所以特判只能落在这里。没有把默认值塞进 `prisma.config.ts`——那样 `migrate` 在 config 缺失时会静默退到占位库,是埋雷。

## 边界(诚实说明)

- 运行服务本身、`migrate`、以及 4 个读 config loader 的测试,**仍需要** `config.yaml` 里的 `databaseUrl`(它是必填非空的运行时配置)。本 PR 只解耦 build / typecheck。

## 验证

- `bash -x scripts/prisma.sh generate`:确认 `read-config.mjs` **未被调用**、用占位 URL、client 正常生成。
- `migrate status` 路径:确认仍调用 `read-config.mjs`。
- `pnpm build` / `typecheck` / `lint` / `format`:全绿。
- `pnpm test`:server 507 + agent-runtime 26 全通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)