### PR TITLE
chore(lint): .cjs 配置层放行 require，全仓真正零 eslint-disable

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-require-imports */
 const path = require("node:path");
 
 module.exports = {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -105,5 +105,13 @@ export default tseslint.config(
       ],
     },
   },
+  // .cjs 是 CommonJS（如 PM2 ecosystem 配置），require 是其原生模块系统，
+  // no-require-imports 不适用——在配置层关闭，取代文件内 disable。
+  {
+    files: ["**/*.cjs"],
+    rules: {
+      "@typescript-eslint/no-require-imports": "off",
+    },
+  },
   prettierConfig,
 );


### PR DESCRIPTION
## 背景

接着你那句"确定都没有了吧"——我前两次 grep 都只搜了 `apps packages scripts`,漏了根目录配置文件。`git grep` 全部跟踪文件后,发现最后一个:`ecosystem.config.cjs:1` 的 `/* eslint-disable @typescript-eslint/no-require-imports */`。

## 改法（与数据文件那次同思路：策略进配置，不留文件内 disable）

`.cjs` 是 CommonJS,`require` / `module.exports` 是它的原生模块系统,`no-require-imports` 对它结构性不适用。给 `**/*.cjs` 加 eslint override 关掉这条规则,删掉 `ecosystem.config.cjs` 里的文件内 disable。

## 结果

`git grep eslint-disable` 全部跟踪文件 → **零命中**。`npx eslint ecosystem.config.cjs` 单独跑也 exit 0。

## 剩余抑制全貌（诚实）

全仓现在只剩 **1 个 TS 层抑制**:`ai-tone-model.data.ts` 的 `// @ts-nocheck`(784K 模型权重数据,被 import 故 tsconfig exclude 挡不住,@ts-nocheck 是跳过它类型检查的实际手段)。这是 TS 不是 eslint;要清零得把数据挪成运行时 `.json`,另算。

## 验证

`pnpm lint` 0 error / 23 warning、`format` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)