### PR TITLE
refactor(server): claude-code-provider 复用 server-core 的 isRecord

### DIFF
--- a/apps/server/src/llm/providers/claude-code-provider.ts
+++ b/apps/server/src/llm/providers/claude-code-provider.ts
@@ -13,6 +13,7 @@ import type {
 } from "../types.js";
 import { imageContentToBase64 } from "@kagami/llm";
 import { BizError } from "@kagami/server-core/common/errors/biz-error";
+import { isRecord } from "@kagami/server-core/common/prisma-json";
 import type { Config } from "@kagami/server-core/config/config.loader";
 import { AppLogger } from "@kagami/server-core/logger/logger";
 import { ClaudeCodeAuthStore } from "./claude-code-auth.js";
@@ -911,10 +912,6 @@ function requireRequestModel(request: { model?: string }): string {
   }
 
   return request.model;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function toClaudeCodeRuntimeArch(): string {


### PR DESCRIPTION
## 背景

第二轮技术债盘点的真实项之一：`claude-code-provider.ts` 内部又写了一份与 `@kagami/server-core/common/prisma-json` 完全相同的 `isRecord` 类型守卫。仓库其它地方（napcat `shared.ts`、`invoke-tool-docs.ts` 等）早已从 server-core 导入同一个。

## 改动

- 删除 `claude-code-provider.ts` 本地重复的 `isRecord` 定义。
- 改为 `import { isRecord } from "@kagami/server-core/common/prisma-json"`，回归单一来源。
- 9 处调用点行为不变（实现逐字相同）。

## 说明：第二轮另一条「前端复用 shared schema」未做

经核实那条 agent 推荐**不安全**：前端 `llm-chat-call-detail-parser.ts` 的 request 解析刻意支持 user 消息里的 image 内容块（vision 调用），而 `@kagami/shared` 的 `LlmRequestMessageSchema` 是 `.strict()` + 纯字符串 content。直接替换会拒掉所有带图历史、导致 vision 调用详情白屏。该 parser 是诊断式宽松解析器，shape 比 API 契约更富属结构性必需，非技术债，故保留。

## 校验

- `pnpm build` ✅
- `pnpm --filter @kagami/server typecheck` ✅
- `pnpm --filter @kagami/server test` ✅ 630 passed
- `pnpm lint` ✅ 0 error
- `pnpm format` ✅