### PR TITLE
fix(agent): commitRoundResult 丢失 append_message effect 产出的消息

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@
 - agent: 移除 `wait` 工具连续第 3 次调用时的 `<wait_blocked>` 短路限制；`wait` 现在总是产出 `wait_for_event`，由事件队列或最大等待时间正常恢复主循环
 - llm-history: 拆分 LLM 调用历史列表 / 详情接口，`/llm-chat-call/query` 列表只返回 summary 字段，新增 `GET /llm-chat-call/:id` 详情接口；前端列表改为按选中 id 单独 fetch detail，降低列表响应体大小（[#72](https://github.com/KisinTheFlame/kagami/pull/72)）
 
+### Fixed
+
+- agent: 修复 root agent 丢失 tool 的 `append_message` effect 产出消息的回归。#78 把 effect 应用下沉进 ReAct kernel 后，effect 翻译出的"屏幕"消息（App 列表 / 文章正文等）只进 `ReActRoundResult.appendedMessages`，而 `RootAgentHost.commitRoundResult` 仍只持久化 tool 结果 content + postToolEffects、从不落 `appendedMessages`——导致 `glance_hn` / `search_hn` / `open_hn_user` / `open_hn_thread` 以及 ithome 的列表 / 文章正文只在回合内可见、不进 ledger，下一轮主 Agent 只剩 tool_result 那句简短状态（如 `{"count":10}`），看不到真正内容。kernel 现在把 effect 产出挂到 `ReActToolExecution.effectMessages`，commit 按"tool 结果 → effect 屏幕 → postToolEffects"顺序持久化；新增 kernel 与 commit 两层回归测试（[#94](https://github.com/KisinTheFlame/kagami/pull/94)）
+
 ## 2026-05
 
 ### Added

--- a/apps/server/src/agent/runtime/root-agent/root-agent-runtime.ts
+++ b/apps/server/src/agent/runtime/root-agent/root-agent-runtime.ts
@@ -89,6 +89,12 @@ type PendingToolPersistence = {
     toolCallId: string;
     content: string;
   };
+  /**
+   * 本次工具执行的 `effects` 经 interpreter 翻译出的待追加消息（App 列表 / 文章正文等
+   * "屏幕"）。必须落库——否则 glance_hn / ithome 列表这类只走 `append_message` effect 的
+   * 内容只会在回合内可见、不进 ledger，下一轮 Agent 就看不到了。
+   */
+  effectMessages: LlmMessage[];
   postToolEffects: RootAgentPostToolEffects;
 };
 
@@ -110,7 +116,7 @@ export type RootLoopExtensionContext = {
   notifyContextCompacted: () => Promise<void>;
 };
 
-class RootAgentHost implements RootAgentExtensionHost {
+export class RootAgentHost implements RootAgentExtensionHost {
   private readonly context: AgentContext;
   private readonly eventQueue: AgentEventQueue;
   private readonly session: RootAgentSessionController;
@@ -290,6 +296,7 @@ class RootAgentHost implements RootAgentExtensionHost {
             },
           }
         : {}),
+      effectMessages: execution.effectMessages,
       postToolEffects: execution.extensionData?.postToolEffects ?? {
         messages: [],
         events: [],
@@ -350,6 +357,12 @@ class RootAgentHost implements RootAgentExtensionHost {
     for (const toolPersistence of input.toolPersistences) {
       if (toolPersistence.toolResult) {
         await this.context.appendToolResult(toolPersistence.toolResult);
+      }
+
+      // tool 结果之后、postToolEffects 之前追加 effect 产出的"屏幕"消息，
+      // 与 kernel 回合内顺序（toolMessages → interpretedMessages → extraMessages）一致。
+      if (toolPersistence.effectMessages.length > 0) {
+        await this.context.appendMessages(toolPersistence.effectMessages);
       }
 
       if (toolPersistence.postToolEffects.messages.length > 0) {

--- a/apps/server/test/agent/root-agent-commit-effects.test.ts
+++ b/apps/server/test/agent/root-agent-commit-effects.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import type { LlmMessage } from "@kagami/llm";
+import { RootAgentHost } from "../../src/agent/runtime/root-agent/root-agent-runtime.js";
+
+/**
+ * 回归测试（针对 glance_hn / ithome 列表"看不到内容"的根因）：
+ *
+ * tool 的 `append_message` effect 经 kernel interpreter 翻译后挂在
+ * `toolExecution.effectMessages` 上。`RootAgentHost.commitRoundResult` 必须把它
+ * 持久化进上下文——否则这些"屏幕"内容只在回合内可见、不进 ledger，下一轮 Agent
+ * 就只剩 tool_result 的那句简短状态（如 `{count:10}`），看不到榜单本身。
+ *
+ * 修复前：commitRoundResult 只落 tool 结果 + postToolEffects，丢掉 effectMessages，
+ * 本测试的 `append_message` 断言失败。
+ */
+describe("RootAgentHost.commitRoundResult — append_message effect 持久化", () => {
+  function makeHost() {
+    const order: string[] = [];
+    const appended: LlmMessage[] = [];
+
+    const context = {
+      appendAssistantTurn: async () => {
+        order.push("assistant");
+      },
+      appendToolResult: async (input: { toolCallId: string; content: string }) => {
+        order.push(`toolResult:${input.content}`);
+      },
+      appendMessages: async (messages: LlmMessage[]) => {
+        order.push(`append:${messages.length}`);
+        appended.push(...messages);
+      },
+    };
+
+    const host = new RootAgentHost({
+      context,
+      eventQueue: {},
+      session: {},
+      interpreter: {},
+    } as unknown as ConstructorParameters<typeof RootAgentHost>[0]);
+
+    const tools = {
+      getKind: () => "business",
+      definitions: () => [],
+      execute: async () => ({ content: "" }),
+    } as unknown as Parameters<RootAgentHost["commitRoundResult"]>[1];
+
+    return { host, tools, order, appended };
+  }
+
+  function makeRoundResult(
+    effectMessages: LlmMessage[],
+  ): Parameters<RootAgentHost["commitRoundResult"]>[0] {
+    const assistantMessage = {
+      role: "assistant" as const,
+      content: "",
+      toolCalls: [{ id: "tc1", name: "invoke", arguments: { tool: "glance_hn" } }],
+    };
+    return {
+      completion: { message: assistantMessage },
+      assistantMessage,
+      toolExecutions: [
+        {
+          toolCall: { id: "tc1", name: "invoke", arguments: { tool: "glance_hn" } },
+          result: { content: '{"ok":true,"feed":"top","count":10}', kind: "business" },
+          appendedMessages: [
+            { role: "tool", toolCallId: "tc1", content: '{"ok":true,"feed":"top","count":10}' },
+          ],
+          effectMessages,
+        },
+      ],
+      appendedMessages: [],
+      shouldCommit: true,
+    } as unknown as Parameters<RootAgentHost["commitRoundResult"]>[0];
+  }
+
+  it("把 effectMessages（渲染好的榜单）append 进上下文，且排在 tool 结果之后", async () => {
+    const { host, tools, order, appended } = makeHost();
+    const frontPage: LlmMessage = {
+      role: "user",
+      content: '<hn_front_page feed="热榜">\n1. [id=1] Some HN Story\n</hn_front_page>',
+    };
+
+    await host.commitRoundResult(makeRoundResult([frontPage]), tools);
+
+    // 榜单必须进上下文（修复前这里为空 → 失败）。
+    expect(appended).toContainEqual(frontPage);
+    // 顺序：assistant → tool 结果 → effect 屏幕。
+    expect(order).toEqual([
+      "assistant",
+      'toolResult:{"ok":true,"feed":"top","count":10}',
+      "append:1",
+    ]);
+  });
+
+  it("没有 effectMessages 时不额外 append（不回归现有行为）", async () => {
+    const { host, tools, order, appended } = makeHost();
+
+    await host.commitRoundResult(makeRoundResult([]), tools);
+
+    expect(appended).toHaveLength(0);
+    expect(order).toEqual(["assistant", 'toolResult:{"ok":true,"feed":"top","count":10}']);
+  });
+});

--- a/packages/agent-runtime/src/react-kernel.ts
+++ b/packages/agent-runtime/src/react-kernel.ts
@@ -56,6 +56,14 @@ export type ReActToolExecution<TExtensionData = unknown> = {
   toolCall: ReActToolCall;
   result: ToolSetExecutionResult;
   appendedMessages: Array<Extract<LlmMessage, { role: "tool" }>>;
+  /**
+   * 本次工具执行的 `effects` 经 interpreter 翻译出的待追加消息（通常是
+   * `append_message` 产的"屏幕"，如 App 列表 / 文章正文）。与 `appendedMessages`
+   * （tool_result 消息）分开放，让 commit 方能按"tool 结果 → effect 屏幕"的顺序
+   * 各自持久化。本字段是 #78 把 effect 下沉进 kernel 后，commit 方持久化这些
+   * 消息的唯一来源——丢了它，App 的"屏幕"内容就进不了 ledger。
+   */
+  effectMessages: LlmMessage[];
   extensionData?: TExtensionData;
 };
 
@@ -249,6 +257,7 @@ export class ReActKernel<
           toolCall,
           result: skippedResult,
           appendedMessages: skippedToolMessages,
+          effectMessages: [],
         });
         continue;
       }
@@ -335,6 +344,7 @@ export class ReActKernel<
         toolCall,
         result,
         appendedMessages: toolMessages,
+        effectMessages: interpretedMessages,
         ...(extensionData !== undefined ? { extensionData } : {}),
       });
     }

--- a/packages/agent-runtime/test/react-kernel.test.ts
+++ b/packages/agent-runtime/test/react-kernel.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import type { LlmMessage } from "@kagami/llm";
+import {
+  ReActKernel,
+  type ReActModel,
+  type ReActKernelRunRoundInput,
+} from "../src/react-kernel.js";
+import type { Effect, EffectInterpreter } from "../src/effect.js";
+import type { ToolExecutor, ToolExecutionResult } from "../src/tool/tool-component.js";
+
+type Completion = { message: { role: "assistant"; content: string; toolCalls: unknown[] } };
+
+/**
+ * 回归测试:tool 的 `append_message` effect 经 interpreter 翻译后,必须挂到
+ * `toolExecution.effectMessages` 上——这是 commit 方（如 RootAgentHost）持久化
+ * 这些"屏幕"消息的唯一来源。漏了它,App 列表 / 文章正文就进不了 ledger。
+ */
+describe("ReActKernel.runRound — tool effects → toolExecution.effectMessages", () => {
+  function makeModelWithOneToolCall(): ReActModel<"agent", Completion> {
+    return {
+      chat: async () => ({
+        message: {
+          role: "assistant",
+          content: "",
+          toolCalls: [{ id: "tc1", name: "do", arguments: {} }],
+        },
+      }),
+    } as unknown as ReActModel<"agent", Completion>;
+  }
+
+  // interpreter:把每个 append_message effect 译成一条 user 消息（模拟真 RootEffectInterpreter）。
+  const interpreter: EffectInterpreter<never> = {
+    apply: async (effects: readonly Effect[]) => ({
+      appendedMessages: effects
+        .filter(e => e.type === "append_message")
+        .map(e => ({ role: "user", content: (e as { content: string }).content }) as LlmMessage),
+    }),
+  };
+
+  function makeToolsReturning(result: ToolExecutionResult): ToolExecutor {
+    return {
+      definitions: () => [{ name: "do", parameters: { type: "object", properties: {} } }],
+      getKind: () => "business",
+      execute: async () => ({ ...result, kind: "business" }),
+    } as unknown as ToolExecutor;
+  }
+
+  it("把 append_message effect 的产出放进 effectMessages（而非只在 round-level appendedMessages）", async () => {
+    const screen = "<screen>front page content</screen>";
+    const kernel = new ReActKernel<"agent", Completion>({
+      model: makeModelWithOneToolCall(),
+      interpreter,
+    });
+
+    const result = await kernel.runRound({
+      state: { systemPrompt: undefined, messages: [] },
+      tools: makeToolsReturning({
+        content: '{"ok":true,"count":1}',
+        effects: [{ type: "append_message", content: screen }],
+      }),
+      usage: "agent",
+    } as unknown as ReActKernelRunRoundInput<"agent">);
+
+    const exec = result.toolExecutions[0];
+    expect(exec).toBeDefined();
+    // 核心:effect 屏幕进了 toolExecution.effectMessages（commit 方据此落库）。
+    expect(exec.effectMessages).toEqual([{ role: "user", content: screen }]);
+    // tool_result 消息仍单独在 appendedMessages 里,不混进 effectMessages。
+    expect(exec.appendedMessages).toEqual([
+      { role: "tool", toolCallId: "tc1", content: '{"ok":true,"count":1}' },
+    ]);
+  });
+
+  it("tool 没有 effects 时 effectMessages 为空数组", async () => {
+    const kernel = new ReActKernel<"agent", Completion>({
+      model: makeModelWithOneToolCall(),
+      interpreter,
+    });
+
+    const result = await kernel.runRound({
+      state: { systemPrompt: undefined, messages: [] },
+      tools: makeToolsReturning({ content: '{"ok":true}' }),
+      usage: "agent",
+    } as unknown as ReActKernelRunRoundInput<"agent">);
+
+    expect(result.toolExecutions[0].effectMessages).toEqual([]);
+  });
+});


### PR DESCRIPTION
## 症状

小镜在 HN App 里 `glance_hn` 逛了一圈，反馈"返回的数据里没带标题和链接，只告诉我有几条，看不到具体内容"。

## 根因（实测定位，非 HN 专属）

查 live LLM 调用记录，发现同一段对话里：

| 内容 | 走哪条路 | 出现在消息历史里的次数 |
|---|---|---|
| `help`（"你在 Hacker News App 里…"） | **tool_result.content** | **30** ✅ |
| `onFocus` 提示屏 / 渲染榜单 | **append_message effect** | **0** ❌ |

凡走 `tool_result` 的内容都在，凡走 `append_message` effect 的内容全没。沿提交链定位到：

**`RootAgentHost.commitRoundResult` 从不持久化 `ReActRoundResult.appendedMessages`。** #78 把 effect 应用下沉进 ReAct kernel 后，tool 的 `append_message` effect 翻译出的"屏幕"消息只进 `result.appendedMessages`，而 root agent 的 commit 仍只落 tool 结果 content + `postToolEffects`。于是这些屏幕只在回合内可见、不进 ledger，下一轮主 Agent 只剩 tool_result 那句简短状态（`glance_hn` 的 `{"count":10}`），看不到真正榜单。

**影响面：** `glance_hn` / `search_hn` / `open_hn_user` / `open_hn_thread` 以及 **ithome 的列表 / 文章正文**全部中招（ithome 这几天没人调，生产未暴露）。对照 `TaskAgent` 是对的——它老老实实 `messages.push(..., ...roundResult.appendedMessages)`。

## 修复

- `packages/agent-runtime/react-kernel.ts`：给 `ReActToolExecution` 加必填字段 `effectMessages`，每次 tool 执行把 interpreter 产出（`interpretedMessages`）挂上去。必填 → TypeScript 保证每处构造都填，不会再被悄悄漏掉。
- `apps/server/.../root-agent-runtime.ts`：`commitRoundResult` / `persistRoundState` 按 **tool 结果 → effect 屏幕 → postToolEffects** 顺序持久化 `effectMessages`（与 kernel 回合内 `[toolMessages, interpretedMessages, extraMessages]` 顺序一致）。

HN / ithome 的工具代码无需改动——运行时修好后屏幕内容自然进上下文。

## 测试（两层回归）

- **kernel 级**（agent-runtime）：`runRound` 把 `append_message` effect 落到 `toolExecution.effectMessages`；无 effect 时为空数组。
- **commit 级**（server）：`commitRoundResult` 把 `effectMessages` append 进上下文且排在 tool 结果之后；无 effectMessages 不额外 append。修复前 commit 级测试必失败。

`pnpm build / typecheck / lint / format` 全绿；server 518 测试、agent-runtime 28 测试全过。

## 一个口子

`RootAgentHost` 为测试改为 `export`（原 `class`）。如果不希望扩大导出面，可以后续把 commit 持久化逻辑抽成纯函数再测，但当前直测 commit 是最贴近 bug 的回归保护。
