### PR TITLE
feat(todo): add_todo 的 note 与 remindAt 改为必填

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- todo: `add_todo` 工具把 `note` 与 `remindAt` 由可选改为**必填**（`repeatEvery` 仍可选），让每条新建待办都带备注与未来提醒时刻、到点必走通知。强制点落在工具的 Zod schema 与 `parameters.required`，并同步收紧 todo App `help()` 文案（`add_todo(title, note, remindAt, repeatEvery?)`）；`TodoService.addTodo` 签名刻意保持宽松（tool 是 Agent 唯一写入口，service 为内部 API），DB 列保持 nullable、不迁移、不回填存量。保证的是「创建时必填」而非全局不变量——一次性提醒（无 `repeatEvery`）触发后 `remindAt` 仍按既有设计被 `clearReminder` 清空。补 `缺 note` / `缺 remindAt` → `INVALID_ARGUMENTS` 两个用例，并修 happy-path 与「过去 remindAt → INVALID_TIME」用例补齐必填字段
+
 ### Fixed
 
 - llm: 修 [#127] 同源的**记录侧崩溃**。#127 把图片内容改 base64 + provider 映射走 `imageContentToBase64` 归一，但 `client.ts` 记录侧 `toRecordableContentPart` 仍 `Buffer.from(part.content, "base64")`；已被 JSON 毒过的历史图片消息（`{type:"Buffer",data:[]}` 对象）恢复后流到记录侧，对对象 `Buffer.from` 抛 `Received an instance of Object` → root agent loop 崩溃（生产部署 #127 后实测到，`invalid base64` 已消失但暴露此条）。记录侧也经 `imageContentToBase64` 归一；中毒对象随上下文压缩老化（[#128](https://github.com/KisinTheFlame/kagami/pull/128)）

--- a/apps/server/src/agent/apps/todo/todo.app.ts
+++ b/apps/server/src/agent/apps/todo/todo.app.ts
@@ -61,7 +61,7 @@ export class TodoApp implements App {
       "你在待办 App 里。这是你自己的待办本，想怎么用都行。",
       "",
       "可调用工具：",
-      "  - add_todo(title, note?, remindAt?, repeatEvery?): 记一条。remindAt/repeatEvery 收相对时长（30m/1d）或 ISO。",
+      "  - add_todo(title, note, remindAt, repeatEvery?): 记一条。note、remindAt 必填；remindAt/repeatEvery 收相对时长（30m/1d）或 ISO。",
       "  - list_todos(filter?): 列出待办（pending 默认 / all / done）。",
       "  - complete_todo(id): 标记完成。",
       "  - snooze_todo(id, until? | forMinutes?): 稍后再提醒。",

--- a/apps/server/src/agent/apps/todo/tools/add-todo.tool.ts
+++ b/apps/server/src/agent/apps/todo/tools/add-todo.tool.ts
@@ -7,8 +7,8 @@ export const ADD_TODO_TOOL_NAME = "add_todo";
 
 const AddTodoArgumentsSchema = z.object({
   title: z.string().min(1),
-  note: z.string().min(1).optional(),
-  remindAt: z.string().min(1).optional(),
+  note: z.string().min(1),
+  remindAt: z.string().min(1),
   repeatEvery: z.string().min(1).optional(),
 });
 
@@ -23,22 +23,22 @@ type AddTodoToolDeps = {
 export class AddTodoTool extends ZodToolComponent<typeof AddTodoArgumentsSchema> {
   public readonly name = ADD_TODO_TOOL_NAME;
   public readonly description =
-    "记一条待办。可选 note 备注、remindAt 首次提醒、repeatEvery 重复间隔。时间收相对时长（如 30m/2h/1d）或 ISO 绝对时间。只能在 todo App 里通过 invoke 调用。";
+    "记一条待办。必填 note 备注、remindAt 首次提醒；可选 repeatEvery 重复间隔。时间收相对时长（如 30m/2h/1d）或 ISO 绝对时间。只能在 todo App 里通过 invoke 调用。";
   public readonly parameters = {
     type: "object",
     properties: {
       title: { type: "string", description: "待办标题。" },
-      note: { type: "string", description: "可选备注（来历、上下文，自由文本）。" },
+      note: { type: "string", description: "必填备注（来历、上下文，自由文本）。" },
       remindAt: {
         type: "string",
-        description: '可选首次提醒时间。相对时长如 "30m"/"2h"/"1d"，或 ISO 绝对时间。',
+        description: '必填首次提醒时间。相对时长如 "30m"/"2h"/"1d"，或 ISO 绝对时间。',
       },
       repeatEvery: {
         type: "string",
         description: '可选重复间隔，如 "1d"。设了则到点后自动续期，不设则只提醒一次。',
       },
     },
-    required: ["title"],
+    required: ["title", "note", "remindAt"],
   } as const;
   public readonly kind: ToolKind = "business";
   protected readonly inputSchema = AddTodoArgumentsSchema;

--- a/apps/server/test/agent/apps/todo/todo-tools.test.ts
+++ b/apps/server/test/agent/apps/todo/todo-tools.test.ts
@@ -25,7 +25,11 @@ async function run(tool: ToolComponent, args: Record<string, unknown>): Promise<
 describe("AddTodoTool", () => {
   it("happy → ok + message", async () => {
     const { getTodoService } = setup();
-    const out = await run(new AddTodoTool({ getTodoService }), { title: "写周报" });
+    const out = await run(new AddTodoTool({ getTodoService }), {
+      title: "写周报",
+      note: "本周进展汇总",
+      remindAt: "1h",
+    });
     expect(out).toMatchObject({ ok: true, id: 1 });
   });
 
@@ -35,10 +39,23 @@ describe("AddTodoTool", () => {
     expect(out).toMatchObject({ ok: false, error: "INVALID_ARGUMENTS" });
   });
 
+  it("缺 note → INVALID_ARGUMENTS（Zod 边界）", async () => {
+    const { getTodoService } = setup();
+    const out = await run(new AddTodoTool({ getTodoService }), { title: "x", remindAt: "1h" });
+    expect(out).toMatchObject({ ok: false, error: "INVALID_ARGUMENTS" });
+  });
+
+  it("缺 remindAt → INVALID_ARGUMENTS（Zod 边界）", async () => {
+    const { getTodoService } = setup();
+    const out = await run(new AddTodoTool({ getTodoService }), { title: "x", note: "n" });
+    expect(out).toMatchObject({ ok: false, error: "INVALID_ARGUMENTS" });
+  });
+
   it("过去 remindAt → INVALID_TIME", async () => {
     const { getTodoService } = setup();
     const out = await run(new AddTodoTool({ getTodoService }), {
       title: "x",
+      note: "n",
       remindAt: "2020-01-01T00:00:00.000Z",
     });
     expect(out).toMatchObject({ ok: false, error: "INVALID_TIME" });


### PR DESCRIPTION
## 背景

TODO App 原本允许创建「裸」待办：只给 `title`，不带备注、不带提醒。这类待办永远不进提醒管线（`remindAt=null` → 不被 `findDueReminders` 捞到），沦为静默清单项，违背「每条待办都该排好预计时间、到点有通知」的使用预期。

## 改动

在**工具层**把 `add_todo` 的 `note` 与 `remindAt` 由可选改为**必填**（`repeatEvery` 仍可选）。

| 文件 | 改动 |
|------|------|
| `apps/server/src/agent/apps/todo/tools/add-todo.tool.ts` | Zod 里 `note`/`remindAt` 去 `.optional()`；`parameters.required` → `["title","note","remindAt"]`；字段与 tool description 措辞由「可选」改「必填」 |
| `apps/server/src/agent/apps/todo/todo.app.ts` | App `help()` 渐进式披露文案同步：`add_todo(title, note, remindAt, repeatEvery?)` |
| `apps/server/test/agent/apps/todo/todo-tools.test.ts` | 补「缺 note」「缺 remindAt」→ `INVALID_ARGUMENTS` 两个用例；修 happy-path 与「过去 remindAt → INVALID_TIME」用例补齐必填字段 |

### 刻意不动

- `TodoService.addTodo` 签名保持宽松 —— tool 是 Agent 唯一写入口，service 是内部 API，不收紧以免无谓波及十几处 service 层测试。
- `update_todo` 不变（部分更新保留）。`repeatEvery` 保持可选（一次性提醒即满足「到点有通知」）。
- DB 列保持 `remindAt DateTime?` nullable，无 Prisma 迁移；存量 `remindAt=null` 行不回填（只管今后）。

### 边界说明

保证的是「**创建时必填**」，不是全局永久不变量 —— 一次性提醒（无 `repeatEvery`）触发后 `remindAt` 会被 `clearReminder` 清空，这是既有设计，符合「通知发过就完事」。

### KV 缓存

改动落在 `add_todo` 的 tool schema 与 App help（稳定前缀的一部分），在飞会话前缀会失效一次，属可接受的一次性代价，已集中在单个 commit。

## 验证

- `pnpm --filter @kagami/server test` → **632 passed**
- `pnpm build / typecheck / lint / format` → 全绿

🤖 本 PR 由 codex 做过独立 spec 评审（抓到 help 文案漏改、第二个待修测试、「不变量」框架误判三处，已全部纳入）。
