### PR TITLE
ci: 新增 GitHub Actions（build/typecheck/lint/format/test 门禁）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+# 同一分支的新推送取消仍在跑的旧 run，节省 CI 时间。
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      # pnpm/action-setup 读 package.json 的 packageManager 字段，安装对应版本 pnpm。
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # build / typecheck / lint / format / test 全部 config-free：
+      # prisma generate 用占位 DATABASE_URL（见 scripts/prisma.sh），测试不读运行时 config。
+      - name: Build
+        run: pnpm build
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Format check
+        run: pnpm format
+
+      - name: Test
+        run: pnpm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Added
 
+- ci: 新增 GitHub Actions CI（`.github/workflows/ci.yml`），在 PR 与 master push 上跑 `build` / `typecheck` / `lint` / `format` / `test` 全套门禁，把"提交前手动跑四件套"变成强制关卡。整条门 config-free（`prisma generate` 用占位 `DATABASE_URL`、测试不读运行时 config），CI 无需伪造 `config.yaml`；Node 22 + pnpm（走 `packageManager` 字段），原生依赖（better-sqlite3 / hnswlib-node 等）按 `pnpm-workspace.yaml` 的 `onlyBuiltDependencies` 编译（[#92](https://github.com/KisinTheFlame/kagami/pull/92)）
 - agent: 新增 `hn` App，给小镜一个只读的 Hacker News 地点（agency 优先：进门不自动拉榜、无未读提醒，想看才看，区别于 ithome 的"推未读"节奏）。4 个 InvokeTool 子工具 `glance_hn` / `open_hn_thread` / `search_hn` / `open_hn_user`，顶层工具集不变（KV 稳定前缀）；feed 列表用官方 Firebase API、评论树与搜索用 Algolia API（搜索 / 嵌套评论树 / 用户主页都是 RSS 做不到、HN 原生的能力）；整个 App 自包含在 `agent/apps/hn`（无轮询 / 无 DB / 无 cursor，刻意不照搬 ithome 的 RSS 驱动结构）；`open_hn_thread` 按最热闹子树优先 + 限深限量 + 字符预算截断；所有 HN 文本过 `htmlToPlainText` 清洗（去标签 / 解码实体 / 软化尖括号）防上下文结构注入；onFocus 只返静态提示屏、无网络 I/O（[#86](https://github.com/KisinTheFlame/kagami/pull/86)）
 - agent-runtime: 为此前零测试的核心包 `@kagami/agent-runtime` 补上 vitest 测试基建，新增 26 条不变量测试，直接测源码、不依赖构建；覆盖 Effect 解释器（`ReplaceLeadingMessages` 唯一前缀重建路径且传副本、无匹配 / Noop 收到 effect 即抛绝不静默吞）、事件队列（FIFO、一次 enqueue 唤醒全部 waiter）、串行执行器（严格串行不交错、单任务抛错隔离）、`ZodToolComponent`（非法参数永不进 `executeTyped`、业务抛错转结构化结果）；根目录 `pnpm test` 现已覆盖该包（[#87](https://github.com/KisinTheFlame/kagami/pull/87)）
 - agent: 新增 `clock` App，提供 `view_time` 工具让 Agent 主动查询当前北京时间（精确到秒）；与 Wake Reminder 降频（[#77](https://github.com/KisinTheFlame/kagami/pull/77)）形成被动 + 主动的时间感知闭环（[#79](https://github.com/KisinTheFlame/kagami/pull/79)）

--- a/apps/server/test/agent/terminal.service.test.ts
+++ b/apps/server/test/agent/terminal.service.test.ts
@@ -270,13 +270,18 @@ describe("TerminalService", () => {
 
     it("cd ~/subdir resolves tilde BEFORE path.resolve (P1 fix)", async () => {
       const homedir = (await import("node:os")).default.homedir();
-      const sub = path.join(homedir, "kagami");
-      // ~/kagami should exist because TerminalService.initialize creates it
-      const { service } = await makeService({ initialCwd: tmpRoot });
-      const result = await service.runBash({ command: "cd ~/kagami" });
-      expect(result.ok).toBe(true);
-      if (!result.ok) return;
-      expect(service.getCwd()).toBe(sub);
+      // 自建 $HOME 下的唯一临时目录再 cd 进去，而不是假设预先存在的 ~/kagami——
+      // 后者只在开发机上恰好存在，干净 CI runner 上没有会导致 cd 失败。
+      const sub = await mkdtemp(path.join(homedir, "kagami-tilde-test-"));
+      try {
+        const { service } = await makeService({ initialCwd: tmpRoot });
+        const result = await service.runBash({ command: `cd ~/${path.basename(sub)}` });
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        expect(service.getCwd()).toBe(sub);
+      } finally {
+        await rm(sub, { recursive: true, force: true });
+      }
     });
 
     it("multi-command (cd a && ls) is NOT intercepted and does not update state.cwd", async () => {


### PR DESCRIPTION
## 概述

加 GitHub Actions CI,把 `pnpm build / typecheck / lint / format / test` 从"提交前手动记得跑"变成 PR 上的强制关卡。

## 关键设计

- **整条门 config-free**:`prisma generate` 已改用占位 `DATABASE_URL`(#91),测试经核实不读运行时 config(只用类型导入 / 自写临时 fixture),所以 CI **不需要伪造 `config.yaml`**。workflow 里没有 `cp config.yaml.example` 这类步骤。
- **pnpm 版本**走 `package.json` 的 `packageManager` 字段(`pnpm/action-setup@v4` 自动读),不写死。
- **Node 22 LTS**:本机是 25 太新,固定 LTS 让原生依赖(better-sqlite3 / hnswlib-node)更可能命中预编译;ubuntu-latest 自带 build-essential + python3 兜底源码编译。
- 原生依赖编译靠 `pnpm-workspace.yaml` 既有的 `onlyBuiltDependencies` 允许列表。
- 加了 `concurrency` 取消同分支旧 run + `timeout-minutes: 20`。

## 触发

- `pull_request`(验证 PR)
- `push: master`(合并后留绿/红信号)

## 本地预演

`build` / `typecheck` / `lint` / `format` / `test` 本地全绿(server 507 + agent-runtime 26);`pnpm install --frozen-lockfile` 与 prettier 对 `.github/workflows/ci.yml` 均通过。首次真机 run 的唯一未知点是 hnswlib-node 在 Node 22 上的原生编译——这条 PR 本身的 CI run 就是验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)