### PR TITLE
feat(agent): 通知改前沿触发+节流窗口（安静直达 / 繁忙聚合）

### DIFF
--- a/apps/server/src/agent/runtime/root-agent/notification/notification-center.ts
+++ b/apps/server/src/agent/runtime/root-agent/notification/notification-center.ts
@@ -5,55 +5,85 @@ import { type NotificationScheduler, RealNotificationScheduler } from "./notific
 const logger = new AppLogger({ source: "agent.notification-center" });
 
 type NotificationCenterDeps = {
-  /** 固定扫描周期（毫秒）：每隔 windowMs 把当前攒下的通知 flush 一次。 */
+  /** 节流窗口（毫秒）：一次 flush 后的这段时间内，新通知攒着不立即发。 */
   windowMs: number;
   /**
    * flush 时把分好段的多行通知交出去（每段一个 `{group}:` 标题 + 各源一行，段间空行）。
    * 调用方负责把它塞进事件队列（手机 OS 模型里：enqueue 一个 `notification` 事件，
-   * 既投递内容也唤醒 Agent）。pending 为空的那次扫描不会调用。
+   * 既投递内容也唤醒 Agent）。pending 为空时不会调用。
    */
   onFlush: (lines: string[]) => void;
-  /** 定时器端口；缺省用真实 setInterval。测试注入确定性假实现。 */
+  /** 定时器端口；缺省用真实 setTimeout。测试注入确定性假实现。 */
   scheduler?: NotificationScheduler;
 };
 
 /**
  * 被动、同步、源无关的通知中心（手机 OS 模型）。
  *
- * - `push(draft)`：谁都能调、不挑调用者；同 source 折叠（`draft.merge(prev)`）。
- *   同步操作（只 `Map.set`），Node 单线程下与 flush 无竞争。
- * - **固定周期扫描**：构造时起一个每 windowMs 的 setInterval，到点把当前攒下的
- *   通知 flush；空闲时扫描是 no-op（不 enqueue）。
- * - `flush`：按 `draft.group` 分段（`{group}:` 标题 + 每源 `render()` 一行，段间
- *   空行），交给 `onFlush`；**防御性**——单个 draft 的 `render` 抛错只跳过它。
- * - `clearForSource`：清掉某源的待发（焦点进入该源时用）。
+ * **前沿触发 + 节流窗口（leading-edge throttle）**——既聚合突发、又让安静时的单条
+ * 通知零延迟直达：
+ * - **空闲**（没有进行中的窗口）时 `push` 一条 → **立即 flush 直达 Agent**，并开启一个
+ *   windowMs 的窗。
+ * - **窗口中** `push` → 同 source 折叠后攒着，不立即发。
+ * - **窗结束**：还有攒着的 → flush 出那一批 + 再开一个窗（继续节流）；没攒着的 → 回到空闲，
+ *   下一条又会立即直达。
+ *
+ * 折叠：`push` 同 source 走 `draft.merge(prev)`；同步操作（只 `Map.set`），Node 单线程下
+ * 与 flush 无竞争。flush 按 `draft.group` 分段（`{group}:` 标题 + 每源 `render()` 一行，
+ * 段间空行），**防御性**——单个 draft 的 `render` 抛错只跳过它。
  *
  * 设计依据：手机 OS 模型设计文档（NotificationCenter）。
  */
 export class NotificationCenter {
   private readonly pending = new Map<string, NotificationDraft>();
+  private readonly windowMs: number;
   private readonly onFlush: (lines: string[]) => void;
-  private readonly stopInterval: () => void;
+  private readonly scheduler: NotificationScheduler;
+  /** 进行中窗口的取消函数；null 表示空闲。 */
+  private cancelWindow: (() => void) | null = null;
 
   public constructor({ windowMs, onFlush, scheduler }: NotificationCenterDeps) {
+    this.windowMs = windowMs;
     this.onFlush = onFlush;
-    const activeScheduler = scheduler ?? new RealNotificationScheduler();
-    this.stopInterval = activeScheduler.scheduleInterval(windowMs, () => this.flush());
+    this.scheduler = scheduler ?? new RealNotificationScheduler();
   }
 
   public push(draft: NotificationDraft): void {
     const prev = this.pending.get(draft.sourceId);
     // this = 最新、prev = 历史：见 NotificationDraft 折叠约定。
     this.pending.set(draft.sourceId, prev ? draft.merge(prev) : draft);
+
+    if (this.cancelWindow === null) {
+      // 空闲：前沿立即触发，这条直达；随后开一个窗节流后续。
+      this.flush();
+      this.openWindow();
+    }
+    // 窗口中：攒着，窗结束时一并 flush。
   }
 
   public clearForSource(sourceId: string): void {
     this.pending.delete(sourceId);
   }
 
-  /** 停止后台扫描（关停时可调；一般 unref 的 interval 不调也无妨）。 */
+  /** 关停时停掉进行中的窗口。 */
   public stop(): void {
-    this.stopInterval();
+    this.cancelWindow?.();
+    this.cancelWindow = null;
+  }
+
+  private openWindow(): void {
+    this.cancelWindow = this.scheduler.schedule(this.windowMs, () => this.onWindowEnd());
+  }
+
+  private onWindowEnd(): void {
+    if (this.pending.size > 0) {
+      // 窗内攒了东西：聚合发出，再开一个窗继续节流。
+      this.flush();
+      this.openWindow();
+    } else {
+      // 静默一整窗：回到空闲，下一条又会前沿立即触发。
+      this.cancelWindow = null;
+    }
   }
 
   private flush(): void {

--- a/apps/server/src/agent/runtime/root-agent/notification/notification-scheduler.ts
+++ b/apps/server/src/agent/runtime/root-agent/notification/notification-scheduler.ts
@@ -1,20 +1,20 @@
 /**
  * NotificationCenter 的定时器端口。
  *
- * 抽出来是为了**确定性测试**：生产用真实 setInterval，测试注入一个能手动「推进
- * 一次扫描」的假实现，不依赖全局假时钟。
+ * 抽出来是为了**确定性测试**：生产用真实 setTimeout，测试注入一个能手动「推进
+ * 一次窗口结束」的假实现，不依赖全局假时钟。
  */
 export interface NotificationScheduler {
-  /** 每隔 intervalMs 调一次 fn（固定周期扫描）。返回停止函数。 */
-  scheduleInterval(intervalMs: number, fn: () => void): () => void;
+  /** 安排 fn 在 delayMs 后执行一次。返回取消函数。 */
+  schedule(delayMs: number, fn: () => void): () => void;
 }
 
-/** 生产实现：setInterval，并 unref 掉——后台扫描不应拖住进程退出。 */
+/** 生产实现：setTimeout，并 unref 掉——后台节流窗口不应拖住进程退出。 */
 export class RealNotificationScheduler implements NotificationScheduler {
-  public scheduleInterval(intervalMs: number, fn: () => void): () => void {
-    const timer = setInterval(fn, intervalMs);
+  public schedule(delayMs: number, fn: () => void): () => void {
+    const timer = setTimeout(fn, delayMs);
     // 通知非关键：关停时丢弃一条待发通知可接受，不让它 hold 住事件循环。
     timer.unref();
-    return () => clearInterval(timer);
+    return () => clearTimeout(timer);
   }
 }

--- a/apps/server/test/agent/apps/qq/qq.app.test.ts
+++ b/apps/server/test/agent/apps/qq/qq.app.test.ts
@@ -14,14 +14,11 @@ initTestLoggerRuntime();
 
 class FakeScheduler implements NotificationScheduler {
   private fn: (() => void) | null = null;
-  public scheduleInterval(_intervalMs: number, fn: () => void): () => void {
+  public schedule(_delayMs: number, fn: () => void): () => void {
     this.fn = fn;
     return () => {
       this.fn = null;
     };
-  }
-  public tick(): void {
-    this.fn?.();
   }
 }
 
@@ -94,7 +91,6 @@ describe("QqApp", () => {
     await app.onStartup();
 
     app.handleNapcatEvent({ type: "napcat_group_message", data: groupMessage("在吗") });
-    scheduler.tick();
 
     expect(onFlush).toHaveBeenCalledTimes(1);
     expect(onFlush.mock.calls[0][0]).toEqual(["QQ:", "产品群: 在吗"]);
@@ -107,7 +103,6 @@ describe("QqApp", () => {
     await app.onStartup();
 
     app.handleNapcatEvent({ type: "napcat_group_message", data: groupMessage("看下", "10001") });
-    scheduler.tick();
 
     expect(onFlush.mock.calls[0][0][1]).toContain("[有人 @ 你]");
   });
@@ -172,7 +167,6 @@ describe("QqApp", () => {
         time: 1,
       },
     });
-    scheduler.tick();
 
     expect(onFlush.mock.calls[0][0]).toEqual(["QQ:", "老王: 在不在"]);
     // 会话被建出来，能打开

--- a/apps/server/test/agent/notification-center.test.ts
+++ b/apps/server/test/agent/notification-center.test.ts
@@ -6,17 +6,20 @@ import { initTestLoggerRuntime } from "../helpers/logger.js";
 
 initTestLoggerRuntime();
 
-/** 确定性假定时器：捕获 center 的固定扫描，由测试手动 tick 一次扫描。 */
+/** 确定性假定时器（一次性）：捕获 center 开的节流窗口，由测试手动推进「窗口结束」。 */
 class FakeScheduler implements NotificationScheduler {
   private fn: (() => void) | null = null;
-  public scheduleInterval(_intervalMs: number, fn: () => void): () => void {
+  public schedule(_delayMs: number, fn: () => void): () => void {
     this.fn = fn;
     return () => {
       this.fn = null;
     };
   }
-  public tick(): void {
-    this.fn?.();
+  /** 模拟窗口定时器到点。 */
+  public fireWindowEnd(): void {
+    const fn = this.fn;
+    this.fn = null;
+    fn?.();
   }
 }
 
@@ -47,77 +50,96 @@ class FakeDraft implements NotificationDraft {
   }
 }
 
-describe("NotificationCenter", () => {
-  it("groups drafts by group into sections at the periodic scan, not before", () => {
+function center(scheduler: FakeScheduler, onFlush: (lines: string[]) => void): NotificationCenter {
+  return new NotificationCenter({ windowMs: 100, onFlush, scheduler });
+}
+
+describe("NotificationCenter (leading-edge throttle)", () => {
+  it("fires the first notification immediately when idle (leading edge)", () => {
     const scheduler = new FakeScheduler();
     const onFlush = vi.fn();
-    const center = new NotificationCenter({ windowMs: 100, onFlush, scheduler });
+    const c = center(scheduler, onFlush);
 
-    center.push(new FakeDraft("a", "QQ", "A", "1"));
-    center.push(new FakeDraft("b", "QQ", "B", "2"));
-    center.push(new FakeDraft("ithome", "IT之家", "IT之家", "x"));
-    expect(onFlush).not.toHaveBeenCalled();
-
-    scheduler.tick();
+    c.push(new FakeDraft("a", "QQ", "A", "1"));
     expect(onFlush).toHaveBeenCalledTimes(1);
-    expect(onFlush.mock.calls[0][0]).toEqual(["QQ:", "A: 1", "B: 2", "", "IT之家:", "IT之家: x"]);
+    expect(onFlush.mock.calls[0][0]).toEqual(["QQ:", "A: 1"]);
   });
 
-  it("folds same-source pushes within a scan via merge(prev)", () => {
+  it("batches notifications that arrive during the window, flushing at window end", () => {
     const scheduler = new FakeScheduler();
     const onFlush = vi.fn();
-    const center = new NotificationCenter({ windowMs: 100, onFlush, scheduler });
+    const c = center(scheduler, onFlush);
 
-    center.push(new FakeDraft("a", "QQ", "A", "1"));
-    center.push(new FakeDraft("a", "QQ", "A", "2"));
-    scheduler.tick();
-    // merge：this = 最新("2")、prev = 历史("1") → "1+2"。
-    expect(onFlush.mock.calls[0][0]).toEqual(["QQ:", "A: 1+2"]);
+    c.push(new FakeDraft("a", "QQ", "A", "1")); // 前沿立即
+    c.push(new FakeDraft("b", "QQ", "B", "2")); // 窗内攒着
+    c.push(new FakeDraft("c", "QQ", "C", "3")); // 窗内攒着
+    expect(onFlush).toHaveBeenCalledTimes(1);
+
+    scheduler.fireWindowEnd();
+    expect(onFlush).toHaveBeenCalledTimes(2);
+    expect(onFlush.mock.calls[1][0]).toEqual(["QQ:", "B: 2", "C: 3"]);
   });
 
-  it("does not flush an empty scan", () => {
+  it("goes idle after an empty window, so the next notification is immediate again", () => {
     const scheduler = new FakeScheduler();
     const onFlush = vi.fn();
-    const center = new NotificationCenter({ windowMs: 100, onFlush, scheduler });
-    expect(center).toBeInstanceOf(NotificationCenter);
-    scheduler.tick();
-    expect(onFlush).not.toHaveBeenCalled();
+    const c = center(scheduler, onFlush);
+
+    c.push(new FakeDraft("a", "QQ", "A", "1")); // 前沿立即（call 1）
+    scheduler.fireWindowEnd(); // 窗内空 → 回空闲，不 flush
+    expect(onFlush).toHaveBeenCalledTimes(1);
+
+    c.push(new FakeDraft("b", "QQ", "B", "2")); // 又空闲 → 立即（call 2）
+    expect(onFlush).toHaveBeenCalledTimes(2);
+    expect(onFlush.mock.calls[1][0]).toEqual(["QQ:", "B: 2"]);
   });
 
-  it("clearForSource drops a pending source before the scan", () => {
+  it("folds same-source messages that arrive during the window", () => {
     const scheduler = new FakeScheduler();
     const onFlush = vi.fn();
-    const center = new NotificationCenter({ windowMs: 100, onFlush, scheduler });
+    const c = center(scheduler, onFlush);
 
-    center.push(new FakeDraft("a", "QQ", "A", "1"));
-    center.clearForSource("a");
-    scheduler.tick();
-    expect(onFlush).not.toHaveBeenCalled();
+    c.push(new FakeDraft("a", "QQ", "A", "1")); // 前沿立即（单独）
+    c.push(new FakeDraft("a", "QQ", "A", "2")); // 窗内
+    c.push(new FakeDraft("a", "QQ", "A", "3")); // 窗内，与上一条折叠 → "2+3"
+    scheduler.fireWindowEnd();
+    expect(onFlush.mock.calls[1][0]).toEqual(["QQ:", "A: 2+3"]);
+  });
+
+  it("groups window-batched drafts by group into sections", () => {
+    const scheduler = new FakeScheduler();
+    const onFlush = vi.fn();
+    const c = center(scheduler, onFlush);
+
+    c.push(new FakeDraft("seed", "QQ", "Seed", "0")); // 前沿，开窗
+    c.push(new FakeDraft("a", "QQ", "A", "1")); // 窗内
+    c.push(new FakeDraft("ithome", "IT之家", "IT之家", "x")); // 窗内
+    scheduler.fireWindowEnd();
+    expect(onFlush.mock.calls[1][0]).toEqual(["QQ:", "A: 1", "", "IT之家:", "IT之家: x"]);
+  });
+
+  it("clearForSource drops a pending source before the window ends", () => {
+    const scheduler = new FakeScheduler();
+    const onFlush = vi.fn();
+    const c = center(scheduler, onFlush);
+
+    c.push(new FakeDraft("seed", "QQ", "Seed", "0")); // 前沿，开窗
+    c.push(new FakeDraft("a", "QQ", "A", "1")); // 窗内
+    c.clearForSource("a");
+    scheduler.fireWindowEnd();
+    // 窗内被清空 → 回空闲，不再 flush（只有前沿那一次）。
+    expect(onFlush).toHaveBeenCalledTimes(1);
   });
 
   it("is defensive: a draft whose render throws is skipped, others still flush", () => {
     const scheduler = new FakeScheduler();
     const onFlush = vi.fn();
-    const center = new NotificationCenter({ windowMs: 100, onFlush, scheduler });
+    const c = center(scheduler, onFlush);
 
-    center.push(new FakeDraft("a", "QQ", "A", "1", true));
-    center.push(new FakeDraft("b", "QQ", "B", "2"));
-    scheduler.tick();
-    expect(onFlush.mock.calls[0][0]).toEqual(["QQ:", "B: 2"]);
-  });
-
-  it("scans repeatedly (fixed interval), flushing whatever is pending each time", () => {
-    const scheduler = new FakeScheduler();
-    const onFlush = vi.fn();
-    const center = new NotificationCenter({ windowMs: 100, onFlush, scheduler });
-
-    center.push(new FakeDraft("a", "QQ", "A", "1"));
-    scheduler.tick();
-    expect(onFlush).toHaveBeenCalledTimes(1);
-
-    center.push(new FakeDraft("a", "QQ", "A", "3"));
-    scheduler.tick();
-    expect(onFlush).toHaveBeenCalledTimes(2);
-    expect(onFlush.mock.calls[1][0]).toEqual(["QQ:", "A: 3"]);
+    c.push(new FakeDraft("seed", "QQ", "Seed", "0")); // 前沿，开窗
+    c.push(new FakeDraft("x", "QQ", "X", "1", true)); // 窗内，render 抛错
+    c.push(new FakeDraft("y", "QQ", "Y", "2")); // 窗内
+    scheduler.fireWindowEnd();
+    expect(onFlush.mock.calls[1][0]).toEqual(["QQ:", "Y: 2"]);
   });
 });


### PR DESCRIPTION
用户要的：保留时间窗聚合，但**安静时单条通知零延迟直达 Agent**。

## 设计：leading-edge throttle（前沿触发 + 节流窗口）
- **空闲**（无进行中窗口）时 `push` 一条 → **立即 flush 直达** + 开一个 `windowMs`（30s）的窗。
- **窗口中** `push` → 同 source 折叠后攒着，不立即发。
- **窗结束**：还有攒着的 → flush 那批 + 再开窗；没攒着的 → 回空闲，下条又会前沿立即触发。

「满足某种条件」= center 当前**空闲**（距上次发出超过一个窗、手头没攒东西）。纯空闲触发，不对 @ 特殊加急（按用户选择）。

效果：安静时来一条零延迟到；突发一串第一条立刻到、其余窗末聚合成一条（最多两次唤醒）；持续刷每窗聚合一批。

## 实现
`NotificationScheduler` 从一次性 `schedule(delayMs,fn)`（可取消）；`NotificationCenter` 加「进行中窗口」标记 + 前沿/窗末逻辑（分组渲染不变）。

## Gate
`pnpm build/typecheck/lint/format/test` 全绿（**528 测试**，新增前沿立即/窗内聚合/空窗回空闲/折叠/分组/防御性等 throttle 用例）。