### PR TITLE
refactor(llm): request payload 收敛为 @kagami/shared 单一契约

### DIFF
--- a/apps/server/src/llm/client.ts
+++ b/apps/server/src/llm/client.ts
@@ -1,5 +1,9 @@
 import { randomUUID } from "node:crypto";
-import { type LlmProviderOption } from "@kagami/shared/schemas/llm-chat";
+import {
+  type LlmChatRequestPayload,
+  type LlmProviderOption,
+  type LlmRequestUserContentPart,
+} from "@kagami/shared/schemas/llm-chat";
 import type { LlmProviderId, LlmUsageId } from "@kagami/server-core/common/contracts/llm";
 import { AppLogger } from "@kagami/server-core/logger/logger";
 import type { Config } from "@kagami/server-core/config/config.loader";
@@ -459,7 +463,9 @@ function requireUsage(usage: LlmUsageId | undefined): LlmUsageId {
 }
 
 function toRecordableChatRequest(request: LlmChatRequest): Record<string, unknown> {
-  return {
+  // payload 显式标注为共享契约类型，把「落库 shape」钉死在 @kagami/shared 上：
+  // 后端序列化结构一旦漂移，这里立刻编译报错，前端 viewer 与之同源不再静默失配。
+  const payload: LlmChatRequestPayload = {
     ...(request.system ? { system: request.system } : {}),
     model: request.model,
     messages: request.messages.map(message => {
@@ -490,9 +496,11 @@ function toRecordableChatRequest(request: LlmChatRequest): Record<string, unknow
     tools: request.tools,
     toolChoice: request.toolChoice,
   };
+
+  return payload;
 }
 
-function toRecordableContentPart(part: LlmContentPart): Record<string, unknown> {
+function toRecordableContentPart(part: LlmContentPart): LlmRequestUserContentPart {
   if (part.type === "text") {
     return part;
   }

--- a/apps/web/src/pages/llm-history/LlmChatCallDetailPanel.tsx
+++ b/apps/web/src/pages/llm-history/LlmChatCallDetailPanel.tsx
@@ -2,6 +2,8 @@ import {
   type LlmChatCallItem,
   type LlmChatCallStatus,
   type LlmChatCallSummary,
+  type LlmRequestMessage,
+  type LlmRequestUserContentPart,
 } from "@kagami/shared/schemas/llm-chat";
 import { FlaskConical } from "lucide-react";
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
@@ -18,11 +20,7 @@ import {
   buildPlaygroundImportDraftFromHistory,
   type PlaygroundImportLocationState,
 } from "@/pages/llm-playground/playground-import";
-import {
-  parseLlmChatCallDetail,
-  type ParsedLlmRequestMessage,
-  type ParsedLlmUserContentPart,
-} from "./llm-chat-call-detail-parser";
+import { parseLlmChatCallDetail } from "./llm-chat-call-detail-parser";
 import { useLlmChatCallDetail } from "./useLlmChatCallDetail";
 
 type LlmChatCallDetailPanelProps = {
@@ -48,7 +46,7 @@ type InputEntry =
     }
   | {
       type: "message";
-      message: ParsedLlmRequestMessage;
+      message: LlmRequestMessage;
       originalIndex: number;
     };
 
@@ -429,7 +427,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function MessageCard({ message, index }: { message: ParsedLlmRequestMessage; index: number }) {
+function MessageCard({ message, index }: { message: LlmRequestMessage; index: number }) {
   const title = `消息 #${index + 1}`;
   const preview = buildMessagePreview({
     content: renderMessageContent(message.content),
@@ -472,7 +470,7 @@ function MessageContent({ content, emptyHint }: { content: string; emptyHint?: s
   return <pre className="whitespace-pre-wrap break-words text-xs leading-6">{content}</pre>;
 }
 
-function renderMessageContent(content: ParsedLlmRequestMessage["content"]): string {
+function renderMessageContent(content: LlmRequestMessage["content"]): string {
   if (typeof content === "string") {
     return content;
   }
@@ -480,7 +478,7 @@ function renderMessageContent(content: ParsedLlmRequestMessage["content"]): stri
   return content.map(renderUserContentPart).join("\n");
 }
 
-function renderUserContentPart(part: ParsedLlmUserContentPart): string {
+function renderUserContentPart(part: LlmRequestUserContentPart): string {
   if (part.type === "text") {
     return part.text;
   }

--- a/apps/web/src/pages/llm-history/llm-chat-call-detail-parser.ts
+++ b/apps/web/src/pages/llm-history/llm-chat-call-detail-parser.ts
@@ -1,57 +1,15 @@
 import {
   LlmChatErrorPayloadSchema,
+  LlmChatRequestPayloadSchema,
   LlmChatResponsePayloadSchema,
   type LlmChatCallItem,
   type LlmChatErrorPayload,
+  type LlmChatRequestPayload,
   type LlmChatResponsePayload,
-  type LlmToolCallPayload,
 } from "@kagami/shared/schemas/llm-chat";
 
-export type ParsedLlmUserContentPart =
-  | {
-      type: "text";
-      text: string;
-    }
-  | {
-      type: "image";
-      mimeType: string | null;
-      filename?: string;
-      sizeBytes?: number;
-    };
-
-export type ParsedLlmRequestMessage =
-  | {
-      role: "user";
-      content: string | ParsedLlmUserContentPart[];
-    }
-  | {
-      role: "assistant";
-      content: string;
-      toolCalls: LlmToolCallPayload[];
-    }
-  | {
-      role: "tool";
-      toolCallId: string;
-      content: string;
-    };
-
-export type ParsedLlmChatRequestPayload = {
-  system?: string;
-  messages: ParsedLlmRequestMessage[];
-  tools: Array<{
-    name: string;
-    description?: string;
-    parameters: {
-      type: "object";
-      properties: Record<string, unknown>;
-    };
-  }>;
-  toolChoice: "required" | "auto" | "none" | { tool_name: string };
-  model?: string;
-};
-
 export type LlmChatCallDetailParseResult = {
-  request: ParsedLlmChatRequestPayload | null;
+  request: LlmChatRequestPayload | null;
   response: LlmChatResponsePayload | null;
   error: LlmChatErrorPayload | null;
   hasSchemaError: boolean;
@@ -59,7 +17,7 @@ export type LlmChatCallDetailParseResult = {
 };
 
 export function parseLlmChatCallDetail(item: LlmChatCallItem): LlmChatCallDetailParseResult {
-  const requestParsed = parseRequestPayload(item.requestPayload);
+  const requestParsed = LlmChatRequestPayloadSchema.safeParse(item.requestPayload);
   const responseParsed =
     item.responsePayload === null
       ? null
@@ -68,7 +26,7 @@ export function parseLlmChatCallDetail(item: LlmChatCallItem): LlmChatCallDetail
 
   const schemaErrors: string[] = [];
   if (!requestParsed.success) {
-    schemaErrors.push(`requestPayload: ${requestParsed.error}`);
+    schemaErrors.push(`requestPayload: ${formatIssueSummary(requestParsed.error.issues)}`);
   }
 
   if (item.status === "success") {
@@ -96,189 +54,6 @@ export function parseLlmChatCallDetail(item: LlmChatCallItem): LlmChatCallDetail
   };
 }
 
-function parseRequestPayload(
-  payload: Record<string, unknown>,
-): { success: true; data: ParsedLlmChatRequestPayload } | { success: false; error: string } {
-  const system = typeof payload.system === "string" ? payload.system : undefined;
-  const model = typeof payload.model === "string" ? payload.model : undefined;
-
-  const toolsValue = payload.tools;
-  if (!Array.isArray(toolsValue)) {
-    return { success: false, error: "tools 必须是数组" };
-  }
-
-  const tools = toolsValue.map((tool, index) => {
-    if (!isRecord(tool)) {
-      throw new Error(`tools.${index} 必须是对象`);
-    }
-
-    if (typeof tool.name !== "string" || tool.name.length === 0) {
-      throw new Error(`tools.${index}.name 必须是非空字符串`);
-    }
-
-    const parameters = isRecord(tool.parameters) ? tool.parameters : null;
-    if (!parameters || parameters.type !== "object" || !isRecord(parameters.properties)) {
-      throw new Error(`tools.${index}.parameters 必须是 object schema`);
-    }
-
-    return {
-      name: tool.name,
-      description: typeof tool.description === "string" ? tool.description : undefined,
-      parameters: {
-        type: "object" as const,
-        properties: parameters.properties,
-      },
-    };
-  });
-
-  const messagesValue = payload.messages;
-  if (!Array.isArray(messagesValue)) {
-    return { success: false, error: "messages 必须是数组" };
-  }
-
-  let messages: ParsedLlmRequestMessage[];
-  try {
-    messages = messagesValue.map((message, index) => parseRequestMessage(message, index));
-  } catch (error) {
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : String(error),
-    };
-  }
-
-  const toolChoice = parseToolChoice(payload.toolChoice);
-  if (!toolChoice) {
-    return { success: false, error: "toolChoice 不合法" };
-  }
-
-  return {
-    success: true,
-    data: {
-      ...(system ? { system } : {}),
-      ...(model ? { model } : {}),
-      messages,
-      tools,
-      toolChoice,
-    },
-  };
-}
-
-function parseRequestMessage(value: unknown, index: number): ParsedLlmRequestMessage {
-  if (!isRecord(value)) {
-    throw new Error(`messages.${index} 必须是对象`);
-  }
-
-  if (value.role === "user") {
-    const content = parseUserContent(value.content, index);
-    return {
-      role: "user",
-      content,
-    };
-  }
-
-  if (value.role === "assistant") {
-    return {
-      role: "assistant",
-      content: typeof value.content === "string" ? value.content : "",
-      toolCalls: parseToolCalls(value.toolCalls, index),
-    };
-  }
-
-  if (value.role === "tool") {
-    if (typeof value.toolCallId !== "string" || value.toolCallId.length === 0) {
-      throw new Error(`messages.${index}.toolCallId 必须是非空字符串`);
-    }
-
-    return {
-      role: "tool",
-      toolCallId: value.toolCallId,
-      content: typeof value.content === "string" ? value.content : "",
-    };
-  }
-
-  throw new Error(`messages.${index}.role 不合法`);
-}
-
-function parseUserContent(value: unknown, index: number): string | ParsedLlmUserContentPart[] {
-  if (typeof value === "string") {
-    return value;
-  }
-
-  if (!Array.isArray(value)) {
-    throw new Error(`messages.${index}.content 必须是字符串或数组`);
-  }
-
-  return value.map((part, partIndex) => parseUserContentPart(part, index, partIndex));
-}
-
-function parseUserContentPart(
-  value: unknown,
-  messageIndex: number,
-  partIndex: number,
-): ParsedLlmUserContentPart {
-  if (!isRecord(value) || typeof value.type !== "string") {
-    throw new Error(`messages.${messageIndex}.content.${partIndex} 必须包含合法 type`);
-  }
-
-  if (value.type === "text") {
-    return {
-      type: "text",
-      text: typeof value.text === "string" ? value.text : "",
-    };
-  }
-
-  if (value.type === "image") {
-    return {
-      type: "image",
-      mimeType: typeof value.mimeType === "string" ? value.mimeType : null,
-      ...(typeof value.filename === "string" ? { filename: value.filename } : {}),
-      ...(typeof value.sizeBytes === "number" ? { sizeBytes: value.sizeBytes } : {}),
-    };
-  }
-
-  throw new Error(`messages.${messageIndex}.content.${partIndex}.type 不支持: ${value.type}`);
-}
-
-function parseToolCalls(value: unknown, index: number): LlmToolCallPayload[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-
-  return value.flatMap((toolCall, toolIndex) => {
-    if (!isRecord(toolCall)) {
-      return [];
-    }
-
-    if (
-      typeof toolCall.id !== "string" ||
-      typeof toolCall.name !== "string" ||
-      !isRecord(toolCall.arguments)
-    ) {
-      throw new Error(`messages.${index}.toolCalls.${toolIndex} 结构不合法`);
-    }
-
-    return [
-      {
-        id: toolCall.id,
-        name: toolCall.name,
-        arguments: toolCall.arguments,
-      },
-    ];
-  });
-}
-
-function parseToolChoice(value: unknown): ParsedLlmChatRequestPayload["toolChoice"] | null {
-  if (value === "required" || value === "auto" || value === "none") {
-    return value;
-  }
-
-  if (isRecord(value) && typeof value.tool_name === "string" && value.tool_name.length > 0) {
-    return { tool_name: value.tool_name };
-  }
-
-  return null;
-}
-
 function sanitizeResponsePayload(payload: Record<string, unknown>): Record<string, unknown> {
   const sanitized = { ...payload };
   delete sanitized.text;
@@ -300,8 +75,4 @@ function formatIssueSummary(
       return `${path} ${issue.message}`;
     })
     .join("; ");
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/apps/web/src/pages/llm-playground/playground-import.ts
+++ b/apps/web/src/pages/llm-playground/playground-import.ts
@@ -1,15 +1,13 @@
 import {
   type LlmChatCallItem,
+  type LlmChatRequestPayload,
   type LlmPlaygroundChatRequest,
   type LlmProviderOption,
+  type LlmRequestMessage,
+  type LlmRequestUserContentPart,
   type PlaygroundContentPart,
   type PlaygroundMessage,
 } from "@kagami/shared/schemas/llm-chat";
-import type {
-  ParsedLlmChatRequestPayload,
-  ParsedLlmRequestMessage,
-  ParsedLlmUserContentPart,
-} from "@/pages/llm-history/llm-chat-call-detail-parser";
 
 export type PlaygroundImportWarningCode =
   | "image_omitted"
@@ -51,7 +49,7 @@ export type ResolvedPlaygroundImport = {
 
 export function buildPlaygroundImportDraftFromHistory(params: {
   item: LlmChatCallItem;
-  request: ParsedLlmChatRequestPayload;
+  request: LlmChatRequestPayload;
 }): PlaygroundImportDraft {
   const { item, request } = params;
   const imageStats = { count: 0 };
@@ -158,7 +156,7 @@ export function getPlaygroundImportDraftFromLocationState(
 }
 
 function toPlaygroundMessage(params: {
-  message: ParsedLlmRequestMessage;
+  message: LlmRequestMessage;
   imageStats: { count: number };
 }): PlaygroundMessage {
   const { message, imageStats } = params;
@@ -188,7 +186,7 @@ function toPlaygroundMessage(params: {
 }
 
 function toPlaygroundContentPart(params: {
-  part: ParsedLlmUserContentPart;
+  part: LlmRequestUserContentPart;
   imageStats: { count: number };
 }): PlaygroundContentPart {
   const { part, imageStats } = params;
@@ -207,7 +205,7 @@ function toPlaygroundContentPart(params: {
 }
 
 function buildImagePlaceholderText(
-  part: Extract<ParsedLlmUserContentPart, { type: "image" }>,
+  part: Extract<LlmRequestUserContentPart, { type: "image" }>,
 ): string {
   const meta = [
     part.filename ? `文件名：${part.filename}` : null,

--- a/packages/shared/src/schemas/llm-chat.ts
+++ b/packages/shared/src/schemas/llm-chat.ts
@@ -24,22 +24,50 @@ export const LlmToolDefinitionSchema = z
   .object({
     name: z.string().min(1),
     description: z.string().optional(),
-    parameters: z
-      .object({
-        type: z.literal("object"),
-        properties: JsonRecordSchema,
-      })
-      .strict(),
+    // parameters 是开放式 JSON Schema：真实工具普遍带 required / enum / $defs 等关键字，
+    // 故只校验 object 顶层骨架、不加 .strict()，其余关键字按 zod 默认 strip。viewer 仅用
+    // tool.name，playground replay 也只需骨架，丢弃这些关键字无影响（与旧手搓 parser 一致）。
+    parameters: z.object({
+      type: z.literal("object"),
+      properties: JsonRecordSchema,
+    }),
   })
   .strict();
 
 export type LlmToolDefinition = z.infer<typeof LlmToolDefinitionSchema>;
 
+export const LlmRequestTextContentPartSchema = z
+  .object({
+    type: z.literal("text"),
+    text: z.string(),
+  })
+  .strict();
+
+/**
+ * user 消息里的图片内容块在落库前已剥掉 base64 原图（见 server 侧
+ * `toRecordableChatRequest`），只留元数据：`mimeType` + 可选 `filename` + 原图字节数。
+ */
+export const LlmRequestImageContentPartSchema = z
+  .object({
+    type: z.literal("image"),
+    mimeType: z.string(),
+    filename: z.string().optional(),
+    sizeBytes: z.number().int().nonnegative(),
+  })
+  .strict();
+
+export const LlmRequestUserContentPartSchema = z.discriminatedUnion("type", [
+  LlmRequestTextContentPartSchema,
+  LlmRequestImageContentPartSchema,
+]);
+
+export type LlmRequestUserContentPart = z.infer<typeof LlmRequestUserContentPartSchema>;
+
 export const LlmRequestMessageSchema = z.discriminatedUnion("role", [
   z
     .object({
       role: z.literal("user"),
-      content: z.string(),
+      content: z.union([z.string(), z.array(LlmRequestUserContentPartSchema)]),
     })
     .strict(),
   z


### PR DESCRIPTION
## 背景

技术债盘点中发现：`@kagami/shared` 里的 `LlmChatRequestPayloadSchema` / `LlmRequestMessageSchema` **定义了却全仓无人引用**，而前端 LLM 历史 viewer 另写了一整套手搓 parser（`ParsedLlmChatRequestPayload` + `parseRequestPayload/parseRequestMessage/...`）来解析 request payload。两者与后端落库结构之间没有任何编译期联系——后端改了序列化格式，前端只能靠手搓跟着改，且不会被任何类型/契约检查发现（静默漂移）。

讨论后选择**彻底档（闭环）**：与其删掉这套没人用的 schema，不如把它接上、让它成为生产端与消费端共同遵守的真契约。

## 改动

**1. shared `schemas/llm-chat.ts`** — 忠实建模落库 shape
- user 消息 `content` 由纯 string 扩展为 `string | (text块 | image块)[]`；image 块按落库结构建模 `{type, mimeType, filename?, sizeBytes}`（base64 原图在落库前已被 `toRecordableChatRequest` 剥除）。
- `LlmToolDefinitionSchema.parameters` 去掉 `.strict()`：tool parameters 本质是开放式 JSON Schema，真实工具普遍带 `required` / `enum` / `$defs` 等关键字，strict 会误拒。其余关键字按 zod 默认 strip（与旧 parser 行为一致，viewer 仅用 `tool.name`）。
- 消息 / 内容块 / toolChoice / 顶层请求对象**保持 `.strict()`**，捕获未来漂移。

**2. 后端 `llm/client.ts`** — 钉死生产端
- `toRecordableChatRequest` / `toRecordableContentPart` 的产出显式标注为 `LlmChatRequestPayload` / `LlmRequestUserContentPart`。后端落库结构一旦漂移，这里立刻编译报错。

**3. 前端** — 消费端走 schema
- `llm-chat-call-detail-parser.ts`：删除手搓 parser（约 130 行）与本地 `ParsedLlm*` 类型、本地 `isRecord`，request 改走 `LlmChatRequestPayloadSchema.safeParse`，与既有 response/error 解析完全统一（含 schema 错误展示）。
- `LlmChatCallDetailPanel.tsx`、`playground-import.ts`：类型引用从 `ParsedLlm*` 切到 shared 的 `LlmRequestMessage` / `LlmRequestUserContentPart`。

净变更：**+65 / −262**。

## 验证

- 全套：`pnpm build` ✅ `typecheck`（全包）✅ `pnpm --filter @kagami/server test`（630）✅ `lint` 0 error ✅ `format` ✅
- **真实生产库全量回放**：导出 `llm_chat_call` 全部 9134 条 `request_payload`，逐条跑新 `LlmChatRequestPayloadSchema.safeParse` —— **100% 通过，零失败**。覆盖含工具记录 8771 条（验证 `required` 等关键字不再被误拒）、含图片块记录 1230 条（验证 vision 路径建模正确）。