### PR TITLE
refactor(types): 清除业务代码 17 处 no-unsafe-* lint 警告

### DIFF
--- a/apps/server/src/common/http/route.helper.ts
+++ b/apps/server/src/common/http/route.helper.ts
@@ -49,7 +49,7 @@ export function registerQueryRoute<
   execute,
 }: QueryRouteDef<TQuerySchema, TResponseSchema>): void {
   app.get(path, async (request, reply) => {
-    const query = querySchema.parse(request.query);
+    const query = querySchema.parse(request.query) as z.infer<TQuerySchema>;
     const result = await execute({ query, request, reply });
     return responseSchema.parse(result);
   });
@@ -66,7 +66,7 @@ export function registerParamRoute<
   execute,
 }: ParamRouteDef<TParamSchema, TResponseSchema>): void {
   app.get(path, async (request, reply) => {
-    const params = paramSchema.parse(request.params);
+    const params = paramSchema.parse(request.params) as z.infer<TParamSchema>;
     const result = await execute({ params, request, reply });
     return responseSchema.parse(result);
   });
@@ -84,9 +84,9 @@ export function registerCommandRoute<
   execute,
 }: CommandRouteDef<TBodySchema, TResponseSchema>): void {
   app.post(path, async (request, reply) => {
-    const body = bodySchema.parse(request.body);
+    const body = bodySchema.parse(request.body) as z.infer<TBodySchema>;
     const result = await execute({ body, request, reply });
-    const response = responseSchema.parse(result);
+    const response = responseSchema.parse(result) as z.infer<TResponseSchema>;
     return reply.code(statusCode).send(response);
   });
 }

--- a/apps/server/src/common/prisma-json.ts
+++ b/apps/server/src/common/prisma-json.ts
@@ -27,7 +27,7 @@ export function toInputJsonObject(value: Record<string, unknown>): Prisma.InputJ
 
 export function normalizeInputJsonValue(value: unknown): Prisma.InputJsonValue {
   try {
-    const serialized = JSON.stringify(value, (_key, currentValue) => {
+    const serialized = JSON.stringify(value, (_key: string, currentValue: unknown) => {
       if (currentValue instanceof Date) {
         return currentValue.toISOString();
       }

--- a/apps/server/src/llm/embedding/providers/tei-embedding-gemma-provider.ts
+++ b/apps/server/src/llm/embedding/providers/tei-embedding-gemma-provider.ts
@@ -37,7 +37,7 @@ export function createTeiEmbeddingGemmaProvider(
       }
 
       const payload: unknown = await response.json();
-      const embedding = Array.isArray(payload) ? payload[0] : undefined;
+      const embedding: unknown = Array.isArray(payload) ? payload[0] : undefined;
       if (!Array.isArray(embedding) || embedding.some(value => typeof value !== "number")) {
         throw new BizError({
           message: "TEI Embedding Gemma 响应缺少合法 embedding",
@@ -48,7 +48,7 @@ export function createTeiEmbeddingGemmaProvider(
       return {
         provider: "tei-embedding-gemma",
         model: options.model,
-        embedding,
+        embedding: embedding as number[],
       };
     },
   };

--- a/apps/server/src/llm/provider.ts
+++ b/apps/server/src/llm/provider.ts
@@ -71,7 +71,7 @@ export function toSerializableLlmNativeRecordOrNull(
 
 function toSerializableLlmNativeValue(value: unknown): unknown {
   try {
-    const serialized = JSON.stringify(value, (_key, currentValue) => {
+    const serialized = JSON.stringify(value, (_key: string, currentValue: unknown) => {
       if (currentValue instanceof Error) {
         const withStatus = currentValue as Error & { status?: unknown; code?: unknown };
         return {

--- a/apps/web/src/pages/auth/AuthPage.tsx
+++ b/apps/web/src/pages/auth/AuthPage.tsx
@@ -529,7 +529,7 @@ function UsageTrendPanel({
             tickLine={false}
             axisLine={false}
             minTickGap={24}
-            tickFormatter={value => formatTrendAxisTick(value, data.range)}
+            tickFormatter={(value: string) => formatTrendAxisTick(value, data.range)}
           />
           <YAxis
             domain={[0, 100]}

--- a/apps/web/src/pages/metric-charts/MetricChartsPage.tsx
+++ b/apps/web/src/pages/metric-charts/MetricChartsPage.tsx
@@ -655,14 +655,17 @@ function MetricChartCard({
                   width={56}
                   tickLine={false}
                   axisLine={false}
-                  tickFormatter={value => formatMetricValue(value)}
+                  tickFormatter={(value: number | string) => formatMetricValue(value)}
                 />
                 <ChartTooltip
                   content={
                     <ChartTooltipContent
                       indicator="line"
                       labelFormatter={(_label, payload) => {
-                        const bucketStart = payload?.[0]?.payload?.bucketStart;
+                        const entry = payload?.[0]?.payload as
+                          | { bucketStart?: unknown }
+                          | undefined;
+                        const bucketStart = entry?.bucketStart;
                         return typeof bucketStart === "string"
                           ? formatFullDateTime(bucketStart)
                           : "未知时间";

--- a/packages/agent-runtime/src/tool/tool-component.ts
+++ b/packages/agent-runtime/src/tool/tool-component.ts
@@ -87,7 +87,7 @@ export abstract class ZodToolComponent<TInput extends z.ZodTypeAny> implements T
     }
 
     try {
-      const result = await this.executeTyped(parsed.data, context);
+      const result = await this.executeTyped(parsed.data as z.infer<TInput>, context);
       if (typeof result === "string") {
         return { content: result };
       }


### PR DESCRIPTION
## 背景
`/health` 体检发现 23 条 `@typescript-eslint/no-unsafe-*` 警告（0 错误）。本 PR 清掉其中落在业务代码里的 17 条，仅留 vendored 的 shadcn `chart.tsx` 6 条（约定不动第三方生成代码）。

## 改动（纯类型，零行为变更）
- **route.helper.ts / tool-component.ts（8 条）**：Zod 泛型约束 `z.ZodTypeAny` 的 `.parse()/.safeParse().data` 运行时返回 `any`，用局部 `as z.infer<...>` 收口，不动泛型 bound、零外溢。
- **prisma-json.ts / provider.ts（3 条）**：`JSON.stringify` replacer 回调参数标 `(_key: string, currentValue: unknown)`。
- **tei-embedding-gemma-provider.ts（2 条）**：embedding 标 `unknown`，运行时守卫后 `as number[]`。
- **MetricChartsPage.tsx / AuthPage.tsx（4 条）**：recharts 回调参数显式注解 + tooltip payload 走类型守卫。

未使用任何 `eslint-disable`。

## 验证
`pnpm build / typecheck / lint / format / test` 全绿；666 个测试通过。lint 仅剩 6 条 vendored 警告，退出码 0。