### PR TITLE
feat(agent): wake reminder 时间附带星期几

### DIFF
--- a/apps/server/src/agent/runtime/context/context-message-factory.ts
+++ b/apps/server/src/agent/runtime/context/context-message-factory.ts
@@ -34,6 +34,7 @@ export function createWakeReminderMessage(now: Date): UserMessage {
     year: "numeric",
     month: "numeric",
     day: "numeric",
+    weekday: "long",
     hour: "2-digit",
     minute: "2-digit",
     hour12: false,

--- a/apps/server/static/context/wake-reminder.hbs
+++ b/apps/server/static/context/wake-reminder.hbs
@@ -1,1 +1,1 @@
-<system_reminder>当前时间为北京时间 {{year}} 年 {{month}} 月 {{day}} 日 {{hour}}:{{minute}}</system_reminder>
+<system_reminder>当前时间为北京时间 {{year}} 年 {{month}} 月 {{day}} 日 {{weekday}} {{hour}}:{{minute}}</system_reminder>

--- a/apps/server/test/context/context-message-factory.test.ts
+++ b/apps/server/test/context/context-message-factory.test.ts
@@ -17,7 +17,8 @@ describe("context-message-factory", () => {
   it("should render the wake reminder with beijing time", () => {
     expect(createWakeReminderMessage(new Date("2026-03-09T10:21:00.000Z"))).toEqual({
       role: "user",
-      content: "<system_reminder>当前时间为北京时间 2026 年 3 月 9 日 18:21</system_reminder>",
+      content:
+        "<system_reminder>当前时间为北京时间 2026 年 3 月 9 日 星期一 18:21</system_reminder>",
     });
   });
 


### PR DESCRIPTION
## 改动

在注入当前时间的 `system_reminder` 中加上星期几，便于 Agent 感知是周几。

输出形如：
```
<system_reminder>当前时间为北京时间 2026 年 3 月 9 日 星期一 18:21</system_reminder>
```

## 涉及文件
- `context-message-factory.ts`：`Intl.DateTimeFormat` 增加 `weekday: "long"`，`formatToParts` 产出「星期X」part
- `wake-reminder.hbs`：模板在日期与时间之间插入 `{{weekday}}`
- `context-message-factory.test.ts`：同步更新断言

## KV 缓存
该 reminder 走消息尾部追加（易变尾部），不属于稳定前缀，加字段不影响前缀缓存。

## 验证
- `pnpm build / typecheck / lint / format` 全部通过（lint 仅既存 warning，0 error）
- 上下文相关单测 24 项通过