### PR TITLE
fix(agent): view_forward 收到数字 id 被拦 + 长 id 丢精度

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Fixed
 
+- agent: 修复 `view_forward` 展开合并转发失败（线上 Kagami 连试 4 次都被拦、根本没走到 `get_forward_msg`）。根因：转发 res_id 是 19 位长数字，PR1 的占位符 `[forward_id: 7655…]` 直接露出裸数字，LLM 当 JSON number 传——既被 `string` schema 拦下（`Expected string, received number`），又因超出 JS 安全整数而丢精度（`…405394` → `…405000`）。修法：占位符给 res_id 加 `fwd-` 前缀（`[forward_id: fwd-7655…]`）强制它在 JSON 里只能是字符串、精度无损，`view_forward` 收到后剥前缀；schema 放宽成 `string|number`，收到纯数字时不静默转换（已丢精度）而是回明确提示让其改用字符串；help / 翻页提示同步带前缀（[#112](https://github.com/KisinTheFlame/kagami/pull/112)）
 - agent: 修复 root agent 丢失 tool 的 `append_message` effect 产出消息的回归。#78 把 effect 应用下沉进 ReAct kernel 后，effect 翻译出的"屏幕"消息（App 列表 / 文章正文等）只进 `ReActRoundResult.appendedMessages`，而 `RootAgentHost.commitRoundResult` 仍只持久化 tool 结果 content + postToolEffects、从不落 `appendedMessages`——导致 `glance_hn` / `search_hn` / `open_hn_user` / `open_hn_thread` 以及 ithome 的列表 / 文章正文只在回合内可见、不进 ledger，下一轮主 Agent 只剩 tool_result 那句简短状态（如 `{"count":10}`），看不到真正内容。kernel 现在把 effect 产出挂到 `ReActToolExecution.effectMessages`，commit 按"tool 结果 → effect 屏幕 → postToolEffects"顺序持久化；新增 kernel 与 commit 两层回归测试（[#94](https://github.com/KisinTheFlame/kagami/pull/94)）
 
 ## 2026-05

--- a/apps/server/src/agent/apps/qq/qq.app.ts
+++ b/apps/server/src/agent/apps/qq/qq.app.ts
@@ -107,7 +107,7 @@ export class QqApp implements App {
       "  - open_conversation(id): 打开某个会话，看最近消息并停在那；之后 send_message 发给它。",
       "  - send_message(message): 发到当前打开的会话。先 open_conversation 才能发。",
       "  - back_to_conversation_list(): 离开当前会话、回到会话列表。",
-      "  - view_forward(forward_id): 展开查看合并转发。消息里看到 [forward_id: xxx] 就是一条合并转发（聊天记录），把那个 id 传进来即可；默认显示前 50 条，更长用 offset 翻页。",
+      "  - view_forward(forward_id): 展开查看合并转发。消息里看到 [forward_id: fwd-xxx] 就是一条合并转发（聊天记录），把 fwd-xxx 原样作为字符串复制进来（含 fwd- 前缀，别当数字）；默认显示前 50 条，更长用 offset 翻页。",
       "",
       "新消息会以通知形式提醒你（不在这个 App 里也会）。调 back_to_portal 退出 QQ 回桌面。",
     ].join("\n");
@@ -434,7 +434,7 @@ function renderForward(forwardId: string, page: NapcatForwardMessagePage): strin
   }
   if (shownEnd < total) {
     lines.push(
-      `还有 ${total - shownEnd} 条，继续看用 view_forward(forward_id="${forwardId}", offset=${shownEnd})。`,
+      `还有 ${total - shownEnd} 条，继续看用 view_forward(forward_id="fwd-${forwardId}", offset=${shownEnd})。`,
     );
   }
   lines.push("</qq_forward>");

--- a/apps/server/src/agent/apps/qq/tools/view-forward.tool.ts
+++ b/apps/server/src/agent/apps/qq/tools/view-forward.tool.ts
@@ -1,9 +1,12 @@
 import { z } from "zod";
 import { ZodToolComponent, type ToolExecutionResult, type ToolKind } from "@kagami/agent-runtime";
+import { FORWARD_ID_DISPLAY_PREFIX } from "../../../../napcat/service/napcat-gateway/shared.js";
 import type { QqApp } from "../qq.app.js";
 
+// forward_id 容忍 string | number：占位符带 fwd- 前缀本会强制成字符串，但 LLM 偶尔仍会把它
+// 当数字传。收 number 时不静默转换（19 位 id 当 number 已丢精度），而是回明确提示让它纠正。
 const ViewForwardArgumentsSchema = z.object({
-  forward_id: z.string().trim().min(1),
+  forward_id: z.union([z.string().trim().min(1), z.number()]),
   offset: z.number().int().nonnegative().optional(),
 });
 
@@ -14,13 +17,14 @@ const ViewForwardArgumentsSchema = z.object({
 export class ViewForwardTool extends ZodToolComponent<typeof ViewForwardArgumentsSchema> {
   public readonly name = "view_forward";
   public readonly description =
-    "展开查看一条合并转发消息（聊天记录）的内容。forward_id 取自消息里的 [forward_id: xxx] 占位符。默认显示前 50 条；转发更长时用 offset 翻页（如 offset=50 看第 51 条起）。";
+    "展开查看一条合并转发消息（聊天记录）的内容。forward_id 取自消息里的 [forward_id: fwd-xxx] 占位符——把 fwd-xxx 原样作为字符串复制进来（含 fwd- 前缀，别当数字）。默认显示前 50 条；转发更长时用 offset 翻页（如 offset=50 看第 51 条起）。";
   public readonly parameters = {
     type: "object",
     properties: {
       forward_id: {
         type: "string",
-        description: "合并转发的 id，来自消息中的 [forward_id: xxx] 占位符。",
+        description:
+          "合并转发的 id，原样复制消息里 [forward_id: fwd-xxx] 的 fwd-xxx（字符串，含 fwd- 前缀，勿当数字传）。",
       },
       offset: {
         type: "number",
@@ -40,16 +44,35 @@ export class ViewForwardTool extends ZodToolComponent<typeof ViewForwardArgument
   protected async executeTyped(
     input: z.infer<typeof ViewForwardArgumentsSchema>,
   ): Promise<ToolExecutionResult> {
-    const result = await this.getApp().viewForward(input.forward_id, input.offset ?? 0);
+    if (typeof input.forward_id === "number") {
+      return {
+        content: JSON.stringify({
+          ok: false,
+          error: "FORWARD_ID_MUST_BE_STRING",
+          note: "forward_id 必须按消息里 [forward_id: fwd-xxx] 原样作为字符串传入（含 fwd- 前缀）。它是超长 id，当数字传会丢精度。",
+        }),
+      };
+    }
+
+    const forwardId = stripForwardIdPrefix(input.forward_id);
+    const result = await this.getApp().viewForward(forwardId, input.offset ?? 0);
     if (!result.ok) {
       return {
         content: JSON.stringify({
           ok: false,
           error: result.error,
-          note: "拉取合并转发失败。forward_id 是否取自消息里的 [forward_id: xxx]？也可能是该转发已过期不可读。",
+          note: "拉取合并转发失败。forward_id 是否取自消息里的 [forward_id: fwd-xxx]（含前缀原样复制）？也可能是该转发已过期不可读。",
         }),
       };
     }
     return { content: result.content ?? "" };
   }
+}
+
+/** 剥掉占位符里的 fwd- 前缀，拿回真实 res_id；没有前缀则原样返回（兼容裸 id 字符串）。 */
+function stripForwardIdPrefix(value: string): string {
+  const trimmed = value.trim();
+  return trimmed.startsWith(FORWARD_ID_DISPLAY_PREFIX)
+    ? trimmed.slice(FORWARD_ID_DISPLAY_PREFIX.length)
+    : trimmed;
 }

--- a/apps/server/src/napcat/service/napcat-gateway/shared.ts
+++ b/apps/server/src/napcat/service/napcat-gateway/shared.ts
@@ -206,12 +206,19 @@ export function renderSupportedMessageSegments(
 }
 
 /**
+ * 渲染合并转发占位符里 res_id 的前缀。res_id 是 19 位长数字，直接露出会被 LLM 当 JSON number
+ * 传给 view_forward——既被 string schema 拦下，又因超出安全整数而丢精度。加个非数字前缀强制
+ * 它在 JSON 里只能是字符串，精度无损；view_forward 收到后剥掉前缀。
+ */
+export const FORWARD_ID_DISPLAY_PREFIX = "fwd-";
+
+/**
  * 合并转发段：只渲染成带 res_id 的占位符,不内联展开内容。Kagami 想看靠 QQ App 的
  * view_forward(forward_id) 工具按需拉取——大段聊天记录绝不直接进主上下文（KV 缓存优先）。
  */
 export function formatForwardSegment(segment: NapcatReceiveForwardSegment): string {
   const id = toNullableString(segment.data.id);
-  return id ? `[forward_id: ${id}]` : "[合并转发]";
+  return id ? `[forward_id: ${FORWARD_ID_DISPLAY_PREFIX}${id}]` : "[合并转发]";
 }
 
 export function parseOutgoingMessageSegments(message: string): NapcatSendMessageSegment[] {

--- a/apps/server/test/agent/apps/qq/view-forward.tool.test.ts
+++ b/apps/server/test/agent/apps/qq/view-forward.tool.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+import { ViewForwardTool } from "../../../../src/agent/apps/qq/tools/view-forward.tool.js";
+import type { QqApp } from "../../../../src/agent/apps/qq/qq.app.js";
+
+function toolWithViewForward(viewForward: ReturnType<typeof vi.fn>) {
+  const app = { viewForward } as unknown as QqApp;
+  return new ViewForwardTool({ getApp: () => app });
+}
+
+describe("ViewForwardTool", () => {
+  it("strips the fwd- prefix before calling viewForward", async () => {
+    const viewForward = vi
+      .fn()
+      .mockResolvedValue({ ok: true, content: "<qq_forward>x</qq_forward>" });
+    const tool = toolWithViewForward(viewForward);
+
+    const result = await tool.execute({ forward_id: "fwd-7655790222306405394" }, {});
+
+    expect(viewForward).toHaveBeenCalledWith("7655790222306405394", 0);
+    expect(result.content).toContain("<qq_forward>");
+  });
+
+  it("accepts a bare id string without prefix and passes the offset", async () => {
+    const viewForward = vi.fn().mockResolvedValue({ ok: true, content: "x" });
+    const tool = toolWithViewForward(viewForward);
+
+    await tool.execute({ forward_id: "7655790222306405394", offset: 50 }, {});
+
+    expect(viewForward).toHaveBeenCalledWith("7655790222306405394", 50);
+  });
+
+  it("rejects a numeric forward_id with guidance and never calls viewForward", async () => {
+    const viewForward = vi.fn();
+    const tool = toolWithViewForward(viewForward);
+
+    // 超长 id 当数字传已丢精度——工具应拦下并提示改用字符串，而不是拿错 id 去查。
+    // 用 Number(...) 运行时构造，避免源码里写超精度数字字面量（也正是这个 bug 的形态）。
+    const result = await tool.execute({ forward_id: Number("7655790222306405394") }, {});
+
+    expect(viewForward).not.toHaveBeenCalled();
+    const parsed = JSON.parse(result.content) as { ok: boolean; error: string };
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toBe("FORWARD_ID_MUST_BE_STRING");
+  });
+});

--- a/apps/server/test/service/napcat-gateway.group-message-processor.test.ts
+++ b/apps/server/test/service/napcat-gateway.group-message-processor.test.ts
@@ -812,7 +812,12 @@ describe("NapcatGroupMessageProcessor", () => {
         rawMessage: "[图片: 一只橘猫趴在键盘上]",
         time: 1710000001,
       },
-      { senderName: "小刚", senderUserId: "10003", rawMessage: "[forward_id: 999]", time: null },
+      {
+        senderName: "小刚",
+        senderUserId: "10003",
+        rawMessage: "[forward_id: fwd-999]",
+        time: null,
+      },
     ]);
   });
 });

--- a/apps/server/test/service/napcat-gateway.shared.test.ts
+++ b/apps/server/test/service/napcat-gateway.shared.test.ts
@@ -173,7 +173,7 @@ describe("renderSupportedMessageSegments", () => {
           },
         },
       ]),
-    ).toBe("[forward_id: 7655556533027578193]");
+    ).toBe("[forward_id: fwd-7655556533027578193]");
   });
 
   it("should fall back to [合并转发] when a forward segment has no id", () => {


### PR DESCRIPTION
## 现象

PR1 上线后，线上 Kagami 调 `view_forward` 展开转发**失败**——连试 4 次都报 `view_forward 参数不合法。Expected string, received number`，然后放弃、发消息跟创造者说"展开不了 可能格式有问题"。(从一条真实 LLM 调用历史 `61a2167d-...` 挖出来的。)

## 根因（双层，且**根本没走到 NapCat**）

转发的 res_id 是 **19 位长数字**（如 `7655790222306405394`），PR1 的占位符 `[forward_id: 7655...]` 直接把它当裸数字露出来。LLM 自然把它当 **JSON number** 传进 `view_forward`：

1. **被 schema 拦下**：`forward_id` 要求 `z.string()`，收到 number 直接 `Expected string, received number`，连 `get_forward_msg` 都没触发。
2. **就算放行也是错的**：19 位远超 JS 安全整数（2^53），当 number 解析**已经丢精度**——`7655790222306405394` → `7655790222306405000`（末位归零）。所以"把 schema 改成接受 number 再 String() 转换"是错的，会拿着错 id 去查。

所以这不是 NapCat / `get_forward_msg` 的问题，是占位符把超长数字 id 直接暴露给 LLM 的设计锅。

## 修法（精度安全）

核心：**让这个 id 全程是字符串**。唯一可靠办法是占位符里别露纯数字。

- **占位符加 `fwd-` 前缀**：`[forward_id: fwd-7655790222306405394]`。`fwd-7655...` 在 JSON 里只能是字符串 → LLM 当字符串复制 → 精度无损。`view_forward` 收到后剥掉 `fwd-` 再查（无前缀的裸 id 字符串也兼容）。
- **schema 放宽成 `string | number`**：收到纯数字时**不静默转换**（已丢精度），而是回一句明确提示让它按 `[forward_id: fwd-xxx]` 原样作为字符串传——给 LLM 一个能纠正的反馈，而不是默默查错 id。
- help 文案 + 翻页提示同步带 `fwd-` 前缀。

这是第 3 次动转发占位符格式（一次性 KV 前缀位移，可接受）。

## 测试

新增/更新：占位渲染断言带 `fwd-` 前缀（shared + processor 嵌套转发）；新增 `view-forward.tool` 单测——剥 `fwd-` 前缀、兼容裸 id 字符串、拒绝数字（`FORWARD_ID_MUST_BE_STRING`，且不调 `viewForward`）。本地四件套全绿，全量测试 server 560 通过。

依赖 PR1（合并转发查看）已合并；本 PR 只修它的入参 bug。