### PR TITLE
feat(agent): QQ 群通知显示发送者 + 未读计数归属 QQ App

### DIFF
--- a/apps/server/src/agent/apps/qq/qq.app.ts
+++ b/apps/server/src/agent/apps/qq/qq.app.ts
@@ -209,13 +209,15 @@ export class QqApp implements App {
     message: ConversationMessage,
     mentioned: boolean,
   ): void {
-    conversation.pushUnread(message);
+    conversation.pushUnread(message, mentioned);
+    // 通知用会话当前的权威未读状态现造 draft：计数 / @ 标记跨窗口累积，open 才清零。
     this.notificationCenter.push(
       new ChatNotificationDraft(
         conversation.id,
         conversation.getShortName(),
         renderMessagePreview(message),
-        mentioned,
+        conversation.hasUnreadMention(),
+        conversation.getUnreadCount(),
       ),
     );
   }
@@ -308,9 +310,13 @@ function renderMessagePlainText(message: ConversationMessage): string {
     : renderPrivateMessagePlainText(message);
 }
 
-/** 通知行里的"最近一条内容"：只取消息文本（会话名由通知行前缀给出，不重复发送者）。 */
+/**
+ * 通知行里的"最近一条内容"。群消息带上发送者（群里不知谁说的没意义）；私聊不带——
+ * 会话名本身就是对方。会话名由通知行前缀给出，这里只补发送者。
+ */
 function renderMessagePreview(message: ConversationMessage): string {
-  return message.rawMessage?.trim() || "（非文本消息）";
+  const text = message.rawMessage?.trim() || "（非文本消息）";
+  return isGroupMessage(message) ? `${message.nickname}：${text}` : text;
 }
 
 function parseConversationGroupId(id: ConversationId): string | null {

--- a/apps/server/src/agent/capabilities/messaging/chat-notification-draft.ts
+++ b/apps/server/src/agent/capabilities/messaging/chat-notification-draft.ts
@@ -10,11 +10,15 @@ const MAX_DISPLAY_COUNT = 99;
  *
  * 在通知里归到 "QQ" 段下，每会话一行：
  *   `{会话名}: {条数标签}{@标签}{最近一条内容}`
- * - 条数标签：本窗口内该会话消息数 > 1 时显示 `[N 条消息]`（N 超 99 显 `99+`）。
- * - @标签：窗口内有人 @ 过小镜时显示 `[有人 @ 你]`（出现过一次就粘住）。
+ * - 条数标签：未读条数 > 1 时显示 `[N 条消息]`（N 超 99 显 `99+`）。
+ * - @标签：未读里有人 @ 过小镜时显示 `[有人 @ 你]`。
  *
- * 折叠约定 this = 最新、prev = 历史：文本取最新、`mentioned` 粘住（OR）、`messageCount`
- * 累加。sourceId = 会话 id（每会话一个源）。
+ * **计数与 @ 都不在这里累积**：每条新消息进来时，QQ App 都用会话当前的权威未读状态
+ * （`Conversation.getUnreadCount()` / `hasUnreadMention()`）现造一个新 draft。这两者只在
+ * open_conversation 时清零，所以未读会跨通知窗口持续累积，而不是每个 30s 窗口重新计数。
+ *
+ * 因此折叠约定是**最新快照覆盖**：`merge(prev)` 直接取 `this`（最新快照已带全量未读计数，
+ * prev 是过期快照）。sourceId = 会话 id（每会话一个源）。
  */
 export class ChatNotificationDraft implements NotificationDraft {
   public readonly group = "QQ";
@@ -24,22 +28,16 @@ export class ChatNotificationDraft implements NotificationDraft {
     public readonly displayName: string,
     private readonly latestText: string,
     private readonly mentioned: boolean,
-    private readonly messageCount = 1,
+    private readonly unreadCount: number,
   ) {}
 
-  public merge(prev: NotificationDraft): NotificationDraft {
-    const previous = prev as ChatNotificationDraft;
-    return new ChatNotificationDraft(
-      this.sourceId,
-      this.displayName,
-      this.latestText, // 最新归我
-      this.mentioned || previous.mentioned, // @ 粘住
-      this.messageCount + previous.messageCount, // 条数累加
-    );
+  public merge(_prev: NotificationDraft): NotificationDraft {
+    // 最新快照已携带权威未读计数 + @ 标记，过期的 prev 直接丢弃。
+    return this;
   }
 
   public render(): string {
-    const countTag = this.messageCount > 1 ? `[${formatCount(this.messageCount)} 条消息]` : "";
+    const countTag = this.unreadCount > 1 ? `[${formatCount(this.unreadCount)} 条消息]` : "";
     const mentionTag = this.mentioned ? MENTION_TAG : "";
     return `${this.displayName}: ${countTag}${mentionTag}${truncate(this.latestText, MAX_PREVIEW_CHARS)}`;
   }

--- a/apps/server/src/agent/capabilities/messaging/conversation.ts
+++ b/apps/server/src/agent/capabilities/messaging/conversation.ts
@@ -32,7 +32,16 @@ export class Conversation {
   public readonly id: ConversationId;
   private readonly meta: GroupMeta | PrivateMeta;
   private readonly unreadLimit: number;
+  /** 未读消息内容缓冲，封顶 unreadLimit（只为渲染最近几条）。 */
   private unread: ConversationMessage[] = [];
+  /**
+   * 未读条数：**不封顶**的真实计数，权威来源在 QQ App 这里。只增不减，唯一清零点是
+   * open_conversation（consumeUnreadTail / clearUnread）。小镜一直不来看，它就一直涨——
+   * 通知里显示的就是这个，而不是某个 30s 窗口内的临时计数。
+   */
+  private unreadCount = 0;
+  /** 未读里是否有人 @ 过小镜：出现一次就粘住，同样到 open_conversation 才清。 */
+  private unreadHasMention = false;
   private entered = false;
 
   private constructor(id: ConversationId, meta: GroupMeta | PrivateMeta, unreadLimit: number) {
@@ -89,8 +98,14 @@ export class Conversation {
     return this.getDisplayName();
   }
 
+  /** 权威未读条数（不封顶，跨通知窗口持续累积，open 才清零）。 */
   public getUnreadCount(): number {
-    return this.unread.length;
+    return this.unreadCount;
+  }
+
+  /** 未读里是否有人 @ 过小镜（粘住，open 才清零）。 */
+  public hasUnreadMention(): boolean {
+    return this.unreadHasMention;
   }
 
   public hasEntered(): boolean {
@@ -113,20 +128,29 @@ export class Conversation {
     }
   }
 
-  public pushUnread(message: ConversationMessage): void {
+  public pushUnread(message: ConversationMessage, mentioned: boolean): void {
     this.unread.push(message);
     this.unread = takeLast(this.unread, this.unreadLimit);
+    // 计数与 @ 标记独立于封顶缓冲：缓冲只留最近几条内容，计数据实累积。
+    this.unreadCount += 1;
+    this.unreadHasMention ||= mentioned;
   }
 
-  /** 进入会话：取未读尾、清空。没进过时调用方会另外拉历史。 */
+  /** 进入会话：取未读尾、清空未读（含计数 + @ 标记）。没进过时调用方会另外拉历史。 */
   public consumeUnreadTail(): ConversationMessage[] {
     const consumed = takeLast(this.unread, this.unreadLimit);
-    this.unread = [];
+    this.resetUnread();
     return consumed;
   }
 
   public clearUnread(): void {
+    this.resetUnread();
+  }
+
+  private resetUnread(): void {
     this.unread = [];
+    this.unreadCount = 0;
+    this.unreadHasMention = false;
   }
 
   public markEntered(): void {

--- a/apps/server/test/agent/apps/qq/qq.app.test.ts
+++ b/apps/server/test/agent/apps/qq/qq.app.test.ts
@@ -20,6 +20,12 @@ class FakeScheduler implements NotificationScheduler {
       this.fn = null;
     };
   }
+  /** 模拟当前节流窗口到点。 */
+  public fireWindowEnd(): void {
+    const fn = this.fn;
+    this.fn = null;
+    fn?.();
+  }
 }
 
 function fakeGateway(overrides: Partial<NapcatGatewayService> = {}): NapcatGatewayService {
@@ -93,7 +99,37 @@ describe("QqApp", () => {
     app.handleNapcatEvent({ type: "napcat_group_message", data: groupMessage("在吗") });
 
     expect(onFlush).toHaveBeenCalledTimes(1);
-    expect(onFlush.mock.calls[0][0]).toEqual(["QQ:", "产品群: 在吗"]);
+    // 群通知行带发送者：`{群名}: {发送者}：{内容}`。
+    expect(onFlush.mock.calls[0][0]).toEqual(["QQ:", "产品群: 群友：在吗"]);
+  });
+
+  it("keeps the unread count climbing across windows, resetting only on open", async () => {
+    const scheduler = new FakeScheduler();
+    const onFlush = vi.fn();
+    const app = createApp(scheduler, onFlush);
+    await app.onStartup();
+
+    // 空闲第一条→立即直达，count 1（无条数标签）。
+    app.handleNapcatEvent({ type: "napcat_group_message", data: groupMessage("1") });
+    expect(onFlush.mock.calls[0][0]).toEqual(["QQ:", "产品群: 群友：1"]);
+
+    // 再来一条→窗内攒着，窗结束 flush，count 2。
+    app.handleNapcatEvent({ type: "napcat_group_message", data: groupMessage("2") });
+    scheduler.fireWindowEnd();
+    expect(onFlush.mock.calls[1][0]).toEqual(["QQ:", "产品群: [2 条消息]群友：2"]);
+
+    // 又一条→没有 open，计数继续涨到 3，而不是按窗口重新计数。
+    app.handleNapcatEvent({ type: "napcat_group_message", data: groupMessage("3") });
+    scheduler.fireWindowEnd();
+    expect(onFlush.mock.calls[2][0]).toEqual(["QQ:", "产品群: [3 条消息]群友：3"]);
+
+    // 小镜终于来看→未读清零；窗口排空回到空闲。
+    await app.openConversation("qq_group:1");
+    scheduler.fireWindowEnd();
+
+    // 之后的新消息从 count 1 重新开始。
+    app.handleNapcatEvent({ type: "napcat_group_message", data: groupMessage("4") });
+    expect(onFlush.mock.calls[3][0]).toEqual(["QQ:", "产品群: 群友：4"]);
   });
 
   it("marks [有人@你] when the bot is mentioned", async () => {

--- a/apps/server/test/agent/chat-notification-draft.test.ts
+++ b/apps/server/test/agent/chat-notification-draft.test.ts
@@ -7,17 +7,17 @@ import type { NapcatReceiveMessageSegment } from "../../src/napcat/service/napca
 
 describe("ChatNotificationDraft", () => {
   it("belongs to the QQ group", () => {
-    expect(new ChatNotificationDraft("qq_group:1", "产品群", "在吗", false).group).toBe("QQ");
+    expect(new ChatNotificationDraft("qq_group:1", "产品群", "在吗", false, 1).group).toBe("QQ");
   });
 
   it("renders {name}: {latest} for a single non-@ message", () => {
-    expect(new ChatNotificationDraft("qq_group:1", "产品群", "在吗", false).render()).toBe(
+    expect(new ChatNotificationDraft("qq_group:1", "产品群", "在吗", false, 1).render()).toBe(
       "产品群: 在吗",
     );
   });
 
   it("shows the mention tag", () => {
-    expect(new ChatNotificationDraft("qq_group:1", "产品群", "看下", true).render()).toBe(
+    expect(new ChatNotificationDraft("qq_group:1", "产品群", "看下", true, 1).render()).toBe(
       "产品群: [有人 @ 你]看下",
     );
   });
@@ -37,15 +37,16 @@ describe("ChatNotificationDraft", () => {
     );
   });
 
-  it("folds via merge(prev): latest text, sticky mention, accumulated count", () => {
-    const older = new ChatNotificationDraft("qq_group:1", "群", "第一条", true, 1); // 历史里 @ 过
-    const newer = new ChatNotificationDraft("qq_group:1", "群", "第二条", false, 1);
-    expect(newer.merge(older).render()).toBe("群: [2 条消息][有人 @ 你]第二条");
+  it("merge(prev) takes the latest snapshot (count is authoritative, not accumulated)", () => {
+    // 未读计数 / @ 标记的权威来源是 Conversation，新 draft 已带全量快照；过期 prev 被丢弃。
+    const older = new ChatNotificationDraft("qq_group:1", "群", "第一条", true, 1); // 旧快照：@ 过、count 1
+    const newer = new ChatNotificationDraft("qq_group:1", "群", "第二条", false, 5); // 新快照：count 5、未 @
+    expect(newer.merge(older).render()).toBe("群: [5 条消息]第二条");
   });
 
   it("truncates an over-long latest message", () => {
     const long = "一".repeat(50);
-    expect(new ChatNotificationDraft("qq_group:1", "群", long, false).render()).toBe(
+    expect(new ChatNotificationDraft("qq_group:1", "群", long, false, 1).render()).toBe(
       `群: ${"一".repeat(40)}…`,
     );
   });

--- a/apps/server/test/agent/conversation.test.ts
+++ b/apps/server/test/agent/conversation.test.ts
@@ -65,20 +65,43 @@ describe("Conversation", () => {
     expect(a.getDisplayName()).toBe("王哥");
   });
 
-  it("accumulates unread up to the limit and exposes the latest", () => {
+  it("counts unread uncapped but caps the buffered content", () => {
     const group = Conversation.group("1", 2);
     expect(group.getUnreadCount()).toBe(0);
-    group.pushUnread(groupMsg("a"));
-    group.pushUnread(groupMsg("b"));
-    group.pushUnread(groupMsg("c")); // 超过上限 2，最旧的被丢
-    expect(group.getUnreadCount()).toBe(2);
+    group.pushUnread(groupMsg("a"), false);
+    group.pushUnread(groupMsg("b"), false);
+    group.pushUnread(groupMsg("c"), false); // 内容缓冲超上限 2，最旧的被丢，但计数不封顶
+    expect(group.getUnreadCount()).toBe(3);
     expect(group.getLatestUnread()?.rawMessage).toBe("c");
+  });
+
+  it("keeps counting unread across many messages, resetting only on consume", () => {
+    const group = Conversation.group("1", 5);
+    for (let i = 0; i < 12; i += 1) {
+      group.pushUnread(groupMsg(String(i)), false);
+    }
+    // 远超缓冲上限 5，仍据实累积——对应通知里"未读越积越多，30s 窗口不重新计数"。
+    expect(group.getUnreadCount()).toBe(12);
+    group.consumeUnreadTail();
+    expect(group.getUnreadCount()).toBe(0);
+  });
+
+  it("sticks the unread mention flag until consume / clear", () => {
+    const group = Conversation.group("1", 5);
+    expect(group.hasUnreadMention()).toBe(false);
+    group.pushUnread(groupMsg("a"), false);
+    expect(group.hasUnreadMention()).toBe(false);
+    group.pushUnread(groupMsg("b"), true); // 有人 @
+    group.pushUnread(groupMsg("c"), false); // 后续没 @ 也粘住
+    expect(group.hasUnreadMention()).toBe(true);
+    group.clearUnread();
+    expect(group.hasUnreadMention()).toBe(false);
   });
 
   it("consumeUnreadTail returns and clears unread", () => {
     const group = Conversation.group("1", 5);
-    group.pushUnread(groupMsg("a"));
-    group.pushUnread(groupMsg("b"));
+    group.pushUnread(groupMsg("a"), false);
+    group.pushUnread(groupMsg("b"), false);
     const tail = group.consumeUnreadTail();
     expect(tail.map(m => m.rawMessage)).toEqual(["a", "b"]);
     expect(group.getUnreadCount()).toBe(0);
@@ -89,15 +112,16 @@ describe("Conversation", () => {
     expect(priv.hasEntered()).toBe(false);
     priv.markEntered();
     expect(priv.hasEntered()).toBe(true);
-    priv.pushUnread(privateMsg("hi"));
+    priv.pushUnread(privateMsg("hi"), false);
     expect(priv.getLatestUnread()?.rawMessage).toBe("hi");
     priv.clearUnread();
     expect(priv.getUnreadCount()).toBe(0);
   });
 
-  it("honors a zero unread limit (drops everything)", () => {
+  it("with a zero unread limit buffers nothing but still counts", () => {
     const group = Conversation.group("1", 0);
-    group.pushUnread(groupMsg("a"));
-    expect(group.getUnreadCount()).toBe(0);
+    group.pushUnread(groupMsg("a"), false);
+    expect(group.getLatestUnread()).toBeNull();
+    expect(group.getUnreadCount()).toBe(1);
   });
 });


### PR DESCRIPTION
## 背景

承接「还有什么未尽之事」的盘点，落地两个确定项 + 一处安全死代码清理。

## 改动

**1. QQ 群通知行显示发送者（#3）**
群里只见内容不知谁说的没意义。通知行从 `{群名}: {内容}` 改为 `{群名}: {发送者}：{内容}`；私聊不带发送者（会话名本身就是对方）。改在 `qq.app.ts` 的 `renderMessagePreview`。

**2. 未读计数归属 QQ App、跨窗口累积（#4）**
此前未读条数靠通知中心 `pending` 在 30s 窗口内折叠累加，每次 flush 清零——小镜不来看也会"重新计数"。现在：

- 计数 / @ 标记的权威来源是 `Conversation`（不封顶的 `unreadCount` + 粘住的 `unreadHasMention`），**只在 `open_conversation` 时清零**。
- 内容缓冲仍按 `unreadLimit` 封顶（只为渲染最近几条），但**计数与缓冲解耦**、据实累积。
- 每条新消息进来时 QQ App 用会话当前权威未读状态现造 `ChatNotificationDraft`；`merge` 改为**最新快照覆盖**（不再累积，过期 prev 直接丢弃）。

效果：小镜一直不看，通知里 `[N 条消息]` 持续涨；一旦 `open_conversation` 就清零，下一条从 1 重新开始。

**3. 清理状态树遗留死代码**
删掉零调用方的 `createCrossStateNotificationMessage` / `CrossStateNotification`（状态树时代产物）。

## 验证
- `pnpm build` / `typecheck` / `lint`（0 error）/ `format` 全过
- 531 单测全过；新增/改写：Conversation 计数不封顶 + @ 粘住 + open 清零、ChatNotificationDraft 最新快照覆盖、QqApp 群通知带发送者 + 计数跨窗口累积到 open 清零

## KV 缓存
通知走消息尾部 `<notification>` 追加，未动稳定前缀；顶层工具集不变。