### PR TITLE
feat(agent): 被动 NotificationCenter + IThome 文章改走通知（手机 OS 模型 PR1）

### DIFF
--- a/apps/server/src/agent/apps/ithome/ithome-notification-draft.ts
+++ b/apps/server/src/agent/apps/ithome/ithome-notification-draft.ts
@@ -1,0 +1,32 @@
+import type { NotificationDraft } from "../../runtime/root-agent/notification/notification-draft.js";
+import { ITHOME_APP_ID } from "./ithome.app.js";
+
+/**
+ * IT之家的后台通知 draft（手机 OS 模型）。
+ *
+ * 一个窗口内来的多篇文章折叠成一条：`IT之家：N篇新文，最新《标题》`。
+ * 折叠约定 this = 最新、prev = 历史：标题取最新、篇数累加。
+ */
+export class IthomeNotificationDraft implements NotificationDraft {
+  public readonly sourceId = ITHOME_APP_ID;
+  public readonly displayName = "IT之家";
+  private readonly count: number;
+  private readonly latestTitle: string;
+
+  public constructor({ title, count = 1 }: { title: string; count?: number }) {
+    this.latestTitle = title;
+    this.count = count;
+  }
+
+  public merge(prev: NotificationDraft): NotificationDraft {
+    const previous = prev as IthomeNotificationDraft;
+    return new IthomeNotificationDraft({
+      title: this.latestTitle,
+      count: previous.count + this.count,
+    });
+  }
+
+  public render(): string {
+    return `IT之家：${this.count}篇新文，最新《${this.latestTitle}》`;
+  }
+}

--- a/apps/server/src/agent/runtime/context/context-message-factory.ts
+++ b/apps/server/src/agent/runtime/context/context-message-factory.ts
@@ -169,6 +169,14 @@ export function createCrossStateNotificationMessage(
   return createUserMessage(lines.join("\n"));
 }
 
+/**
+ * 手机 OS 模型的统一通知消息：NotificationCenter 聚合后每源一行，包在
+ * `<notification>` 标签里追加到上下文尾部。`lines` 已由各源 Draft 渲染好。
+ */
+export function createNotificationMessage(lines: string[]): UserMessage {
+  return createUserMessage(["<notification>", ...lines, "</notification>"].join("\n"));
+}
+
 export function createStoryRecallMessage(
   stories: Array<{ id: string; markdown: string; createdAt: Date }>,
 ): UserMessage {
@@ -400,9 +408,9 @@ export function createMessagesFromEvent(event: Event): UserMessage[] {
       return [createUserMessage(renderPrivateMessagePlainText(event.data))];
     case "napcat_friend_list_updated":
       return [];
-    case "ithome_article_ingested":
-      return [];
     default:
+      // `notification` 事件不走这里——它由 session 直接装配成 <notification> 消息
+      // 追加（createNotificationMessage），不是 event 类 ContextItem。
       return [];
   }
 }

--- a/apps/server/src/agent/runtime/context/default-agent-context.ts
+++ b/apps/server/src/agent/runtime/context/default-agent-context.ts
@@ -248,13 +248,15 @@ function summarizeEvent(event: Event, previewLength: number): AgentContextDashbo
         preview: "",
         truncated: false,
       };
-    case "ithome_article_ingested":
+    case "notification": {
+      const summary = truncateText(event.data.lines.join("；"), previewLength);
       return {
         kind: "event",
-        label: "资讯文章事件",
-        preview: truncateText(`IT之家新文章：${event.data.title}`, previewLength).text,
-        truncated: truncateText(`IT之家新文章：${event.data.title}`, previewLength).truncated,
+        label: "通知事件",
+        preview: summary.text,
+        truncated: summary.truncated,
       };
+    }
     default:
       return {
         kind: "event",

--- a/apps/server/src/agent/runtime/event/event.ts
+++ b/apps/server/src/agent/runtime/event/event.ts
@@ -21,11 +21,17 @@ export type NapcatFriendListUpdatedEvent = {
   };
 };
 
-export type IthomeArticleIngestedEvent = {
-  type: "ithome_article_ingested";
+/**
+ * 聚合后的通知事件，由 NotificationCenter 在窗口 flush 时塞进事件队列（手机 OS
+ * 模型里 center 是 App→Agent 的唯一桥）。每个 source 一行 `lines`。Session 路由时
+ * 装配成一条 `<notification>` user message 追加到上下文尾部，并触发一轮 round。
+ * 这条事件进队列本身就是「唤醒」——见 Queue 的 wake-up generality。
+ */
+export type NotificationEvent = {
+  type: "notification";
   data: {
-    articleId: number;
-    title: string;
+    /** 每个源一行，已渲染好的展示文本。 */
+    lines: string[];
   };
 };
 
@@ -62,6 +68,6 @@ export type Event =
   | NapcatGroupMessageEvent
   | NapcatPrivateMessageEvent
   | NapcatFriendListUpdatedEvent
-  | IthomeArticleIngestedEvent
+  | NotificationEvent
   | StoryRecallCompletedEvent
   | WakeEvent;

--- a/apps/server/src/agent/runtime/root-agent/notification/notification-center.ts
+++ b/apps/server/src/agent/runtime/root-agent/notification/notification-center.ts
@@ -1,0 +1,84 @@
+import { AppLogger } from "../../../../logger/logger.js";
+import type { NotificationDraft } from "./notification-draft.js";
+import { type NotificationScheduler, RealNotificationScheduler } from "./notification-scheduler.js";
+
+const logger = new AppLogger({ source: "agent.notification-center" });
+
+type NotificationCenterDeps = {
+  /** 攒批时间窗（毫秒）：第一条 push 起窗，窗到了 flush。 */
+  windowMs: number;
+  /**
+   * flush 时把渲染好的多行通知交出去（每源一行）。调用方负责把它塞进事件队列
+   * （在手机 OS 模型里：enqueue 一个 `notification` 事件，既投递内容也唤醒 Agent）。
+   */
+  onFlush: (lines: string[]) => void;
+  /** 定时器端口；缺省用真实 setTimeout。测试注入确定性假实现。 */
+  scheduler?: NotificationScheduler;
+};
+
+/**
+ * 被动、同步、源无关的通知中心（手机 OS 模型）。
+ *
+ * - `push(draft)`：谁都能调、不挑调用者；同 source 折叠（`draft.merge(prev)`）。
+ *   同步操作（只 `Map.set`），Node 单线程下与 flush 无竞争。
+ * - setTimeout-on-first-push：pending 从空变非空时起一个窗口，窗到了 flush。
+ * - `flush`：渲染所有 draft 成行，交给 `onFlush`；**防御性**——单个 draft 的
+ *   `render` 抛错只跳过它、不炸整个 flush。
+ * - `clearForSource`：清掉某源的待发（焦点进入该源时用）。
+ *
+ * 设计依据：手机 OS 模型设计文档（NotificationCenter）。
+ */
+export class NotificationCenter {
+  private readonly pending = new Map<string, NotificationDraft>();
+  private readonly windowMs: number;
+  private readonly onFlush: (lines: string[]) => void;
+  private readonly scheduler: NotificationScheduler;
+  private flushScheduled = false;
+
+  public constructor({ windowMs, onFlush, scheduler }: NotificationCenterDeps) {
+    this.windowMs = windowMs;
+    this.onFlush = onFlush;
+    this.scheduler = scheduler ?? new RealNotificationScheduler();
+  }
+
+  public push(draft: NotificationDraft): void {
+    const prev = this.pending.get(draft.sourceId);
+    // this = 最新、prev = 历史：见 NotificationDraft 折叠约定。
+    this.pending.set(draft.sourceId, prev ? draft.merge(prev) : draft);
+    if (!this.flushScheduled) {
+      this.flushScheduled = true;
+      this.scheduler.schedule(this.windowMs, () => this.flush());
+    }
+  }
+
+  public clearForSource(sourceId: string): void {
+    this.pending.delete(sourceId);
+  }
+
+  private flush(): void {
+    this.flushScheduled = false;
+    if (this.pending.size === 0) {
+      return;
+    }
+    const drafts = [...this.pending.values()];
+    this.pending.clear();
+
+    const lines: string[] = [];
+    for (const draft of drafts) {
+      try {
+        lines.push(draft.render());
+      } catch (error) {
+        // 防御性：单个 draft 渲染抛错只跳过它，不影响其余源、不炸 flush。
+        logger.warn("Notification draft render failed; skipping", {
+          sourceId: draft.sourceId,
+          errorName: error instanceof Error ? error.name : "Error",
+          errorMessage: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    if (lines.length > 0) {
+      this.onFlush(lines);
+    }
+  }
+}

--- a/apps/server/src/agent/runtime/root-agent/notification/notification-draft.ts
+++ b/apps/server/src/agent/runtime/root-agent/notification/notification-draft.ts
@@ -1,0 +1,23 @@
+/**
+ * 一条待发通知的「源自定义」表示（手机 OS 模型）。
+ *
+ * NotificationCenter 是被动、源无关的：它只按 `sourceId` 归组、按 `merge` 折叠、
+ * 调 `render` 渲染，完全不懂任何具体源（ithome / 聊天 …）的语义。所有语义都落在
+ * 各源自己实现的 Draft 里。
+ *
+ * 折叠约定（重要）：`merge(prev)` 里 **this = 最新、prev = 历史**。显示字段取
+ * `this`（最新那条），粘性 / 累计字段从 `prev` 继承。这样 survivor（最新对象）
+ * 上每个字段都有意义，merge 体里只出现「依赖历史」的字段。
+ *
+ * 设计依据：手机 OS 模型设计文档（NotificationCenter / 折叠契约）。
+ */
+export interface NotificationDraft {
+  /** 不透明源标识（appId / stateId）。NotificationCenter 按它归组、折叠、清空。 */
+  readonly sourceId: string;
+  /** 给人看的源短名，渲染时可用。 */
+  readonly displayName: string;
+  /** 把同源的历史 draft 折叠进来。this = 最新、prev = 历史。 */
+  merge(prev: NotificationDraft): NotificationDraft;
+  /** 折成一行展示文本（flush 时调用）。 */
+  render(): string;
+}

--- a/apps/server/src/agent/runtime/root-agent/notification/notification-scheduler.ts
+++ b/apps/server/src/agent/runtime/root-agent/notification/notification-scheduler.ts
@@ -1,0 +1,20 @@
+/**
+ * NotificationCenter 的定时器端口。
+ *
+ * 抽出来是为了**确定性测试**：生产用真实 setTimeout，测试注入一个能手动「推进
+ * 窗口」的假实现，不依赖全局假时钟。设计依据：手机 OS 模型设计文档（PR1 / center
+ * 可测性，eng-review Finding 1）。
+ */
+export interface NotificationScheduler {
+  /** 安排 fn 在 delayMs 后执行一次。center 每个窗口至多调一次。 */
+  schedule(delayMs: number, fn: () => void): void;
+}
+
+/** 生产实现：setTimeout，并 unref 掉——后台 flush 定时器不应拖住进程退出。 */
+export class RealNotificationScheduler implements NotificationScheduler {
+  public schedule(delayMs: number, fn: () => void): void {
+    const timer = setTimeout(fn, delayMs);
+    // 通知非关键：关停时丢弃一条待发通知可接受，不让它 hold 住事件循环。
+    timer.unref();
+  }
+}

--- a/apps/server/src/agent/runtime/root-agent/session/root-agent-session.ts
+++ b/apps/server/src/agent/runtime/root-agent/session/root-agent-session.ts
@@ -3,6 +3,7 @@ import type { AgentContext } from "../../context/agent-context.js";
 import type { LlmMessage } from "../../../../llm/types.js";
 import {
   createCrossStateNotificationMessage,
+  createNotificationMessage,
   createStateSystemReminderMessage,
   createStoryRecallMessage,
   createUserMessage,
@@ -355,6 +356,15 @@ export class RootAgentSession implements RootAgentSessionController, RootAgentSt
 
     if (event.type === "story_recall_completed") {
       this.pendingIncomingMessages.push(createStoryRecallMessage(event.data.stories));
+      return {
+        shouldTriggerRound: true,
+      };
+    }
+
+    if (event.type === "notification") {
+      // NotificationCenter 聚合后塞进队列的统一通知（手机 OS 模型）。装配成一条
+      // <notification> 消息追加到尾部，触发一轮 round。
+      this.pendingIncomingMessages.push(createNotificationMessage(event.data.lines));
       return {
         shouldTriggerRound: true,
       };
@@ -725,12 +735,6 @@ export class RootAgentSession implements RootAgentSessionController, RootAgentSt
   }
 
   private resolveEventStateId(event: Event): RootAgentStateId | null {
-    if (event.type === "ithome_article_ingested") {
-      // ithome 文章事件不再走状态树——IthomeApp 自己管 unread 计数（PoC 阶段未实现，
-      // 等通知系统设计成熟后再处理）。这里直接忽略。
-      return null;
-    }
-
     if (event.type === "napcat_group_message") {
       return this.groupStateById.has(event.data.groupId)
         ? createQqGroupStateId(event.data.groupId)
@@ -740,8 +744,11 @@ export class RootAgentSession implements RootAgentSessionController, RootAgentSt
     if (
       event.type === "napcat_friend_list_updated" ||
       event.type === "wake" ||
-      event.type === "story_recall_completed"
+      event.type === "story_recall_completed" ||
+      event.type === "notification"
     ) {
+      // notification 已在 consumeIncomingEvent 顶层处理、不会走到这里；列出仅为
+      // 让 TS 在落到下方私聊兜底分支前把它收窄掉。
       return null;
     }
 

--- a/apps/server/src/app/server-runtime.ts
+++ b/apps/server/src/app/server-runtime.ts
@@ -57,6 +57,8 @@ import { PrismaIthomeFeedCursorDao } from "../agent/capabilities/ithome/infra/pr
 import { DefaultIthomeClient } from "../agent/capabilities/ithome/application/ithome-client.js";
 import { IthomeService } from "../agent/capabilities/ithome/application/ithome.service.js";
 import { IthomePoller } from "../agent/capabilities/ithome/application/ithome-poller.js";
+import { IthomeNotificationDraft } from "../agent/apps/ithome/ithome-notification-draft.js";
+import { NotificationCenter } from "../agent/runtime/root-agent/notification/notification-center.js";
 import { StoryHandler } from "../ops/http/story.handler.js";
 import type { MetricService } from "../metric/application/metric.service.js";
 import { DefaultMetricService } from "../metric/application/metric.impl.service.js";
@@ -217,6 +219,14 @@ export async function buildServerRuntime(): Promise<ServerRuntime> {
   });
   const eventQueue = new InMemoryQueue<Event>();
   const storyEventQueue = new InMemoryQueue<StoryAgentEvent>();
+  // 手机 OS 模型：被动通知中心。各源（这里是 ithome poller）向它 push draft，它窗口
+  // 聚合后把一条 notification 事件塞进事件队列——既投递内容也唤醒 Agent。
+  const notificationCenter = new NotificationCenter({
+    windowMs: config.server.agent.notificationBatchWindowMs,
+    onFlush: lines => {
+      eventQueue.enqueue({ type: "notification", data: { lines } });
+    },
+  });
   const ithomeService = new IthomeService({
     articleDao: ithomeArticleDao,
     cursorDao: ithomeFeedCursorDao,
@@ -228,13 +238,7 @@ export async function buildServerRuntime(): Promise<ServerRuntime> {
     ithomeService,
     pollIntervalMs: config.server.ithome.pollIntervalMs,
     onArticleIngested: article => {
-      eventQueue.enqueue({
-        type: "ithome_article_ingested",
-        data: {
-          articleId: article.articleId,
-          title: article.title,
-        },
-      });
+      notificationCenter.push(new IthomeNotificationDraft({ title: article.title }));
     },
   });
   const napcatGatewayService = await DefaultNapcatGatewayService.create({

--- a/apps/server/test/agent/apps/ithome/ithome-notification-draft.test.ts
+++ b/apps/server/test/agent/apps/ithome/ithome-notification-draft.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { IthomeNotificationDraft } from "../../../../src/agent/apps/ithome/ithome-notification-draft.js";
+
+describe("IthomeNotificationDraft", () => {
+  it("renders a single article with sourceId 'ithome'", () => {
+    const draft = new IthomeNotificationDraft({ title: "某标题" });
+    expect(draft.sourceId).toBe("ithome");
+    expect(draft.render()).toBe("IT之家：1篇新文，最新《某标题》");
+  });
+
+  it("folds via merge(prev): count accumulates, title takes the latest", () => {
+    const older = new IthomeNotificationDraft({ title: "旧标题" });
+    const newer = new IthomeNotificationDraft({ title: "新标题" });
+    // center 的调用约定：newer.merge(older)，this = 最新、prev = 历史。
+    const merged = newer.merge(older);
+    expect(merged.render()).toBe("IT之家：2篇新文，最新《新标题》");
+  });
+});

--- a/apps/server/test/agent/notification-center.test.ts
+++ b/apps/server/test/agent/notification-center.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from "vitest";
+import { NotificationCenter } from "../../src/agent/runtime/root-agent/notification/notification-center.js";
+import type { NotificationDraft } from "../../src/agent/runtime/root-agent/notification/notification-draft.js";
+import type { NotificationScheduler } from "../../src/agent/runtime/root-agent/notification/notification-scheduler.js";
+import { initTestLoggerRuntime } from "../helpers/logger.js";
+
+initTestLoggerRuntime();
+
+/** 确定性假定时器：捕获 center 安排的 flush，由测试手动「推进窗口」。 */
+class FakeScheduler implements NotificationScheduler {
+  private fns: Array<() => void> = [];
+
+  public schedule(_delayMs: number, fn: () => void): void {
+    this.fns.push(fn);
+  }
+
+  public fire(): void {
+    const fns = this.fns;
+    this.fns = [];
+    for (const fn of fns) {
+      fn();
+    }
+  }
+
+  public scheduledCount(): number {
+    return this.fns.length;
+  }
+}
+
+/**
+ * 最小可控 draft，用来测 center 的**源无关机制**。具体折叠语义（计数 / @ 粘住等）
+ * 由各源自己的 draft 测试覆盖。
+ */
+class FakeDraft implements NotificationDraft {
+  public constructor(
+    public readonly sourceId: string,
+    public readonly displayName: string,
+    private readonly text: string,
+    private readonly throwOnRender = false,
+  ) {}
+
+  public merge(prev: NotificationDraft): NotificationDraft {
+    const previous = prev as FakeDraft;
+    // this = 最新；把历史文本拼上，证明 merge 确实收到了 prev。
+    return new FakeDraft(this.sourceId, this.displayName, `${previous.text}+${this.text}`);
+  }
+
+  public render(): string {
+    if (this.throwOnRender) {
+      throw new Error("render boom");
+    }
+    return `${this.displayName}: ${this.text}`;
+  }
+}
+
+describe("NotificationCenter", () => {
+  it("flushes one line per source after the window, not before", () => {
+    const scheduler = new FakeScheduler();
+    const onFlush = vi.fn();
+    const center = new NotificationCenter({ windowMs: 100, onFlush, scheduler });
+
+    center.push(new FakeDraft("a", "A", "1"));
+    center.push(new FakeDraft("b", "B", "2"));
+    expect(onFlush).not.toHaveBeenCalled();
+
+    scheduler.fire();
+    expect(onFlush).toHaveBeenCalledTimes(1);
+    expect(onFlush).toHaveBeenCalledWith(["A: 1", "B: 2"]);
+  });
+
+  it("folds same-source pushes within a window via merge(prev)", () => {
+    const scheduler = new FakeScheduler();
+    const onFlush = vi.fn();
+    const center = new NotificationCenter({ windowMs: 100, onFlush, scheduler });
+
+    center.push(new FakeDraft("a", "A", "1"));
+    center.push(new FakeDraft("a", "A", "2"));
+    // 第一条 push 起窗，后续同窗不重排。
+    expect(scheduler.scheduledCount()).toBe(1);
+
+    scheduler.fire();
+    // merge：this = 最新("2")、prev = 历史("1") → "1+2"。
+    expect(onFlush).toHaveBeenCalledWith(["A: 1+2"]);
+  });
+
+  it("does not enqueue when pending was cleared before the window fired", () => {
+    const scheduler = new FakeScheduler();
+    const onFlush = vi.fn();
+    const center = new NotificationCenter({ windowMs: 100, onFlush, scheduler });
+
+    center.push(new FakeDraft("a", "A", "1"));
+    center.clearForSource("a");
+    scheduler.fire();
+    expect(onFlush).not.toHaveBeenCalled();
+  });
+
+  it("is defensive: a draft whose render throws is skipped, others still flush", () => {
+    const scheduler = new FakeScheduler();
+    const onFlush = vi.fn();
+    const center = new NotificationCenter({ windowMs: 100, onFlush, scheduler });
+
+    center.push(new FakeDraft("a", "A", "1", true));
+    center.push(new FakeDraft("b", "B", "2"));
+    scheduler.fire();
+    expect(onFlush).toHaveBeenCalledWith(["B: 2"]);
+  });
+
+  it("starts a fresh window after a flush", () => {
+    const scheduler = new FakeScheduler();
+    const onFlush = vi.fn();
+    const center = new NotificationCenter({ windowMs: 100, onFlush, scheduler });
+
+    center.push(new FakeDraft("a", "A", "1"));
+    scheduler.fire();
+    expect(onFlush).toHaveBeenCalledTimes(1);
+
+    center.push(new FakeDraft("a", "A", "3"));
+    expect(scheduler.scheduledCount()).toBe(1);
+    scheduler.fire();
+    expect(onFlush).toHaveBeenCalledTimes(2);
+    expect(onFlush).toHaveBeenLastCalledWith(["A: 3"]);
+  });
+});

--- a/apps/server/test/agent/root-agent-session.test.ts
+++ b/apps/server/test/agent/root-agent-session.test.ts
@@ -232,6 +232,30 @@ describe("RootAgentSession", () => {
     expect(reminderMessages.at(-1)?.content).toContain("未读 1 条消息");
   });
 
+  it("should append a <notification> message and trigger a round on notification events", async () => {
+    const context = new DefaultAgentContext({
+      systemPromptFactory: () => "system-prompt",
+    });
+    const session = createSession({ context });
+
+    await session.initializeContext();
+    const consumeResult = await session.consumeIncomingEvent({
+      type: "notification",
+      data: { lines: ["IT之家：2篇新文，最新《某标题》"] },
+    });
+    const flushResult = await session.flushPendingIncomingEffects();
+
+    expect(consumeResult).toEqual({ shouldTriggerRound: true });
+    expect(flushResult).toEqual({ shouldTriggerRound: true });
+
+    const snapshot = await context.getSnapshot();
+    const notificationMessage = snapshot.messages.find(
+      message => typeof message.content === "string" && message.content.includes("<notification>"),
+    );
+    expect(notificationMessage?.content).toContain("IT之家：2篇新文，最新《某标题》");
+    expect(notificationMessage?.content).toContain("</notification>");
+  });
+
   // NOTE: wait-overlay tests removed. Under the new event-driven model the
   // session has no concept of a waiting state — the wait tool blocks directly
   // on the event queue, and session state is unchanged while the tool is

--- a/apps/server/test/context/context-message-factory.test.ts
+++ b/apps/server/test/context/context-message-factory.test.ts
@@ -4,6 +4,7 @@ import {
   createIthomeArticleDetailMessage,
   createIthomeArticleListMessage,
   createMergedGroupMessagesMessage,
+  createNotificationMessage,
   createPortalSnapshotMessage,
   createRootContextSummaryReminderMessage,
   createStateSystemReminderMessage,
@@ -18,6 +19,16 @@ describe("context-message-factory", () => {
     expect(createWakeReminderMessage(new Date("2026-03-09T10:21:00.000Z"))).toEqual({
       role: "user",
       content: "<system_reminder>当前时间为北京时间 2026 年 3 月 9 日 18:21</system_reminder>",
+    });
+  });
+
+  it("should wrap notification lines in the notification tag, one line per source", () => {
+    expect(
+      createNotificationMessage(["IT之家：2篇新文，最新《某标题》", "产品群：[有人@你] 在吗"]),
+    ).toEqual({
+      role: "user",
+      content:
+        "<notification>\nIT之家：2篇新文，最新《某标题》\n产品群：[有人@你] 在吗\n</notification>",
     });
   });
 


### PR DESCRIPTION
## 这是什么

把「Agent 接收生活输入」重做成**手机 OS 模型**的第一步（PR1）。纯追加、不动顶层工具集/稳定前缀，KV 缓存零影响。

经两轮 office-hours + plan-eng-review 定稿，设计为：每个输入源是自包含 App，自己 push 通知到一个**被动的 NotificationCenter**，center 聚合后作为 App→Agent 的唯一桥把通知塞进事件队列。PR1 先把 center 立住并用 IThome 验证；聊天 App 化（PR2）后再把聊天通知并入 center。

## 改了什么

- **NotificationCenter**（新）：被动、同步、源无关。`push(draft)` 谁都能调；按 source 折叠（`Draft.merge(prev)`，this=最新/prev=历史）；setTimeout-on-first-push 窗口聚合后**由 center 自己** enqueue 一个 `notification` 事件——既投递内容也唤醒 Agent（复用 `Queue` 的 wake-up generality，无需独立 wake 通道）；**防御性 flush**（单 draft 渲染抛错只跳过）；定时器经注入端口 `NotificationScheduler` 以确定性测试。
- **NotificationDraft** 折叠契约（新）+ **IthomeNotificationDraft**（新）：同窗多篇折叠成一条「IT之家：N篇新文，最新《标题》」。
- **IThome poller 回调改道**：从 `enqueue ithome_article_ingested` 改为 `center.push(IthomeNotificationDraft)`，消除该**死事件**；event union 用 `NotificationEvent` 取代 `IthomeArticleIngestedEvent`。
- **session** 顶层处理 `notification` 事件 → 装配 `<notification>` 追加尾部 + 触发轮次。
- **createNotificationMessage**（`<notification>` 包裹，多源多行）。

## 不在本 PR（PR2）

QQ App 化、`ChatNotificationDraft`/@ 检测、状态树退役、持久化迁移、napcat 其它消费者迁移、poller 完整归属移进 App。

## 测试 / Gate

- 新增单测：NotificationCenter（push/折叠/防御性 flush/注入时钟/空窗不 enqueue/flush 后重起窗，5）、IthomeNotificationDraft（merge/render，2）、session 处理 notification 事件、createNotificationMessage。含 2 个回归（poller 改道、ithome_article_ingested 退役）。
- `pnpm build / typecheck / lint / format / test` 全绿（516 测试通过）。