### PR TITLE
fix(llm): 记录侧图片 sizeBytes 走 imageContentToBase64，修复中毒历史崩溃

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- llm: 修 [#127] 同源的**记录侧崩溃**。#127 把图片内容改 base64 + provider 映射走 `imageContentToBase64` 归一，但 `client.ts` 记录侧 `toRecordableContentPart` 仍 `Buffer.from(part.content, "base64")`；已被 JSON 毒过的历史图片消息（`{type:"Buffer",data:[]}` 对象）恢复后流到记录侧，对对象 `Buffer.from` 抛 `Received an instance of Object` → root agent loop 崩溃（生产部署 #127 后实测到，`invalid base64` 已消失但暴露此条）。记录侧也经 `imageContentToBase64` 归一；中毒对象随上下文压缩老化（[#128](https://github.com/KisinTheFlame/kagami/pull/128)）
 - llm/agent: 修复**多模态图片内容经持久化后 base64 失效**导致主 Agent 卡死的问题。`LlmImageContentPart.content` 原为 `Buffer`，而 Browser App 的 `screenshot` 是首个把图片放进**主 Agent 持久上下文**的场景——图片消息会随快照 / ledger 按 JSON 存，`Buffer` 经 JSON 往返变成 `{ type:"Buffer", data:[...] }` 不再是 Buffer，provider 侧 `part.content.toString("base64")` 于是产出 `"[object Object]"`，Claude API 报 `image.source.base64: invalid base64 data`；坏图留在历史里，每轮重发、每轮失败。修法：把 `LlmImageContentPart.content` 改为 **base64 字符串**（JSON 原生、往返不变、正是各 provider wire 格式所需），生产者（vision / playground / screenshot）在边缘 `toString("base64")` 一次；新增 `@kagami/llm` 导出 `imageContentToBase64(unknown)` 防御性归一，兼容 base64 字符串 / Buffer / `{type:"Buffer",data:[]}` 三态，让 4 个消费者（claude / openai-codex / openai-chat-mapper / 记录侧）对**已被 JSON 毒过的历史图片消息**也能恢复成合法 base64，无需手动改库；快照恢复 schema 放宽为永不拒绝（否则旧中毒快照恢复失败会丢上下文）。vision / playground 既有图片路径同步迁到字符串契约。新增 `imageContentToBase64` 三态回归测试（[#127](https://github.com/KisinTheFlame/kagami/pull/127)）
 
 ### Removed

--- a/apps/server/src/agent/runtime/root-agent/persistence/root-agent-runtime-snapshot.ts
+++ b/apps/server/src/agent/runtime/root-agent/persistence/root-agent-runtime-snapshot.ts
@@ -17,8 +17,9 @@ import { NapcatReceiveMessageSegmentSchema } from "../../../../napcat/domain/nap
 const DateValueSchema = z.coerce.date();
 const JsonRecordSchema = z.record(z.string(), z.unknown());
 // 图片内容现为 base64 字符串。恢复期永不拒绝（含被 JSON 毒过的旧快照里
-// {type:"Buffer",data:[...]} 残骸），由 provider 侧 imageContentToBase64 在发送时归一恢复；
-// 不在这里强校验 z.string()，否则旧中毒快照会恢复失败导致启动丢上下文。
+// {type:"Buffer",data:[...]} 残骸——z.string() 强校验会让旧中毒快照恢复失败、丢上下文）。
+// 对象形态的恢复兜底在两个下游消费点用 imageContentToBase64 完成：provider 发送映射、
+// client 记录侧；中毒对象随上下文压缩自然老化。
 const ImageContentSchema = z.custom<string>(() => true);
 
 const LlmTextContentPartSchema: z.ZodType<LlmTextContentPart> = z.object({

--- a/apps/server/src/llm/client.ts
+++ b/apps/server/src/llm/client.ts
@@ -17,6 +17,7 @@ import type {
   LlmChatResponsePayload,
   LlmToolChoice,
 } from "./types.js";
+import { imageContentToBase64 } from "@kagami/llm";
 
 const llmClientLogger = new AppLogger({ source: "llm.client" });
 
@@ -500,8 +501,9 @@ function toRecordableContentPart(part: LlmContentPart): Record<string, unknown> 
     type: "image",
     mimeType: part.mimeType,
     filename: part.filename,
-    // content 是 base64 字符串；解码回字节数用于记录展示。
-    sizeBytes: Buffer.from(part.content, "base64").byteLength,
+    // content 一般是 base64 字符串；imageContentToBase64 兜底已被 JSON 毒过的历史图片
+    // （{type:"Buffer",data:[]} 对象），避免对对象直接 Buffer.from 崩溃。解码回字节数仅用于记录。
+    sizeBytes: Buffer.from(imageContentToBase64(part.content), "base64").byteLength,
   };
 }
 


### PR DESCRIPTION
#127 的后续修复。#127 把图片内容改 base64 字符串 + provider 映射归一,但 `client.ts` 记录侧 `toRecordableContentPart` 仍 `Buffer.from(part.content,"base64")`。已被 JSON 毒过的历史图片消息(`{type:"Buffer",data:[]}` 对象)恢复后流到记录侧 → 对对象 `Buffer.from` 抛 `Received an instance of Object` → root agent loop 崩溃(生产部署 #127 后实测到)。

修法:记录侧也经 `imageContentToBase64` 归一。`invalid base64` 已消失,这条补掉同源的记录侧崩溃。中毒对象随上下文压缩自然老化。

验证:build / typecheck / lint / test(630)全绿。