### PR TITLE
refactor(server): 清理后端 P2/P3 技术债

### DIFF
--- a/apps/server/src/agent/capabilities/story/infra/hnsw-vector-index.ts
+++ b/apps/server/src/agent/capabilities/story/infra/hnsw-vector-index.ts
@@ -25,7 +25,7 @@ export type VectorIndexPoint = {
 };
 
 /**
- * Story 向量记忆的进程内 HNSW 索引（替代 pgvector）。
+ * Story 向量记忆的进程内 HNSW 索引。
  *
  * 设计：SQLite 是唯一事实来源（每条 `story_memory_document` 行内存归一化向量的 JSON），
  * HNSW 仅是派生的内存索引。启动时由 {@link rebuildFrom} 从 SQLite 全量重建，因此索引文件

--- a/apps/server/src/scheduler/tasks/data-retention/data-retention-task.factory.ts
+++ b/apps/server/src/scheduler/tasks/data-retention/data-retention-task.factory.ts
@@ -1,7 +1,11 @@
 import type { Database } from "@kagami/server-core/db/client";
 import type { MetricService } from "../../../metric/application/metric.service.js";
 import type { ScheduledTask, TaskRunMetadata } from "../../domain/scheduled-task.js";
-import { RETENTION_TASKS, type RetentionSpec } from "./retention-tasks.js";
+import {
+  RETENTION_TASKS,
+  type PrismaRetentionDelegate,
+  type RetentionSpec,
+} from "./retention-tasks.js";
 
 const CHUNK_SIZE = 5_000;
 const DAY_MS = 86_400_000;
@@ -21,7 +25,7 @@ function buildTask({ db, metricService, spec }: DataRetentionTaskDeps): Schedule
     schedule: { kind: "cron", expression },
     async run(signal: AbortSignal): Promise<TaskRunMetadata> {
       const threshold = new Date(Date.now() - spec.days * DAY_MS);
-      const delegate = spec.getDelegate(db);
+      const delegate = spec.getDelegate(db) as PrismaRetentionDelegate;
 
       let deletedRows = 0;
       let chunks = 0;

--- a/apps/server/src/scheduler/tasks/data-retention/retention-tasks.ts
+++ b/apps/server/src/scheduler/tasks/data-retention/retention-tasks.ts
@@ -24,8 +24,13 @@ export type RetentionSpec = {
   days: number;
   /** Stagger offset in minutes, combined with the 00:00 base cron to form `<offset> 0 * * *`. */
   offsetMinutes: number;
-  /** Resolve the Prisma delegate for this table. */
-  getDelegate: (db: Database) => PrismaRetentionDelegate;
+  /**
+   * Pick the Prisma delegate for this table. Returns `unknown` because each
+   * concrete delegate has a model-specific `findMany`/`deleteMany` signature
+   * that does not structurally match the loose {@link PrismaRetentionDelegate};
+   * the single narrowing cast lives at the call site in the task factory.
+   */
+  getDelegate: (db: Database) => unknown;
 };
 
 /**
@@ -59,62 +64,62 @@ export const RETENTION_TASKS: readonly RetentionSpec[] = [
     field: "createdAt",
     days: 7,
     offsetMinutes: 0,
-    getDelegate: db => db.appLog as unknown as PrismaRetentionDelegate,
+    getDelegate: db => db.appLog,
   },
   {
     displayName: "llm_chat_call",
     field: "createdAt",
     days: 3,
     offsetMinutes: 5,
-    getDelegate: db => db.llmChatCall as unknown as PrismaRetentionDelegate,
+    getDelegate: db => db.llmChatCall,
   },
   {
     displayName: "metric",
     field: "createdAt",
     days: 7,
     offsetMinutes: 10,
-    getDelegate: db => db.metric as unknown as PrismaRetentionDelegate,
+    getDelegate: db => db.metric,
   },
   {
     displayName: "napcat_event",
     field: "createdAt",
     days: 7,
     offsetMinutes: 15,
-    getDelegate: db => db.napcatEvent as unknown as PrismaRetentionDelegate,
+    getDelegate: db => db.napcatEvent,
   },
   {
     displayName: "napcat_qq_message",
     field: "createdAt",
     days: 7,
     offsetMinutes: 20,
-    getDelegate: db => db.napcatQqMessage as unknown as PrismaRetentionDelegate,
+    getDelegate: db => db.napcatQqMessage,
   },
   {
     displayName: "terminal_output",
     field: "createdAt",
     days: 7,
     offsetMinutes: 25,
-    getDelegate: db => db.terminalOutput as unknown as PrismaRetentionDelegate,
+    getDelegate: db => db.terminalOutput,
   },
   {
     displayName: "auth_usage_snapshot",
     field: "capturedAt",
     days: 30,
     offsetMinutes: 30,
-    getDelegate: db => db.authUsageSnapshot as unknown as PrismaRetentionDelegate,
+    getDelegate: db => db.authUsageSnapshot,
   },
   {
     displayName: "embedding_cache",
     field: "createdAt",
     days: 30,
     offsetMinutes: 35,
-    getDelegate: db => db.embeddingCache as unknown as PrismaRetentionDelegate,
+    getDelegate: db => db.embeddingCache,
   },
   {
     displayName: "oauth_state",
     field: "expiresAt",
     days: 7,
     offsetMinutes: 40,
-    getDelegate: db => db.oauthState as unknown as PrismaRetentionDelegate,
+    getDelegate: db => db.oauthState,
   },
 ];

--- a/apps/server/test/config/config.impl.manager.test.ts
+++ b/apps/server/test/config/config.impl.manager.test.ts
@@ -20,7 +20,7 @@ async function writeConfigFile(content: string): Promise<string> {
 function buildConfigYaml(napcatBlock: string, extraServerBlock = ""): string {
   return `
 server:
-  databaseUrl: postgresql://user:password@localhost:5432/kagami
+  databaseUrl: "file::memory:"
 ${extraServerBlock ? `${indent(extraServerBlock, 2)}\n` : ""}  napcat:
 ${indent(napcatBlock, 4)}
   agent:
@@ -135,7 +135,7 @@ startupContextRecentMessageCount: 0
 
     await expect(manager.config()).resolves.toMatchObject({
       server: {
-        databaseUrl: "postgresql://user:password@localhost:5432/kagami",
+        databaseUrl: "file::memory:",
         port: 3100,
         agent: {
           contextCompactionTotalTokenThreshold: 150_000,
@@ -329,7 +329,7 @@ listenGroupIds:
   it("should default context compaction threshold to 60", async () => {
     const configPath = await writeConfigFile(`
 server:
-  databaseUrl: postgresql://user:password@localhost:5432/kagami
+  databaseUrl: "file::memory:"
   agent:
     story:
       memory:
@@ -634,7 +634,7 @@ listenGroupIds:
   it("should allow overriding context compaction total token threshold", async () => {
     const configPath = await writeConfigFile(`
 server:
-  databaseUrl: postgresql://user:password@localhost:5432/kagami
+  databaseUrl: "file::memory:"
   agent:
     contextCompactionTotalTokenThreshold: 80000
     story:
@@ -705,7 +705,7 @@ server:
   it("should reject the legacy context compaction threshold field", async () => {
     const configPath = await writeConfigFile(`
 server:
-  databaseUrl: postgresql://user:password@localhost:5432/kagami
+  databaseUrl: "file::memory:"
   agent:
     contextCompactionThreshold: 80
     story:
@@ -779,7 +779,7 @@ server:
   it("should allow overriding llm retry backoff ms", async () => {
     const configPath = await writeConfigFile(`
 server:
-  databaseUrl: postgresql://user:password@localhost:5432/kagami
+  databaseUrl: "file::memory:"
   agent:
     llmRetryBackoffMs: 45000
     story:
@@ -849,7 +849,7 @@ server:
   it("should allow overriding wait tool max wait ms", async () => {
     const configPath = await writeConfigFile(`
 server:
-  databaseUrl: postgresql://user:password@localhost:5432/kagami
+  databaseUrl: "file::memory:"
   agent:
     waitToolMaxWaitMs: 120000
     story:

--- a/apps/server/test/napcat/napcat-gateway.test-helper.ts
+++ b/apps/server/test/napcat/napcat-gateway.test-helper.ts
@@ -92,7 +92,7 @@ export function createNapcatGroupMessageDao(): NapcatQqMessageDao & {
 export function createConfigManager(): ConfigManager {
   const config: Config = {
     server: {
-      databaseUrl: "postgresql://localhost:5432/kagami",
+      databaseUrl: "file::memory:",
       port: 20003,
       agent: {
         contextCompactionTotalTokenThreshold: 150_000,


### PR DESCRIPTION
## 背景

盘点后端 `apps/server/` 技术债后，先收拾 P2/P3 的低风险小点（P0 token 明文存储、P1 IThome 表清理策略另议）。

## 改动

1. **retention 任务类型收敛**（P2）
   - `retention-tasks.ts` 的 9 处 `db.xxx as unknown as PrismaRetentionDelegate` 全部消除；`getDelegate` 返回类型改为 `unknown`，各 entry 退化为纯映射 `db => db.appLog`。
   - 唯一一处 narrow（`as PrismaRetentionDelegate`）移到 `data-retention-task.factory.ts` 的调用点，并补注释说明原因（每个 Prisma delegate 各有 model-specific 签名，结构上不匹配松散接口）。

2. **测试 PG 占位串清理**（P3）
   - 8 处遗留的 `postgresql://user:password@localhost:5432/kagami` 改为 `file::memory:`。SQLite 迁移后这些只是误导性示例串；`file::memory:` 语义上即测试内存库，且 `resolveSqliteFileUrl` 对其原样透传，断言保持稳定。

3. **pgvector 注释残留**（P3）
   - 删除 `hnsw-vector-index.ts` 里「（替代 pgvector）」的纯历史框架表述。第 35–36 行解释 `score = 1 - distance` 数学由来的 pgvector 引用**保留**（有信息价值，非残留）。

## 校验

- `pnpm build` ✅
- `pnpm --filter @kagami/server typecheck` ✅
- `pnpm --filter @kagami/server test` ✅ 630 passed
- `pnpm lint` ✅ 0 error（6 个 warning 均为前端 recharts 既有，与本次无关）
- `pnpm format` ✅