### PR TITLE
chore(lint): AI 味数据文件改用 eslint ignores，全仓零 eslint-disable

### DIFF
--- a/apps/server/src/agent/capabilities/messaging/infra/ai-tone-model.data.ts
+++ b/apps/server/src/agent/capabilities/messaging/infra/ai-tone-model.data.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 // @ts-nocheck
 // prettier-ignore
 //

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,9 @@ export default tseslint.config(
       "**/prisma/generated/**",
       "**/src/generated/prisma/**",
       ".claude/**",
+      // 784K 模型权重数据文件（AIRadar 移植），非手写源码，整体不过 lint。与
+      // .prettierignore 一致：把"不处理生成数据"收进 ignore 配置，取代文件内 /* eslint-disable */。
+      "**/ai-tone-model.data.ts",
     ],
   },
   js.configs.recommended,


### PR DESCRIPTION
## 背景

你问"是不是真没有 eslint-disable 了",我查了一遍——**漏了一个**:`ai-tone-model.data.ts` 头部有文件级 `/* eslint-disable */`。

## 这文件是什么

784K 的 AI 味检测模型权重(TF-IDF + 逻辑回归,从 AIRadar 移植),20 行里塞一坨纯数据,非手写源码。它已经在 `.prettierignore` 里,但不在 eslint ignores 里——所以才靠文件内 disable。

## 改法

把"这坨生成数据整体不过 lint"的策略从**文件内 `/* eslint-disable */`** 收进 **`eslint.config.mjs` 的 `ignores`**(与 `.prettierignore` 一致)。效果相同,但策略集中在 ignore 配置里,数据文件不再带 lint 控制注释。

**结果:全仓 grep `eslint-disable` 零命中。**

## 诚实附注(不在本次范围)

同文件还有一个 `// @ts-nocheck`(TS 层,非 eslint)。它较难干净去掉:该文件被其它源码 import,而 tsc 会处理所有被 import 的文件(`tsconfig.exclude` 挡不住),所以 `@ts-nocheck` 是跳过这个巨型数据 blob 类型检查的实际手段。真要做到"零 TS 抑制",得把数据挪成运行时加载的 `.json`——那是更大的改动。需要的话我另开。

## 验证

`pnpm lint` 0 error / 23 warning、`format`、`typecheck` 均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)