### PR TITLE
feat(agent): 通知改固定周期扫描 + 按 source 分组的新格式

### DIFF
--- a/apps/server/src/agent/apps/ithome/ithome-notification-draft.ts
+++ b/apps/server/src/agent/apps/ithome/ithome-notification-draft.ts
@@ -4,11 +4,13 @@ import { ITHOME_APP_ID } from "./ithome.app.js";
 /**
  * IT之家的后台通知 draft（手机 OS 模型）。
  *
- * 一个窗口内来的多篇文章折叠成一条：`IT之家：N篇新文，最新《标题》`。
+ * 在通知里归到 "IT之家" 段下（段标题由 NotificationCenter 输出），内容一行：
+ *   `N篇新文，最新《标题》`
  * 折叠约定 this = 最新、prev = 历史：标题取最新、篇数累加。
  */
 export class IthomeNotificationDraft implements NotificationDraft {
   public readonly sourceId = ITHOME_APP_ID;
+  public readonly group = "IT之家";
   public readonly displayName = "IT之家";
   private readonly count: number;
   private readonly latestTitle: string;
@@ -27,6 +29,6 @@ export class IthomeNotificationDraft implements NotificationDraft {
   }
 
   public render(): string {
-    return `IT之家：${this.count}篇新文，最新《${this.latestTitle}》`;
+    return `${this.count}篇新文，最新《${this.latestTitle}》`;
   }
 }

--- a/apps/server/src/agent/apps/qq/qq.app.ts
+++ b/apps/server/src/agent/apps/qq/qq.app.ts
@@ -308,10 +308,9 @@ function renderMessagePlainText(message: ConversationMessage): string {
     : renderPrivateMessagePlainText(message);
 }
 
+/** 通知行里的"最近一条内容"：只取消息文本（会话名由通知行前缀给出，不重复发送者）。 */
 function renderMessagePreview(message: ConversationMessage): string {
-  const nickname = message.nickname?.trim() || "某人";
-  const text = message.rawMessage?.trim() || "（非文本消息）";
-  return `${nickname}: ${text}`;
+  return message.rawMessage?.trim() || "（非文本消息）";
 }
 
 function parseConversationGroupId(id: ConversationId): string | null {

--- a/apps/server/src/agent/capabilities/messaging/chat-notification-draft.ts
+++ b/apps/server/src/agent/capabilities/messaging/chat-notification-draft.ts
@@ -1,22 +1,30 @@
 import type { NotificationDraft } from "../../runtime/root-agent/notification/notification-draft.js";
 import type { NapcatReceiveMessageSegment } from "../../../napcat/service/napcat-gateway/shared.js";
 
-const MENTION_TAG = "[有人@你]";
+const MENTION_TAG = "[有人 @ 你]";
 const MAX_PREVIEW_CHARS = 40;
+const MAX_DISPLAY_COUNT = 99;
 
 /**
  * 一个 QQ 会话的后台通知 draft（手机 OS 模型）。
  *
- * 一个窗口内同会话的多条消息折叠成一行：`{会话名}：{[有人@你] }{最新一条(截断)}`。
- * 折叠约定 this = 最新、prev = 历史：文本取最新、`mentioned` 在窗口内**粘住**
- * （出现过一次 @ 就为真）。sourceId = 会话 id（每会话一个源）。
+ * 在通知里归到 "QQ" 段下，每会话一行：
+ *   `{会话名}: {条数标签}{@标签}{最近一条内容}`
+ * - 条数标签：本窗口内该会话消息数 > 1 时显示 `[N 条消息]`（N 超 99 显 `99+`）。
+ * - @标签：窗口内有人 @ 过小镜时显示 `[有人 @ 你]`（出现过一次就粘住）。
+ *
+ * 折叠约定 this = 最新、prev = 历史：文本取最新、`mentioned` 粘住（OR）、`messageCount`
+ * 累加。sourceId = 会话 id（每会话一个源）。
  */
 export class ChatNotificationDraft implements NotificationDraft {
+  public readonly group = "QQ";
+
   public constructor(
     public readonly sourceId: string,
     public readonly displayName: string,
     private readonly latestText: string,
     private readonly mentioned: boolean,
+    private readonly messageCount = 1,
   ) {}
 
   public merge(prev: NotificationDraft): NotificationDraft {
@@ -26,12 +34,14 @@ export class ChatNotificationDraft implements NotificationDraft {
       this.displayName,
       this.latestText, // 最新归我
       this.mentioned || previous.mentioned, // @ 粘住
+      this.messageCount + previous.messageCount, // 条数累加
     );
   }
 
   public render(): string {
-    const mark = this.mentioned ? `${MENTION_TAG} ` : "";
-    return `${this.displayName}：${mark}${truncate(this.latestText, MAX_PREVIEW_CHARS)}`;
+    const countTag = this.messageCount > 1 ? `[${formatCount(this.messageCount)} 条消息]` : "";
+    const mentionTag = this.mentioned ? MENTION_TAG : "";
+    return `${this.displayName}: ${countTag}${mentionTag}${truncate(this.latestText, MAX_PREVIEW_CHARS)}`;
   }
 }
 
@@ -41,6 +51,10 @@ export function detectBotMentioned(
   botQQ: string,
 ): boolean {
   return segments.some(segment => segment.type === "at" && segment.data.qq === botQQ);
+}
+
+function formatCount(count: number): string {
+  return count <= MAX_DISPLAY_COUNT ? String(count) : `${MAX_DISPLAY_COUNT}+`;
 }
 
 function truncate(text: string, max: number): string {

--- a/apps/server/src/agent/runtime/root-agent/notification/notification-center.ts
+++ b/apps/server/src/agent/runtime/root-agent/notification/notification-center.ts
@@ -5,14 +5,15 @@ import { type NotificationScheduler, RealNotificationScheduler } from "./notific
 const logger = new AppLogger({ source: "agent.notification-center" });
 
 type NotificationCenterDeps = {
-  /** 攒批时间窗（毫秒）：第一条 push 起窗，窗到了 flush。 */
+  /** 固定扫描周期（毫秒）：每隔 windowMs 把当前攒下的通知 flush 一次。 */
   windowMs: number;
   /**
-   * flush 时把渲染好的多行通知交出去（每源一行）。调用方负责把它塞进事件队列
-   * （在手机 OS 模型里：enqueue 一个 `notification` 事件，既投递内容也唤醒 Agent）。
+   * flush 时把分好段的多行通知交出去（每段一个 `{group}:` 标题 + 各源一行，段间空行）。
+   * 调用方负责把它塞进事件队列（手机 OS 模型里：enqueue 一个 `notification` 事件，
+   * 既投递内容也唤醒 Agent）。pending 为空的那次扫描不会调用。
    */
   onFlush: (lines: string[]) => void;
-  /** 定时器端口；缺省用真实 setTimeout。测试注入确定性假实现。 */
+  /** 定时器端口；缺省用真实 setInterval。测试注入确定性假实现。 */
   scheduler?: NotificationScheduler;
 };
 
@@ -21,52 +22,53 @@ type NotificationCenterDeps = {
  *
  * - `push(draft)`：谁都能调、不挑调用者；同 source 折叠（`draft.merge(prev)`）。
  *   同步操作（只 `Map.set`），Node 单线程下与 flush 无竞争。
- * - setTimeout-on-first-push：pending 从空变非空时起一个窗口，窗到了 flush。
- * - `flush`：渲染所有 draft 成行，交给 `onFlush`；**防御性**——单个 draft 的
- *   `render` 抛错只跳过它、不炸整个 flush。
+ * - **固定周期扫描**：构造时起一个每 windowMs 的 setInterval，到点把当前攒下的
+ *   通知 flush；空闲时扫描是 no-op（不 enqueue）。
+ * - `flush`：按 `draft.group` 分段（`{group}:` 标题 + 每源 `render()` 一行，段间
+ *   空行），交给 `onFlush`；**防御性**——单个 draft 的 `render` 抛错只跳过它。
  * - `clearForSource`：清掉某源的待发（焦点进入该源时用）。
  *
  * 设计依据：手机 OS 模型设计文档（NotificationCenter）。
  */
 export class NotificationCenter {
   private readonly pending = new Map<string, NotificationDraft>();
-  private readonly windowMs: number;
   private readonly onFlush: (lines: string[]) => void;
-  private readonly scheduler: NotificationScheduler;
-  private flushScheduled = false;
+  private readonly stopInterval: () => void;
 
   public constructor({ windowMs, onFlush, scheduler }: NotificationCenterDeps) {
-    this.windowMs = windowMs;
     this.onFlush = onFlush;
-    this.scheduler = scheduler ?? new RealNotificationScheduler();
+    const activeScheduler = scheduler ?? new RealNotificationScheduler();
+    this.stopInterval = activeScheduler.scheduleInterval(windowMs, () => this.flush());
   }
 
   public push(draft: NotificationDraft): void {
     const prev = this.pending.get(draft.sourceId);
     // this = 最新、prev = 历史：见 NotificationDraft 折叠约定。
     this.pending.set(draft.sourceId, prev ? draft.merge(prev) : draft);
-    if (!this.flushScheduled) {
-      this.flushScheduled = true;
-      this.scheduler.schedule(this.windowMs, () => this.flush());
-    }
   }
 
   public clearForSource(sourceId: string): void {
     this.pending.delete(sourceId);
   }
 
+  /** 停止后台扫描（关停时可调；一般 unref 的 interval 不调也无妨）。 */
+  public stop(): void {
+    this.stopInterval();
+  }
+
   private flush(): void {
-    this.flushScheduled = false;
     if (this.pending.size === 0) {
       return;
     }
     const drafts = [...this.pending.values()];
     this.pending.clear();
 
-    const lines: string[] = [];
+    // 按 group 分段；段内每源一行。
+    const byGroup = new Map<string, string[]>();
     for (const draft of drafts) {
+      let line: string;
       try {
-        lines.push(draft.render());
+        line = draft.render();
       } catch (error) {
         // 防御性：单个 draft 渲染抛错只跳过它，不影响其余源、不炸 flush。
         logger.warn("Notification draft render failed; skipping", {
@@ -74,11 +76,30 @@ export class NotificationCenter {
           errorName: error instanceof Error ? error.name : "Error",
           errorMessage: error instanceof Error ? error.message : String(error),
         });
+        continue;
+      }
+      const lines = byGroup.get(draft.group);
+      if (lines) {
+        lines.push(line);
+      } else {
+        byGroup.set(draft.group, [line]);
       }
     }
 
-    if (lines.length > 0) {
-      this.onFlush(lines);
+    if (byGroup.size === 0) {
+      return;
     }
+
+    const out: string[] = [];
+    let first = true;
+    for (const [group, lines] of byGroup) {
+      if (!first) {
+        out.push(""); // 段间空行
+      }
+      first = false;
+      out.push(`${group}:`);
+      out.push(...lines);
+    }
+    this.onFlush(out);
   }
 }

--- a/apps/server/src/agent/runtime/root-agent/notification/notification-draft.ts
+++ b/apps/server/src/agent/runtime/root-agent/notification/notification-draft.ts
@@ -12,8 +12,13 @@
  * 设计依据：手机 OS 模型设计文档（NotificationCenter / 折叠契约）。
  */
 export interface NotificationDraft {
-  /** 不透明源标识（appId / stateId）。NotificationCenter 按它归组、折叠、清空。 */
+  /** 不透明源标识（每个会话 / app 一个）。NotificationCenter 按它折叠、清空。 */
   readonly sourceId: string;
+  /**
+   * 通知里的分组段名（如 "QQ"、"IT之家"）。NotificationCenter flush 时按 group
+   * 把各源的 render() 行归到同一段标题下，输出 `{group}:` + 每行。
+   */
+  readonly group: string;
   /** 给人看的源短名，渲染时可用。 */
   readonly displayName: string;
   /** 把同源的历史 draft 折叠进来。this = 最新、prev = 历史。 */

--- a/apps/server/src/agent/runtime/root-agent/notification/notification-scheduler.ts
+++ b/apps/server/src/agent/runtime/root-agent/notification/notification-scheduler.ts
@@ -1,20 +1,20 @@
 /**
  * NotificationCenter 的定时器端口。
  *
- * 抽出来是为了**确定性测试**：生产用真实 setTimeout，测试注入一个能手动「推进
- * 窗口」的假实现，不依赖全局假时钟。设计依据：手机 OS 模型设计文档（PR1 / center
- * 可测性，eng-review Finding 1）。
+ * 抽出来是为了**确定性测试**：生产用真实 setInterval，测试注入一个能手动「推进
+ * 一次扫描」的假实现，不依赖全局假时钟。
  */
 export interface NotificationScheduler {
-  /** 安排 fn 在 delayMs 后执行一次。center 每个窗口至多调一次。 */
-  schedule(delayMs: number, fn: () => void): void;
+  /** 每隔 intervalMs 调一次 fn（固定周期扫描）。返回停止函数。 */
+  scheduleInterval(intervalMs: number, fn: () => void): () => void;
 }
 
-/** 生产实现：setTimeout，并 unref 掉——后台 flush 定时器不应拖住进程退出。 */
+/** 生产实现：setInterval，并 unref 掉——后台扫描不应拖住进程退出。 */
 export class RealNotificationScheduler implements NotificationScheduler {
-  public schedule(delayMs: number, fn: () => void): void {
-    const timer = setTimeout(fn, delayMs);
+  public scheduleInterval(intervalMs: number, fn: () => void): () => void {
+    const timer = setInterval(fn, intervalMs);
     // 通知非关键：关停时丢弃一条待发通知可接受，不让它 hold 住事件循环。
     timer.unref();
+    return () => clearInterval(timer);
   }
 }

--- a/apps/server/test/agent/apps/ithome/ithome-notification-draft.test.ts
+++ b/apps/server/test/agent/apps/ithome/ithome-notification-draft.test.ts
@@ -2,10 +2,11 @@ import { describe, expect, it } from "vitest";
 import { IthomeNotificationDraft } from "../../../../src/agent/apps/ithome/ithome-notification-draft.js";
 
 describe("IthomeNotificationDraft", () => {
-  it("renders a single article with sourceId 'ithome'", () => {
+  it("renders a single article line (no prefix; section header is added by the center)", () => {
     const draft = new IthomeNotificationDraft({ title: "某标题" });
     expect(draft.sourceId).toBe("ithome");
-    expect(draft.render()).toBe("IT之家：1篇新文，最新《某标题》");
+    expect(draft.group).toBe("IT之家");
+    expect(draft.render()).toBe("1篇新文，最新《某标题》");
   });
 
   it("folds via merge(prev): count accumulates, title takes the latest", () => {
@@ -13,6 +14,6 @@ describe("IthomeNotificationDraft", () => {
     const newer = new IthomeNotificationDraft({ title: "新标题" });
     // center 的调用约定：newer.merge(older)，this = 最新、prev = 历史。
     const merged = newer.merge(older);
-    expect(merged.render()).toBe("IT之家：2篇新文，最新《新标题》");
+    expect(merged.render()).toBe("2篇新文，最新《新标题》");
   });
 });

--- a/apps/server/test/agent/apps/qq/qq.app.test.ts
+++ b/apps/server/test/agent/apps/qq/qq.app.test.ts
@@ -13,14 +13,15 @@ import { initTestLoggerRuntime } from "../../../helpers/logger.js";
 initTestLoggerRuntime();
 
 class FakeScheduler implements NotificationScheduler {
-  private fns: Array<() => void> = [];
-  public schedule(_delayMs: number, fn: () => void): void {
-    this.fns.push(fn);
+  private fn: (() => void) | null = null;
+  public scheduleInterval(_intervalMs: number, fn: () => void): () => void {
+    this.fn = fn;
+    return () => {
+      this.fn = null;
+    };
   }
-  public fire(): void {
-    const fns = this.fns;
-    this.fns = [];
-    for (const fn of fns) fn();
+  public tick(): void {
+    this.fn?.();
   }
 }
 
@@ -93,10 +94,10 @@ describe("QqApp", () => {
     await app.onStartup();
 
     app.handleNapcatEvent({ type: "napcat_group_message", data: groupMessage("在吗") });
-    scheduler.fire();
+    scheduler.tick();
 
     expect(onFlush).toHaveBeenCalledTimes(1);
-    expect(onFlush.mock.calls[0][0][0]).toBe("产品群：群友: 在吗");
+    expect(onFlush.mock.calls[0][0]).toEqual(["QQ:", "产品群: 在吗"]);
   });
 
   it("marks [有人@你] when the bot is mentioned", async () => {
@@ -106,9 +107,9 @@ describe("QqApp", () => {
     await app.onStartup();
 
     app.handleNapcatEvent({ type: "napcat_group_message", data: groupMessage("看下", "10001") });
-    scheduler.fire();
+    scheduler.tick();
 
-    expect(onFlush.mock.calls[0][0][0]).toContain("[有人@你]");
+    expect(onFlush.mock.calls[0][0][1]).toContain("[有人 @ 你]");
   });
 
   it("open_conversation sets the current chat target and clears that source", async () => {
@@ -171,9 +172,9 @@ describe("QqApp", () => {
         time: 1,
       },
     });
-    scheduler.fire();
+    scheduler.tick();
 
-    expect(onFlush.mock.calls[0][0][0]).toBe("老王：老王: 在不在");
+    expect(onFlush.mock.calls[0][0]).toEqual(["QQ:", "老王: 在不在"]);
     // 会话被建出来，能打开
     expect((await app.openConversation("qq_private:888")).ok).toBe(true);
     expect(app.getCurrentChatTarget()).toEqual({ chatType: "private", userId: "888" });

--- a/apps/server/test/agent/chat-notification-draft.test.ts
+++ b/apps/server/test/agent/chat-notification-draft.test.ts
@@ -6,28 +6,48 @@ import {
 import type { NapcatReceiveMessageSegment } from "../../src/napcat/service/napcat-gateway/shared.js";
 
 describe("ChatNotificationDraft", () => {
-  it("renders {name}：{latest} without a mention", () => {
-    const draft = new ChatNotificationDraft("qq_group:1", "产品群", "在吗", false);
-    expect(draft.sourceId).toBe("qq_group:1");
-    expect(draft.render()).toBe("产品群：在吗");
+  it("belongs to the QQ group", () => {
+    expect(new ChatNotificationDraft("qq_group:1", "产品群", "在吗", false).group).toBe("QQ");
   });
 
-  it("renders the mention tag when mentioned", () => {
-    const draft = new ChatNotificationDraft("qq_group:1", "产品群", "看下这个", true);
-    expect(draft.render()).toBe("产品群：[有人@你] 看下这个");
+  it("renders {name}: {latest} for a single non-@ message", () => {
+    expect(new ChatNotificationDraft("qq_group:1", "产品群", "在吗", false).render()).toBe(
+      "产品群: 在吗",
+    );
+  });
+
+  it("shows the mention tag", () => {
+    expect(new ChatNotificationDraft("qq_group:1", "产品群", "看下", true).render()).toBe(
+      "产品群: [有人 @ 你]看下",
+    );
+  });
+
+  it("shows the count tag when >1, capping at 99+", () => {
+    expect(new ChatNotificationDraft("qq_group:1", "群", "x", false, 2).render()).toBe(
+      "群: [2 条消息]x",
+    );
+    expect(new ChatNotificationDraft("qq_group:1", "群", "x", false, 150).render()).toBe(
+      "群: [99+ 条消息]x",
+    );
+  });
+
+  it("orders count tag before mention tag before content", () => {
+    expect(new ChatNotificationDraft("qq_group:1", "程序喵", "哈哈", true, 150).render()).toBe(
+      "程序喵: [99+ 条消息][有人 @ 你]哈哈",
+    );
+  });
+
+  it("folds via merge(prev): latest text, sticky mention, accumulated count", () => {
+    const older = new ChatNotificationDraft("qq_group:1", "群", "第一条", true, 1); // 历史里 @ 过
+    const newer = new ChatNotificationDraft("qq_group:1", "群", "第二条", false, 1);
+    expect(newer.merge(older).render()).toBe("群: [2 条消息][有人 @ 你]第二条");
   });
 
   it("truncates an over-long latest message", () => {
     const long = "一".repeat(50);
-    const draft = new ChatNotificationDraft("qq_group:1", "群", long, false);
-    expect(draft.render()).toBe(`群：${"一".repeat(40)}…`);
-  });
-
-  it("folds via merge(prev): latest text wins, mention is sticky within the window", () => {
-    const older = new ChatNotificationDraft("qq_group:1", "群", "第一条", true); // 历史里 @ 过
-    const newer = new ChatNotificationDraft("qq_group:1", "群", "第二条", false);
-    const merged = newer.merge(older);
-    expect(merged.render()).toBe("群：[有人@你] 第二条");
+    expect(new ChatNotificationDraft("qq_group:1", "群", long, false).render()).toBe(
+      `群: ${"一".repeat(40)}…`,
+    );
   });
 });
 

--- a/apps/server/test/agent/notification-center.test.ts
+++ b/apps/server/test/agent/notification-center.test.ts
@@ -6,45 +6,39 @@ import { initTestLoggerRuntime } from "../helpers/logger.js";
 
 initTestLoggerRuntime();
 
-/** 确定性假定时器：捕获 center 安排的 flush，由测试手动「推进窗口」。 */
+/** 确定性假定时器：捕获 center 的固定扫描，由测试手动 tick 一次扫描。 */
 class FakeScheduler implements NotificationScheduler {
-  private fns: Array<() => void> = [];
-
-  public schedule(_delayMs: number, fn: () => void): void {
-    this.fns.push(fn);
+  private fn: (() => void) | null = null;
+  public scheduleInterval(_intervalMs: number, fn: () => void): () => void {
+    this.fn = fn;
+    return () => {
+      this.fn = null;
+    };
   }
-
-  public fire(): void {
-    const fns = this.fns;
-    this.fns = [];
-    for (const fn of fns) {
-      fn();
-    }
-  }
-
-  public scheduledCount(): number {
-    return this.fns.length;
+  public tick(): void {
+    this.fn?.();
   }
 }
 
-/**
- * 最小可控 draft，用来测 center 的**源无关机制**。具体折叠语义（计数 / @ 粘住等）
- * 由各源自己的 draft 测试覆盖。
- */
+/** 最小可控 draft，用来测 center 的源无关机制（分组 / 折叠 / 防御性）。 */
 class FakeDraft implements NotificationDraft {
   public constructor(
     public readonly sourceId: string,
+    public readonly group: string,
     public readonly displayName: string,
     private readonly text: string,
     private readonly throwOnRender = false,
   ) {}
-
   public merge(prev: NotificationDraft): NotificationDraft {
     const previous = prev as FakeDraft;
-    // this = 最新；把历史文本拼上，证明 merge 确实收到了 prev。
-    return new FakeDraft(this.sourceId, this.displayName, `${previous.text}+${this.text}`);
+    // this = 最新；拼上历史文本以证明 merge 收到了 prev。
+    return new FakeDraft(
+      this.sourceId,
+      this.group,
+      this.displayName,
+      `${previous.text}+${this.text}`,
+    );
   }
-
   public render(): string {
     if (this.throwOnRender) {
       throw new Error("render boom");
@@ -54,43 +48,50 @@ class FakeDraft implements NotificationDraft {
 }
 
 describe("NotificationCenter", () => {
-  it("flushes one line per source after the window, not before", () => {
+  it("groups drafts by group into sections at the periodic scan, not before", () => {
     const scheduler = new FakeScheduler();
     const onFlush = vi.fn();
     const center = new NotificationCenter({ windowMs: 100, onFlush, scheduler });
 
-    center.push(new FakeDraft("a", "A", "1"));
-    center.push(new FakeDraft("b", "B", "2"));
+    center.push(new FakeDraft("a", "QQ", "A", "1"));
+    center.push(new FakeDraft("b", "QQ", "B", "2"));
+    center.push(new FakeDraft("ithome", "IT之家", "IT之家", "x"));
     expect(onFlush).not.toHaveBeenCalled();
 
-    scheduler.fire();
+    scheduler.tick();
     expect(onFlush).toHaveBeenCalledTimes(1);
-    expect(onFlush).toHaveBeenCalledWith(["A: 1", "B: 2"]);
+    expect(onFlush.mock.calls[0][0]).toEqual(["QQ:", "A: 1", "B: 2", "", "IT之家:", "IT之家: x"]);
   });
 
-  it("folds same-source pushes within a window via merge(prev)", () => {
+  it("folds same-source pushes within a scan via merge(prev)", () => {
     const scheduler = new FakeScheduler();
     const onFlush = vi.fn();
     const center = new NotificationCenter({ windowMs: 100, onFlush, scheduler });
 
-    center.push(new FakeDraft("a", "A", "1"));
-    center.push(new FakeDraft("a", "A", "2"));
-    // 第一条 push 起窗，后续同窗不重排。
-    expect(scheduler.scheduledCount()).toBe(1);
-
-    scheduler.fire();
+    center.push(new FakeDraft("a", "QQ", "A", "1"));
+    center.push(new FakeDraft("a", "QQ", "A", "2"));
+    scheduler.tick();
     // merge：this = 最新("2")、prev = 历史("1") → "1+2"。
-    expect(onFlush).toHaveBeenCalledWith(["A: 1+2"]);
+    expect(onFlush.mock.calls[0][0]).toEqual(["QQ:", "A: 1+2"]);
   });
 
-  it("does not enqueue when pending was cleared before the window fired", () => {
+  it("does not flush an empty scan", () => {
+    const scheduler = new FakeScheduler();
+    const onFlush = vi.fn();
+    const center = new NotificationCenter({ windowMs: 100, onFlush, scheduler });
+    expect(center).toBeInstanceOf(NotificationCenter);
+    scheduler.tick();
+    expect(onFlush).not.toHaveBeenCalled();
+  });
+
+  it("clearForSource drops a pending source before the scan", () => {
     const scheduler = new FakeScheduler();
     const onFlush = vi.fn();
     const center = new NotificationCenter({ windowMs: 100, onFlush, scheduler });
 
-    center.push(new FakeDraft("a", "A", "1"));
+    center.push(new FakeDraft("a", "QQ", "A", "1"));
     center.clearForSource("a");
-    scheduler.fire();
+    scheduler.tick();
     expect(onFlush).not.toHaveBeenCalled();
   });
 
@@ -99,25 +100,24 @@ describe("NotificationCenter", () => {
     const onFlush = vi.fn();
     const center = new NotificationCenter({ windowMs: 100, onFlush, scheduler });
 
-    center.push(new FakeDraft("a", "A", "1", true));
-    center.push(new FakeDraft("b", "B", "2"));
-    scheduler.fire();
-    expect(onFlush).toHaveBeenCalledWith(["B: 2"]);
+    center.push(new FakeDraft("a", "QQ", "A", "1", true));
+    center.push(new FakeDraft("b", "QQ", "B", "2"));
+    scheduler.tick();
+    expect(onFlush.mock.calls[0][0]).toEqual(["QQ:", "B: 2"]);
   });
 
-  it("starts a fresh window after a flush", () => {
+  it("scans repeatedly (fixed interval), flushing whatever is pending each time", () => {
     const scheduler = new FakeScheduler();
     const onFlush = vi.fn();
     const center = new NotificationCenter({ windowMs: 100, onFlush, scheduler });
 
-    center.push(new FakeDraft("a", "A", "1"));
-    scheduler.fire();
+    center.push(new FakeDraft("a", "QQ", "A", "1"));
+    scheduler.tick();
     expect(onFlush).toHaveBeenCalledTimes(1);
 
-    center.push(new FakeDraft("a", "A", "3"));
-    expect(scheduler.scheduledCount()).toBe(1);
-    scheduler.fire();
+    center.push(new FakeDraft("a", "QQ", "A", "3"));
+    scheduler.tick();
     expect(onFlush).toHaveBeenCalledTimes(2);
-    expect(onFlush).toHaveBeenLastCalledWith(["A: 3"]);
+    expect(onFlush.mock.calls[1][0]).toEqual(["QQ:", "A: 3"]);
   });
 });


### PR DESCRIPTION
两处用户要的调整：

## 1. 通知改成固定每 30s 扫一次
`NotificationCenter` 从「第一条 push 起一个 30s 窗」改为**固定每 `windowMs`（默认 30s）扫一次**：构造时起 `setInterval`，到点把当前攒下的通知 flush，空闲扫描 no-op。`NotificationScheduler` 端口随之从一次性 `schedule` 改成 `scheduleInterval`（返回停止函数，生产用 `setInterval().unref()`）。

## 2. `<notification>` 新格式：按 source 分组
```
<notification>
QQ:
Kisin: [2 条消息]在干嘛呢？
程序喵: [99+ 条消息][有人 @ 你]哈哈，确实，这波有点反转了

IT之家:
3篇新文，最新《某标题》
</notification>
```
- 每个 source（App）一段：`{group}:` 标题 + 各源一行，段间空行。
- **QQ 会话行**：`{会话名}: {[N 条消息]}{[有人 @ 你]}{最近一条内容}`——条数 >1 才显（>99 显 `99+`）、@ 粘住、最近内容只取消息文本（不带发送者前缀）。
- IThome 行去掉 `IT之家：` 前缀（已由段标题给出）。

## 实现
`NotificationDraft` 加 `group`；`ChatNotificationDraft` 加 `messageCount` + 新 render；`IthomeNotificationDraft` 加 `group` + 去前缀；`center.flush` 按 `group` 分段渲染。

## Gate
`pnpm build/typecheck/lint/format/test` 全绿（**527 测试**）。lint 0 错误（23 警告为存量、与本 PR 无关）。