### PR TITLE
refactor(agent): napcat 网关收纳进 QQ App

### DIFF
--- a/apps/server/src/agent/apps/qq/qq-app.factory.ts
+++ b/apps/server/src/agent/apps/qq/qq-app.factory.ts
@@ -1,0 +1,88 @@
+import type { ConfigManager } from "../../../config/config.manager.js";
+import type { NapcatQqMessageDao } from "../../../napcat/dao/napcat-group-message.dao.js";
+import { DefaultNapcatGatewayService } from "../../../napcat/service/napcat-gateway.impl.service.js";
+import type { NapcatAgentEvent } from "../../../napcat/service/napcat-gateway.service.js";
+import type { NapcatGatewayPersistenceWriter } from "../../../napcat/service/napcat-gateway/event-persistence-writer.js";
+import type { NapcatImageMessageAnalyzer } from "../../../napcat/service/napcat-gateway/image-message-analyzer.js";
+import type { AgentMessageService } from "../../capabilities/messaging/application/agent-message.service.js";
+import { DefaultAgentMessageService } from "../../capabilities/messaging/application/default-agent-message.service.js";
+import { PendingDraftStore } from "../../capabilities/messaging/application/pending-draft.store.js";
+import { AiToneScorer } from "../../capabilities/messaging/infra/ai-tone-scorer.js";
+import { SendMessageTool } from "../../capabilities/messaging/tools/send-message.tool.js";
+import type { NotificationCenter } from "../../runtime/root-agent/notification/notification-center.js";
+import { QqApp } from "./qq.app.js";
+
+type BuildQqAppInput = {
+  configManager: ConfigManager;
+  /** napcat 网关的协作者：抓线持久化、图片消息分析、消息历史 DAO。由组合根注入。 */
+  persistenceWriter: NapcatGatewayPersistenceWriter;
+  imageMessageAnalyzer: NapcatImageMessageAnalyzer;
+  qqMessageDao: NapcatQqMessageDao;
+  notificationCenter: NotificationCenter;
+  botQQ: string;
+  listenGroupIds: string[];
+  recentMessageLimit: number;
+  aiTone: { enabled: boolean; blockThreshold: number };
+};
+
+export type QqAppBundle = {
+  qqApp: QqApp;
+  /** QQ 出站发送端口：send_message 工具与管理台直发 HTTP 都收口到这里，没人再碰裸网关。 */
+  outboundService: AgentMessageService;
+};
+
+/**
+ * 装配 QQ App 这条竖切——手机 OS 模型下 napcat 网关被「收纳」进 QQ App。
+ *
+ * 网关在这里构造、由 QqApp 独占持有：生命周期归 QqApp（onStartup 起 / onShutdown 停），
+ * 出站发送统一走 outboundService（收口），不再有第二个消费方直接拿裸网关。网关的协作者
+ * （持久化 / 图片分析 / DAO）仍由组合根构造后注入——它们是跨切面基础设施，不算 QQ 内部。
+ *
+ * 入站回调与发送之间是环依赖（网关 onEvent → QqApp.handleNapcatEvent；QqApp.send → 网关）。
+ * 这里用一个局部 forward-ref（inbound holder）就地解掉，不再跨 server-runtime / factory 边界
+ * 做 late-bind。回调只在网关 start() 之后才触发，那时 QqApp 必已装配完，holder 已回填。
+ */
+export async function buildQqApp({
+  configManager,
+  persistenceWriter,
+  imageMessageAnalyzer,
+  qqMessageDao,
+  notificationCenter,
+  botQQ,
+  listenGroupIds,
+  recentMessageLimit,
+  aiTone,
+}: BuildQqAppInput): Promise<QqAppBundle> {
+  const inbound: { handle: (event: NapcatAgentEvent) => void } = {
+    handle: () => {},
+  };
+  const napcatGateway = await DefaultNapcatGatewayService.create({
+    configManager,
+    enqueueGroupMessageEvent: event => {
+      inbound.handle(event);
+      return 0;
+    },
+    persistenceWriter,
+    imageMessageAnalyzer,
+    qqMessageDao,
+  });
+  const outboundService = new DefaultAgentMessageService({
+    napcatGatewayService: napcatGateway,
+  });
+  const sendMessageTool = new SendMessageTool({
+    agentMessageService: outboundService,
+    aiToneScorer: new AiToneScorer(),
+    pendingDraftStore: new PendingDraftStore(),
+    aiTone,
+  });
+  const qqApp = new QqApp({
+    napcatGateway,
+    notificationCenter,
+    botQQ,
+    listenGroupIds,
+    recentMessageLimit,
+    sendMessageTool,
+  });
+  inbound.handle = event => qqApp.handleNapcatEvent(event);
+  return { qqApp, outboundService };
+}

--- a/apps/server/src/agent/apps/qq/qq.app.ts
+++ b/apps/server/src/agent/apps/qq/qq.app.ts
@@ -105,6 +105,8 @@ export class QqApp implements App {
   }
 
   public async onStartup(): Promise<void> {
+    // napcat 网关收纳进 QQ App：由这里起 WS 连接（先连上，下面拉群信息才有效）。
+    await this.napcatGateway.start();
     // 拉群信息（显示名）。私聊会话由 friend_list 事件 upsert。
     await Promise.all(
       [...this.conversations.values()]
@@ -131,6 +133,11 @@ export class QqApp implements App {
   public async onBlur(): Promise<readonly RootAgentEffect[]> {
     this.currentConversationId = null;
     return [];
+  }
+
+  /** 关停：停掉网关 WS（收纳后由 QQ App 负责，经 AppManager.shutdownAll 反序触发）。 */
+  public async onShutdown(): Promise<void> {
+    await this.napcatGateway.stop();
   }
 
   /** session.getCurrentChatTarget 委派到这里：当前会话的发送目标。 */

--- a/apps/server/src/app/agent-runtime.factory.ts
+++ b/apps/server/src/app/agent-runtime.factory.ts
@@ -17,7 +17,11 @@ import type { EmbeddingClient } from "../llm/embedding/client.js";
 import { DefaultLlmPlaygroundService } from "../llm/application/llm-playground.impl.service.js";
 import type { LlmPlaygroundService } from "../llm/application/llm-playground.service.js";
 import type { MetricService } from "../metric/application/metric.service.js";
-import type { NapcatGatewayService } from "../napcat/service/napcat-gateway.service.js";
+import type { ConfigManager } from "../config/config.manager.js";
+import type { NapcatQqMessageDao } from "../napcat/dao/napcat-group-message.dao.js";
+import type { NapcatGatewayPersistenceWriter } from "../napcat/service/napcat-gateway/event-persistence-writer.js";
+import type { NapcatImageMessageAnalyzer } from "../napcat/service/napcat-gateway/image-message-analyzer.js";
+import type { AgentMessageService } from "../agent/capabilities/messaging/application/agent-message.service.js";
 import type { IthomeService } from "../agent/capabilities/ithome/application/ithome.service.js";
 import type { StoryQueryService } from "../ops/application/story-query.service.js";
 import type { StoryReindexService } from "../ops/application/story-reindex.service.js";
@@ -46,10 +50,6 @@ import {
   createRootContextSummaryReminderMessage,
   createStoryContextSummaryReminderMessage,
 } from "../agent/runtime/context/context-message-factory.js";
-import { DefaultAgentMessageService } from "../agent/capabilities/messaging/application/default-agent-message.service.js";
-import { PendingDraftStore } from "../agent/capabilities/messaging/application/pending-draft.store.js";
-import { AiToneScorer } from "../agent/capabilities/messaging/infra/ai-tone-scorer.js";
-import { SendMessageTool } from "../agent/capabilities/messaging/tools/send-message.tool.js";
 import { TavilyWebSearchService } from "../agent/capabilities/web-search/application/tavily-web-search.service.js";
 import { SearchWebRawTool } from "../agent/capabilities/web-search/task-agent/tools/search-web-raw.tool.js";
 import { FinalizeWebSearchTool } from "../agent/capabilities/web-search/task-agent/tools/finalize-web-search.tool.js";
@@ -85,10 +85,22 @@ import {
 import { CalcApp } from "../agent/apps/calc/calc.app.js";
 import { ClockApp } from "../agent/apps/clock/clock.app.js";
 import { HnApp } from "../agent/apps/hn/hn.app.js";
-import { QqApp } from "../agent/apps/qq/qq.app.js";
+import type { QqApp } from "../agent/apps/qq/qq.app.js";
+import { buildQqApp } from "../agent/apps/qq/qq-app.factory.js";
 import type { NotificationCenter } from "../agent/runtime/root-agent/notification/notification-center.js";
 
 const logger = new AppLogger({ source: "agent.runtime-factory" });
+
+/**
+ * napcat 网关的协作者（组合根构造后注入）。网关本身在 buildQqApp 内构造、归 QQ App 持有；
+ * 这些是跨切面基础设施：持久化写入器 + 图片分析 + 消息 DAO（DAO 同时被 ops 查询侧读）。
+ */
+type NapcatGatewayDeps = {
+  configManager: ConfigManager;
+  persistenceWriter: NapcatGatewayPersistenceWriter;
+  imageMessageAnalyzer: NapcatImageMessageAnalyzer;
+  qqMessageDao: NapcatQqMessageDao;
+};
 
 type BuildAgentRuntimeInput = {
   config: Config;
@@ -96,7 +108,7 @@ type BuildAgentRuntimeInput = {
   llmClient: LlmClient;
   embeddingClient: EmbeddingClient;
   metricService: MetricService;
-  napcatGatewayService: NapcatGatewayService;
+  napcat: NapcatGatewayDeps;
   ithomeService: IthomeService;
   notificationCenter: NotificationCenter;
   eventQueue: Queue<Event>;
@@ -113,8 +125,12 @@ export type AgentRuntimeBundle = {
   restoredRootAgentSnapshot: boolean;
   hydrateColdStartAgentContext: () => Promise<void>;
   hasTavilyApiKey: boolean;
-  /** QQ App：手机 OS 模型下聊天的承载者。server-runtime 把 napcat 事件接到它。 */
+  /** QQ App：手机 OS 模型下聊天的承载者，已收纳 napcat 网关（自管生命周期 + 入站事件）。 */
   qqApp: QqApp;
+  /** QQ 出站发送端口（收口）：管理台直发 HTTP 走这里，不碰裸网关。 */
+  qqOutboundService: AgentMessageService;
+  /** 反序关停所有 App 的 onShutdown（含 QQ App 停网关）。由服务关停链调用。 */
+  shutdownApps: () => Promise<void>;
 };
 
 export async function buildAgentRuntime({
@@ -123,7 +139,7 @@ export async function buildAgentRuntime({
   llmClient,
   embeddingClient,
   metricService,
-  napcatGatewayService,
+  napcat,
   ithomeService,
   notificationCenter,
   eventQueue,
@@ -201,31 +217,25 @@ export async function buildAgentRuntime({
       return await taskAgent.invoke(input);
     },
   };
-  const agentMessageService = new DefaultAgentMessageService({
-    napcatGatewayService,
-  });
   const terminalStateDao = new PrismaTerminalStateDao({ database });
   const terminalOutputDao = new PrismaTerminalOutputDao({ database });
 
-  // send_message（带 AI 味门控）迁进 QQ App 的工具集；不再是状态树子工具。
-  const sendMessageTool = new SendMessageTool({
-    agentMessageService,
-    aiToneScorer: new AiToneScorer(),
-    pendingDraftStore: new PendingDraftStore(),
-    aiTone: {
-      enabled: config.server.agent.messaging.aiTone.enabled,
-      blockThreshold: config.server.agent.messaging.aiTone.blockThreshold,
-    },
-  });
-  // QQ App：手机 OS 模型下聊天的承载者，持会话表 + 当前会话 + 订阅 napcat。napcat
-  // 事件由 server-runtime 接到 qqApp.handleNapcatEvent（不再走共享事件队列）。
-  const qqApp = new QqApp({
-    napcatGateway: napcatGatewayService,
+  // QQ App 装配：手机 OS 模型下聊天的承载者，已「收纳」napcat 网关——网关在 buildQqApp
+  // 内构造并由 QqApp 独占持有，入站事件直达 handleNapcatEvent（不走共享事件队列），出站
+  // 统一走 outboundService（收口）。这里不再见到裸网关。
+  const { qqApp, outboundService: qqOutboundService } = await buildQqApp({
+    configManager: napcat.configManager,
+    persistenceWriter: napcat.persistenceWriter,
+    imageMessageAnalyzer: napcat.imageMessageAnalyzer,
+    qqMessageDao: napcat.qqMessageDao,
     notificationCenter,
     botQQ: config.server.bot.qq,
     listenGroupIds: config.server.napcat.listenGroupIds,
     recentMessageLimit: config.server.napcat.startupContextRecentMessageCount,
-    sendMessageTool,
+    aiTone: {
+      enabled: config.server.agent.messaging.aiTone.enabled,
+      blockThreshold: config.server.agent.messaging.aiTone.blockThreshold,
+    },
   });
 
   // App 框架：先建 AppManager 并注册 Apps，再按各 App 的 configSchema 校验
@@ -477,6 +487,8 @@ export async function buildAgentRuntime({
     hydrateColdStartAgentContext: async () => {},
     hasTavilyApiKey: Boolean(config.server.tavily.apiKey),
     qqApp,
+    qqOutboundService,
+    shutdownApps: () => appManager.shutdownAll(),
   };
 }
 

--- a/apps/server/src/app/server-runtime.ts
+++ b/apps/server/src/app/server-runtime.ts
@@ -47,11 +47,6 @@ import { SchedulerHandler } from "../scheduler/http/scheduler.handler.js";
 import { DefaultLlmChatCallQueryService } from "../ops/application/llm-chat-call-query.impl.service.js";
 import { NapcatEventPersistenceWriter } from "../napcat/service/napcat-gateway/event-persistence-writer.js";
 import { DefaultNapcatImageMessageAnalyzer } from "../napcat/service/napcat-gateway/image-message-analyzer.js";
-import { DefaultNapcatGatewayService } from "../napcat/service/napcat-gateway.impl.service.js";
-import type {
-  NapcatAgentEvent,
-  NapcatGatewayService,
-} from "../napcat/service/napcat-gateway.service.js";
 import { DefaultNapcatEventQueryService } from "../ops/application/napcat-event-query.impl.service.js";
 import { DefaultNapcatQqMessageQueryService } from "../ops/application/napcat-group-message-query.impl.service.js";
 import { VisionAgent } from "../agent/capabilities/vision/application/vision-agent.js";
@@ -83,7 +78,8 @@ type AppRouteHandler = {
 export type ServerRuntime = {
   app: FastifyInstance;
   database: Database;
-  napcatGatewayService: NapcatGatewayService;
+  /** 反序关停所有 App（含 QQ App 停 napcat 网关）。取代旧的裸 napcatGatewayService.stop。 */
+  shutdownApps: () => Promise<void>;
   taskScheduler: TaskScheduler;
   callbackServers: Array<{ stop(): Promise<void> }>;
   rootAgentRuntime: RootLoopAgent;
@@ -244,33 +240,26 @@ export async function buildServerRuntime(): Promise<ServerRuntime> {
       notificationCenter.push(new IthomeNotificationDraft({ title: article.title }));
     },
   });
-  // 手机 OS 模型：napcat 事件不再进共享事件队列，直达 QQ App。QqApp 在
-  // buildAgentRuntime 里才构造，这里用 late-bind holder 接线。
-  let onNapcatEvent: ((event: NapcatAgentEvent) => void) | null = null;
-  const napcatGatewayService = await DefaultNapcatGatewayService.create({
-    configManager,
-    enqueueGroupMessageEvent: event => {
-      onNapcatEvent?.(event);
-      return 0;
-    },
-    persistenceWriter: napcatPersistenceWriter,
-    imageMessageAnalyzer,
-    qqMessageDao: napcatQqMessageDao,
-  });
-
+  // 手机 OS 模型：napcat 网关收纳进 QQ App。这里只把网关的协作者（持久化 / 图片分析 /
+  // DAO + configManager）传进去，网关实例由 buildQqApp 构造并独占持有，入站事件直达
+  // QqApp、不再走共享事件队列（也就不再需要跨边界的 late-bind holder）。
   const agentRuntime = await buildAgentRuntime({
     config,
     database,
     llmClient,
     embeddingClient,
     metricService,
-    napcatGatewayService,
+    napcat: {
+      configManager,
+      persistenceWriter: napcatPersistenceWriter,
+      imageMessageAnalyzer,
+      qqMessageDao: napcatQqMessageDao,
+    },
     ithomeService,
     notificationCenter,
     eventQueue,
     storyEventQueue,
   });
-  onNapcatEvent = event => agentRuntime.qqApp.handleNapcatEvent(event);
 
   const taskScheduler = new TaskScheduler();
   const [codexAuthRefreshScheduler, claudeCodeAuthRefreshScheduler] =
@@ -309,7 +298,7 @@ export async function buildServerRuntime(): Promise<ServerRuntime> {
         storyQueryService: agentRuntime.storyQueryService,
         storyReindexService: agentRuntime.storyReindexService,
       }),
-      new NapcatHandler({ napcatGatewayService }),
+      new NapcatHandler({ qqMessageSender: agentRuntime.qqOutboundService }),
       new SchedulerHandler({ taskScheduler }),
     ],
   });
@@ -317,7 +306,7 @@ export async function buildServerRuntime(): Promise<ServerRuntime> {
   return {
     app,
     database,
-    napcatGatewayService,
+    shutdownApps: agentRuntime.shutdownApps,
     taskScheduler,
     callbackServers: authModule.callbackServers,
     rootAgentRuntime: agentRuntime.rootAgentRuntime,

--- a/apps/server/src/app/server-shutdown.ts
+++ b/apps/server/src/app/server-shutdown.ts
@@ -3,7 +3,6 @@ import type { Database } from "../db/client.js";
 import { closeDb as defaultCloseDb } from "../db/client.js";
 import { AppLogger } from "../logger/logger.js";
 import { getLoggerRuntime } from "../logger/runtime.js";
-import type { NapcatGatewayService } from "../napcat/service/napcat-gateway.service.js";
 import type { TaskScheduler } from "../scheduler/application/task-scheduler.js";
 
 export type AgentRuntimeController = {
@@ -21,7 +20,8 @@ type ShutdownServerResourcesOptions = {
   isServerStarted: boolean;
   app: FastifyInstance | null;
   database: Database | null;
-  napcatGatewayService: NapcatGatewayService | null;
+  /** 反序关停所有 App（含 QQ App 停 napcat 网关）。取代旧的 napcatGatewayService.stop。 */
+  shutdownApps: (() => Promise<void>) | null;
   taskScheduler: TaskScheduler | null;
   callbackServers: Array<{ stop(): Promise<void> }>;
   rootAgentRuntime: AgentRuntimeController | null;
@@ -43,7 +43,7 @@ export async function shutdownServerResources({
   isServerStarted,
   app,
   database,
-  napcatGatewayService,
+  shutdownApps,
   taskScheduler,
   callbackServers,
   rootAgentRuntime,
@@ -81,10 +81,10 @@ export async function shutdownServerResources({
       });
     }
 
-    if (napcatGatewayService) {
-      await napcatGatewayService.stop();
-      shutdownLogger.info("Napcat gateway closed", {
-        event: "server.shutdown.napcat_closed",
+    if (shutdownApps) {
+      await shutdownApps();
+      shutdownLogger.info("Apps shut down (incl. Napcat gateway)", {
+        event: "server.shutdown.apps_closed",
       });
     }
 

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -4,7 +4,6 @@ import { AppLogger } from "./logger/logger.js";
 import { StdoutLogSink } from "./logger/sinks/stdout-sink.js";
 import { buildServerRuntime } from "./app/server-runtime.js";
 import type { FastifyInstance } from "fastify";
-import type { NapcatGatewayService } from "./napcat/service/napcat-gateway.service.js";
 import type { TaskScheduler } from "./scheduler/application/task-scheduler.js";
 import { shutdownServerResources, type AgentRuntimeController } from "./app/server-shutdown.js";
 
@@ -18,7 +17,7 @@ const logger = new AppLogger({ source: "bootstrap" });
 
 let app: FastifyInstance | null = null;
 let database: Database | null = null;
-let napcatGatewayService: NapcatGatewayService | null = null;
+let shutdownApps: (() => Promise<void>) | null = null;
 let taskScheduler: TaskScheduler | null = null;
 let callbackServers: Array<{ stop(): Promise<void> }> = [];
 let rootAgentRuntime: AgentRuntimeController | null = null;
@@ -89,7 +88,7 @@ async function shutdown(signal: NodeJS.Signals): Promise<void> {
     isServerStarted,
     app,
     database,
-    napcatGatewayService,
+    shutdownApps,
     taskScheduler,
     callbackServers,
     rootAgentRuntime,
@@ -111,7 +110,7 @@ try {
   const runtime = await buildServerRuntime();
   app = runtime.app;
   database = runtime.database;
-  napcatGatewayService = runtime.napcatGatewayService;
+  shutdownApps = runtime.shutdownApps;
   taskScheduler = runtime.taskScheduler;
   callbackServers = runtime.callbackServers;
   rootAgentRuntime = runtime.rootAgentRuntime;
@@ -119,7 +118,7 @@ try {
   closeLlmProviders = runtime.closeLlmProviders;
   port = runtime.port;
 
-  await runtime.napcatGatewayService.start();
+  // napcat 网关已收纳进 QQ App：在 buildServerRuntime 内随 App.onStartup 起好了，这里不再单独 start。
   await runtime.app.listen({ host: "0.0.0.0", port: runtime.port });
   runtime.taskScheduler.start();
   isServerStarted = true;

--- a/apps/server/src/napcat/http/napcat.handler.ts
+++ b/apps/server/src/napcat/http/napcat.handler.ts
@@ -5,19 +5,27 @@ import {
   NapcatSendGroupMessageRequestSchema,
   NapcatSendGroupMessageResponseSchema,
 } from "@kagami/shared/schemas/napcat-message";
-import type { NapcatGatewayService } from "../service/napcat-gateway.service.js";
 import { registerCommandRoute } from "../../common/http/route.helper.js";
 
+/**
+ * 管理台直发 QQ 消息的最小出站端口。结构化定义，避免 napcat/http 反向依赖 agent 模块——
+ * server-runtime 把 QQ App 收口后的 outboundService 传进来即可（形状天然吻合）。
+ */
+type QqMessageSender = {
+  sendGroupMessage(input: { groupId: string; message: string }): Promise<{ messageId: number }>;
+  sendPrivateMessage(input: { userId: string; message: string }): Promise<{ messageId: number }>;
+};
+
 type NapcatHandlerDeps = {
-  napcatGatewayService: NapcatGatewayService;
+  qqMessageSender: QqMessageSender;
 };
 
 export class NapcatHandler {
   public readonly prefix = "/napcat";
-  private readonly napcatGatewayService: NapcatGatewayService;
+  private readonly qqMessageSender: QqMessageSender;
 
-  public constructor({ napcatGatewayService }: NapcatHandlerDeps) {
-    this.napcatGatewayService = napcatGatewayService;
+  public constructor({ qqMessageSender }: NapcatHandlerDeps) {
+    this.qqMessageSender = qqMessageSender;
   }
 
   public register(app: FastifyInstance): void {
@@ -27,7 +35,7 @@ export class NapcatHandler {
       bodySchema: NapcatSendGroupMessageRequestSchema,
       responseSchema: NapcatSendGroupMessageResponseSchema,
       execute: ({ body }) => {
-        return this.napcatGatewayService.sendGroupMessage({
+        return this.qqMessageSender.sendGroupMessage({
           groupId: body.groupId,
           message: body.message,
         });
@@ -40,7 +48,7 @@ export class NapcatHandler {
       bodySchema: NapcatSendPrivateMessageRequestSchema,
       responseSchema: NapcatSendPrivateMessageResponseSchema,
       execute: ({ body }) => {
-        return this.napcatGatewayService.sendPrivateMessage({
+        return this.qqMessageSender.sendPrivateMessage({
           userId: body.userId,
           message: body.message,
         });

--- a/apps/server/test/agent/apps/qq/qq.app.test.ts
+++ b/apps/server/test/agent/apps/qq/qq.app.test.ts
@@ -90,6 +90,29 @@ describe("QqApp", () => {
     expect("content" in content ? content.content : "").toContain("产品群");
   });
 
+  it("owns the napcat gateway lifecycle: start on startup, stop on shutdown", async () => {
+    const start = vi.fn().mockResolvedValue(undefined);
+    const stop = vi.fn().mockResolvedValue(undefined);
+    const app = new QqApp({
+      napcatGateway: fakeGateway({ start, stop }),
+      notificationCenter: new NotificationCenter({
+        windowMs: 100,
+        onFlush: vi.fn(),
+        scheduler: new FakeScheduler(),
+      }),
+      botQQ: "10001",
+      listenGroupIds: ["1"],
+      recentMessageLimit: 5,
+      sendMessageTool: dummySendTool,
+    });
+
+    await app.onStartup();
+    expect(start).toHaveBeenCalledTimes(1);
+
+    await app.onShutdown();
+    expect(stop).toHaveBeenCalledTimes(1);
+  });
+
   it("pushes a chat notification on an incoming group message", async () => {
     const scheduler = new FakeScheduler();
     const onFlush = vi.fn();

--- a/apps/server/test/app/server-shutdown.test.ts
+++ b/apps/server/test/app/server-shutdown.test.ts
@@ -38,11 +38,9 @@ describe("shutdownServerResources", () => {
         order.push("app.close");
       }),
     } as unknown as FastifyInstance;
-    const napcatGatewayService = {
-      stop: vi.fn(async () => {
-        order.push("napcatGateway.stop");
-      }),
-    };
+    const shutdownApps = vi.fn(async () => {
+      order.push("shutdownApps");
+    });
     const taskScheduler = {
       stop: vi.fn(async () => {
         order.push("taskScheduler.stop");
@@ -74,7 +72,7 @@ describe("shutdownServerResources", () => {
       isServerStarted: true,
       app,
       database: {} as never,
-      napcatGatewayService: napcatGatewayService as never,
+      shutdownApps,
       taskScheduler: taskScheduler as never,
       callbackServers: [callbackServer],
       rootAgentRuntime,
@@ -90,7 +88,7 @@ describe("shutdownServerResources", () => {
 
     expect(order).toEqual([
       "app.close",
-      "napcatGateway.stop",
+      "shutdownApps",
       "taskScheduler.stop",
       "callbackServer.stop",
       "rootAgentRuntime.stop",
@@ -117,7 +115,7 @@ describe("shutdownServerResources", () => {
       isServerStarted: false,
       app: null,
       database: {} as never,
-      napcatGatewayService: null,
+      shutdownApps: null,
       taskScheduler: null,
       callbackServers: [],
       rootAgentRuntime: null,
@@ -148,7 +146,7 @@ describe("shutdownServerResources", () => {
       isServerStarted: false,
       app: null,
       database: null,
-      napcatGatewayService: null,
+      shutdownApps: null,
       taskScheduler: null,
       callbackServers: [],
       rootAgentRuntime,
@@ -188,7 +186,7 @@ describe("shutdownServerResources", () => {
       isServerStarted: false,
       app: null,
       database: {} as never,
-      napcatGatewayService: null,
+      shutdownApps: null,
       taskScheduler: null,
       callbackServers: [],
       rootAgentRuntime,

--- a/apps/server/test/handler/napcat.handler.test.ts
+++ b/apps/server/test/handler/napcat.handler.test.ts
@@ -3,8 +3,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import { BizError } from "../../src/common/errors/biz-error.js";
 import { NapcatHandler } from "../../src/napcat/http/napcat.handler.js";
-import type { NapcatGatewayService } from "../../src/napcat/service/napcat-gateway.service.js";
 import { initTestLoggerRuntime } from "../helpers/logger.js";
+
+/** 收口后 NapcatHandler 只依赖 2 方法的出站端口（QQ App 的 outboundService 形状）。 */
+type QqMessageSender = {
+  sendGroupMessage(input: { groupId: string; message: string }): Promise<{ messageId: number }>;
+  sendPrivateMessage(input: { userId: string; message: string }): Promise<{ messageId: number }>;
+};
+
+function fakeSender(overrides: Partial<QqMessageSender> = {}): QqMessageSender {
+  return {
+    sendGroupMessage: vi.fn().mockResolvedValue({ messageId: 1 }),
+    sendPrivateMessage: vi.fn().mockResolvedValue({ messageId: 1 }),
+    ...overrides,
+  };
+}
 
 describe("NapcatHandler", () => {
   let app = Fastify({ logger: false });
@@ -33,19 +46,9 @@ describe("NapcatHandler", () => {
     await app.close();
   });
 
-  it("should send group message via injected NapCat gateway", async () => {
+  it("should send group message via the injected outbound sender", async () => {
     const sendGroupMessage = vi.fn().mockResolvedValue({ messageId: 654321 });
-    const napcatGatewayService: NapcatGatewayService = {
-      start: vi.fn().mockResolvedValue(undefined),
-      stop: vi.fn().mockResolvedValue(undefined),
-      sendGroupMessage,
-      sendPrivateMessage: vi.fn().mockResolvedValue({ messageId: 1 }),
-      getGroupInfo: vi.fn(),
-      getRecentGroupMessages: vi.fn().mockResolvedValue([]),
-      getRecentPrivateMessages: vi.fn().mockResolvedValue([]),
-    };
-
-    const handler = new NapcatHandler({ napcatGatewayService });
+    const handler = new NapcatHandler({ qqMessageSender: fakeSender({ sendGroupMessage }) });
     handler.register(app);
 
     const response = await app.inject({
@@ -67,17 +70,7 @@ describe("NapcatHandler", () => {
 
   it("should return 400 when request payload is invalid", async () => {
     const sendGroupMessage = vi.fn();
-    const napcatGatewayService: NapcatGatewayService = {
-      start: vi.fn().mockResolvedValue(undefined),
-      stop: vi.fn().mockResolvedValue(undefined),
-      sendGroupMessage,
-      sendPrivateMessage: vi.fn().mockResolvedValue({ messageId: 1 }),
-      getGroupInfo: vi.fn(),
-      getRecentGroupMessages: vi.fn().mockResolvedValue([]),
-      getRecentPrivateMessages: vi.fn().mockResolvedValue([]),
-    };
-
-    const handler = new NapcatHandler({ napcatGatewayService });
+    const handler = new NapcatHandler({ qqMessageSender: fakeSender({ sendGroupMessage }) });
     handler.register(app);
 
     const response = await app.inject({
@@ -93,23 +86,13 @@ describe("NapcatHandler", () => {
     expect(sendGroupMessage).not.toHaveBeenCalled();
   });
 
-  it("should return 502 when NapCat gateway raises upstream error", async () => {
+  it("should return 500 when the sender raises upstream error", async () => {
     const sendGroupMessage = vi.fn().mockRejectedValue(
       new BizError({
         message: "NapCat 请求发送失败",
       }),
     );
-    const napcatGatewayService: NapcatGatewayService = {
-      start: vi.fn().mockResolvedValue(undefined),
-      stop: vi.fn().mockResolvedValue(undefined),
-      sendGroupMessage,
-      sendPrivateMessage: vi.fn().mockResolvedValue({ messageId: 1 }),
-      getGroupInfo: vi.fn(),
-      getRecentGroupMessages: vi.fn().mockResolvedValue([]),
-      getRecentPrivateMessages: vi.fn().mockResolvedValue([]),
-    };
-
-    const handler = new NapcatHandler({ napcatGatewayService });
+    const handler = new NapcatHandler({ qqMessageSender: fakeSender({ sendGroupMessage }) });
     handler.register(app);
 
     const response = await app.inject({
@@ -129,17 +112,7 @@ describe("NapcatHandler", () => {
 
   it("should return 400 when groupId is missing", async () => {
     const sendGroupMessage = vi.fn();
-    const napcatGatewayService: NapcatGatewayService = {
-      start: vi.fn().mockResolvedValue(undefined),
-      stop: vi.fn().mockResolvedValue(undefined),
-      sendGroupMessage,
-      sendPrivateMessage: vi.fn().mockResolvedValue({ messageId: 1 }),
-      getGroupInfo: vi.fn(),
-      getRecentGroupMessages: vi.fn().mockResolvedValue([]),
-      getRecentPrivateMessages: vi.fn().mockResolvedValue([]),
-    };
-
-    const handler = new NapcatHandler({ napcatGatewayService });
+    const handler = new NapcatHandler({ qqMessageSender: fakeSender({ sendGroupMessage }) });
     handler.register(app);
 
     const response = await app.inject({
@@ -154,19 +127,9 @@ describe("NapcatHandler", () => {
     expect(sendGroupMessage).not.toHaveBeenCalled();
   });
 
-  it("should send private message via injected NapCat gateway", async () => {
+  it("should send private message via the injected outbound sender", async () => {
     const sendPrivateMessage = vi.fn().mockResolvedValue({ messageId: 7654321 });
-    const napcatGatewayService: NapcatGatewayService = {
-      start: vi.fn().mockResolvedValue(undefined),
-      stop: vi.fn().mockResolvedValue(undefined),
-      sendGroupMessage: vi.fn().mockResolvedValue({ messageId: 1 }),
-      sendPrivateMessage,
-      getGroupInfo: vi.fn(),
-      getRecentGroupMessages: vi.fn().mockResolvedValue([]),
-      getRecentPrivateMessages: vi.fn().mockResolvedValue([]),
-    };
-
-    const handler = new NapcatHandler({ napcatGatewayService });
+    const handler = new NapcatHandler({ qqMessageSender: fakeSender({ sendPrivateMessage }) });
     handler.register(app);
 
     const response = await app.inject({
@@ -187,17 +150,7 @@ describe("NapcatHandler", () => {
   });
 
   it("should return 400 when private request payload is invalid", async () => {
-    const napcatGatewayService: NapcatGatewayService = {
-      start: vi.fn().mockResolvedValue(undefined),
-      stop: vi.fn().mockResolvedValue(undefined),
-      sendGroupMessage: vi.fn().mockResolvedValue({ messageId: 1 }),
-      sendPrivateMessage: vi.fn().mockResolvedValue({ messageId: 1 }),
-      getGroupInfo: vi.fn(),
-      getRecentGroupMessages: vi.fn().mockResolvedValue([]),
-      getRecentPrivateMessages: vi.fn().mockResolvedValue([]),
-    };
-
-    const handler = new NapcatHandler({ napcatGatewayService });
+    const handler = new NapcatHandler({ qqMessageSender: fakeSender() });
     handler.register(app);
 
     const response = await app.inject({
@@ -218,17 +171,7 @@ describe("NapcatHandler", () => {
         message: "NapCat 私聊发送失败",
       }),
     );
-    const napcatGatewayService: NapcatGatewayService = {
-      start: vi.fn().mockResolvedValue(undefined),
-      stop: vi.fn().mockResolvedValue(undefined),
-      sendGroupMessage: vi.fn().mockResolvedValue({ messageId: 1 }),
-      sendPrivateMessage,
-      getGroupInfo: vi.fn(),
-      getRecentGroupMessages: vi.fn().mockResolvedValue([]),
-      getRecentPrivateMessages: vi.fn().mockResolvedValue([]),
-    };
-
-    const handler = new NapcatHandler({ napcatGatewayService });
+    const handler = new NapcatHandler({ qqMessageSender: fakeSender({ sendPrivateMessage }) });
     handler.register(app);
 
     const response = await app.inject({


### PR DESCRIPTION
## 背景

手机 OS 模型「QQ App 收纳整个 napcat」的网关层落地。此前 napcat 网关是 server-runtime 持有的共享服务，QqApp 只是借用方 + 一条跨边界 late-bind 接线；本 PR 让网关真正成为 QQ App 自己的东西。

## 改动

**1. 网关构造 + 持有搬进 QQ App 竖切**
新增 `apps/qq/qq-app.factory.ts` 的 `buildQqApp`：网关在这里构造、由 QqApp 独占持有，没有第二个消费方直接拿裸网关。协作者（持久化写入 / 图片分析 / 消息 DAO）仍由组合根注入——它们是跨切面基础设施（DAO 还被 ops 查询侧读），不算 QQ 内部。

**2. 生命周期归 QqApp**
- `onStartup` 起 WS（先连上，再拉群信息——顺带修了"getGroupInfo 跑在 start 之前"的隐患）。
- `onShutdown` 停网关。
- 配套把 `AppManager.shutdownAll` 接进服务关停链（**此前根本没接**，App 的 onShutdown 永不触发）。落在原 gateway.stop 槽位，行为等价；其它 App 无 onShutdown。

**3. 删跨边界 late-bind**
入站回调改在 `buildQqApp` 内用局部 forward-ref 就地解环（网关 onEvent ↔ QqApp.send 的环），server-runtime 不再有 `onNapcatEvent` holder。回调只在 start() 之后触发，那时 QqApp 必已装配完。

**4. 出站发送收口**
管理台直发 HTTP `/napcat/*/send` 改走 QQ App 的 `outboundService`，与 `send_message` 工具同一条出站路径。`NapcatHandler` 依赖一个结构化最小端口 `QqMessageSender`（避免 napcat/http 反向依赖 agent 模块；响应 schema 恰为 `{ messageId }`，形状天然吻合）。

## 不在本 PR

napcat 死分支（`createMessagesFromEvent`/`summarizeEvent` 的 napcat 分支）耦合 cold-start hydrator —— 唯一往 eventQueue 塞 napcat Event 的就是那条 orphaned 补水链，属 **C2**（要不要恢复冷启动补水）待定项，留给 C2 PR 一并清，避免提前替决策拍板。

## 验证
- `pnpm build` / `typecheck` / `lint`（0 error）/ `format` 全过
- **534** 单测全过；新增 QqApp 生命周期测试（onStartup 起网关 / onShutdown 停）；napcat.handler 测试改用最小出站端口；server-shutdown 测试改断言 shutdownApps

## KV 缓存
纯后端装配搬家，不动 system prompt / 工具集 / 消息序列化，稳定前缀零影响。