### PR TITLE
feat(todo): App 级回顾改为每天两次并加创建提示

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Changed
 
+- todo: App 级回顾由**每天一次**改为**每天两次**（09:00 / 21:00）的统一提醒，并加入推动小镜规划的固定提示。每条 todo 自己的 `remindAt` 到点提醒（`reminder-tick`）不变，只动 App 级 digest：`DAILY_DIGEST_CRON` 由 `0 9 * * *` 改为 `0 9,21 * * *`（croner 原生支持 `9,21` 列表）；`TodoReminderPoller.runDigest` 去掉 `totalCount > 0` 守卫改为**无条件回调**——即使当前没有未完成项也照发，因为这条提醒除汇总未完成项外还要顺带提示小镜「去 todo App 按自己打算做的事添几条新待办」，空待办时同样需要推动规划。`TodoDigestDraft.render` 改为两段式：有未完成项时在「还有 N 件没做…」后追加创建提示，零未完成项时输出兜底文案「待办都清空了，没有未完成的事。」+ 同一句提示。两次回顾间隔 12h、共用 `sourceId="todo:digest"` 互不重叠，提醒仍经 NotificationCenter append 到尾部、不碰稳定前缀，对 KV 缓存中性。同步更新 digest draft 渲染与 runDigest 空待办两处用例
 - todo: `add_todo` 工具把 `note` 与 `remindAt` 由可选改为**必填**（`repeatEvery` 仍可选），让每条新建待办都带备注与未来提醒时刻、到点必走通知。强制点落在工具的 Zod schema 与 `parameters.required`，并同步收紧 todo App `help()` 文案（`add_todo(title, note, remindAt, repeatEvery?)`）；`TodoService.addTodo` 签名刻意保持宽松（tool 是 Agent 唯一写入口，service 为内部 API），DB 列保持 nullable、不迁移、不回填存量。保证的是「创建时必填」而非全局不变量——一次性提醒（无 `repeatEvery`）触发后 `remindAt` 仍按既有设计被 `clearReminder` 清空。补 `缺 note` / `缺 remindAt` → `INVALID_ARGUMENTS` 两个用例，并修 happy-path 与「过去 remindAt → INVALID_TIME」用例补齐必填字段
 
 ### Fixed

--- a/apps/server/src/agent/apps/todo/todo-digest-draft.ts
+++ b/apps/server/src/agent/apps/todo/todo-digest-draft.ts
@@ -2,11 +2,12 @@ import type { NotificationDraft } from "../../runtime/root-agent/notification/no
 import { TODO_NOTIFICATION_GROUP } from "./todo-reminder-draft.js";
 
 /**
- * 每日待办回顾的通知 draft（手机 OS 模型）。
+ * 待办回顾的通知 draft（手机 OS 模型）：App 级的每日两次（09:00 / 21:00）统一提醒。
  *
- * 单一 `sourceId="todo:digest"`，一天一条；items 已由 service 封顶。渲染：
- *   `还有 N 件没做：《X》《Y》…（其余 M 件）`
- * digest 一天只 push 一次，merge 取最新即可。
+ * 单一 `sourceId="todo:digest"`，每次回顾一条；items 已由 service 封顶。渲染分两段：
+ *   1. 未完成项汇总（空待办时给兜底文案）；
+ *   2. 固定提示小镜去 todo App 按自己打算做的事添新待办。
+ * 两次回顾间隔 12h、互不重叠，merge 取最新即可。
  */
 export class TodoDigestDraft implements NotificationDraft {
   public readonly sourceId = "todo:digest";
@@ -25,9 +26,13 @@ export class TodoDigestDraft implements NotificationDraft {
   }
 
   public render(): string {
+    const nudge = "顺便想想接下来打算做什么，去 todo App 按自己的计划添几条新待办吧。";
+    if (this.totalCount === 0) {
+      return `待办都清空了，没有未完成的事。${nudge}`;
+    }
     const listed = this.titles.map(title => `《${title}》`).join("");
     const hidden = this.totalCount - this.titles.length;
     const tail = hidden > 0 ? `…（其余 ${hidden} 件）` : "";
-    return `还有 ${this.totalCount} 件没做：${listed}${tail}`;
+    return `还有 ${this.totalCount} 件没做：${listed}${tail}。${nudge}`;
   }
 }

--- a/apps/server/src/agent/capabilities/todo/application/todo-reminder-poller.ts
+++ b/apps/server/src/agent/capabilities/todo/application/todo-reminder-poller.ts
@@ -8,7 +8,7 @@ type TodoReminderPollerDeps = {
   todoService: TodoService;
   /** 每条到点提醒回调一次（由上层构造 TodoReminderDraft 并 push）。 */
   onDueReminder: (reminder: DueReminder) => void;
-  /** 每日 digest 有未完成项时回调一次（由上层构造 TodoDigestDraft 并 push）。 */
+  /** 每次待办回顾（每天两次）无条件回调一次（由上层构造 TodoDigestDraft 并 push）。 */
   onDigest: (summary: DigestSummary) => void;
 };
 
@@ -46,13 +46,16 @@ export class TodoReminderPoller {
     }
   }
 
-  /** 每日回顾：有未完成项才回调。 */
+  /**
+   * 待办回顾：每天两次（09:00 / 21:00）无条件回调一次。
+   *
+   * 即使当前没有未完成项也照样回调——这条 App 级提醒除了汇总未完成项，还要顺带推动小镜去
+   * todo App 按自己打算做的事添新待办，所以空待办时也得发（由 TodoDigestDraft 渲染兜底文案）。
+   */
   public async runDigest(): Promise<void> {
     try {
       const summary = await this.todoService.buildDigest({ limit: TODO_LIST_RENDER_LIMIT });
-      if (summary.totalCount > 0) {
-        this.onDigest(summary);
-      }
+      this.onDigest(summary);
     } catch (error) {
       logger.warn("Failed to run todo daily digest", {
         event: "todo.digest_failed",

--- a/apps/server/src/agent/capabilities/todo/application/todo.constants.ts
+++ b/apps/server/src/agent/capabilities/todo/application/todo.constants.ts
@@ -10,12 +10,15 @@
 export const REMINDER_TICK_MS = 60_000;
 
 /**
- * 每日待办回顾的 cron 表达式。
+ * 待办回顾的 cron 表达式：每天两次（09:00 与 21:00）的 App 级统一提醒。
+ *
+ * 这条是 todo App 自己的整体提醒，与每条 todo 的 remindAt 到点提醒（reminder-tick）相互独立。
+ * 除汇总未完成项外，还会顺带提示小镜去 todo App 按自己打算做的事添新待办（见 TodoDigestDraft）。
  *
  * 时区：cron 解析依赖进程本地时区。部署机需设 `TZ=Asia/Shanghai`，否则 UTC 机器上
  * 小镜会在本地凌晨唠叨。（若调度层将来支持显式 TZ，应在那里指定，把这条注释收紧。）
  */
-export const DAILY_DIGEST_CRON = "0 9 * * *";
+export const DAILY_DIGEST_CRON = "0 9,21 * * *";
 
 /** active（pending）待办上限，防爆。 */
 export const MAX_ACTIVE_TODOS = 200;

--- a/apps/server/test/agent/apps/todo/todo-drafts.test.ts
+++ b/apps/server/test/agent/apps/todo/todo-drafts.test.ts
@@ -17,22 +17,29 @@ describe("TodoReminderDraft", () => {
   });
 });
 
+const NUDGE = "顺便想想接下来打算做什么，去 todo App 按自己的计划添几条新待办吧。";
+
 describe("TodoDigestDraft", () => {
-  it("无截断：列出全部", () => {
+  it("无截断：列出全部，附创建提示", () => {
     const draft = new TodoDigestDraft({
       totalCount: 2,
       items: [{ title: "a" }, { title: "b" }],
     });
     expect(draft.sourceId).toBe("todo:digest");
     expect(draft.group).toBe("待办");
-    expect(draft.render()).toBe("还有 2 件没做：《a》《b》");
+    expect(draft.render()).toBe(`还有 2 件没做：《a》《b》。${NUDGE}`);
   });
 
-  it("有截断：附「其余 N 件」", () => {
+  it("有截断：附「其余 N 件」与创建提示", () => {
     const draft = new TodoDigestDraft({
       totalCount: 5,
       items: [{ title: "a" }, { title: "b" }],
     });
-    expect(draft.render()).toBe("还有 5 件没做：《a》《b》…（其余 3 件）");
+    expect(draft.render()).toBe(`还有 5 件没做：《a》《b》…（其余 3 件）。${NUDGE}`);
+  });
+
+  it("零未完成项：兜底文案 + 创建提示", () => {
+    const draft = new TodoDigestDraft({ totalCount: 0, items: [] });
+    expect(draft.render()).toBe(`待办都清空了，没有未完成的事。${NUDGE}`);
   });
 });

--- a/apps/server/test/agent/capabilities/todo/todo-reminder-poller.test.ts
+++ b/apps/server/test/agent/capabilities/todo/todo-reminder-poller.test.ts
@@ -69,9 +69,10 @@ describe("TodoReminderPoller.runDigest", () => {
     expect(digests[0].totalCount).toBe(1);
   });
 
-  it("零未完成项 → 不回调", async () => {
+  it("零未完成项 → 仍回调一次（无条件触发，用于推动小镜创建新待办）", async () => {
     const { poller, digests } = setup();
     await poller.runDigest();
-    expect(digests).toEqual([]);
+    expect(digests).toHaveLength(1);
+    expect(digests[0].totalCount).toBe(0);
   });
 });


### PR DESCRIPTION
## 背景

todo App 此前的 App 级提醒（`todo:daily-digest`）每天 09:00 一次，汇总未完成项「还有 N 件没做…」。本次按需求改成**每天两次**的统一提醒，并新增一段推动小镜主动规划的提示。

每条 todo 自己的 `remindAt` 到点提醒（`reminder-tick`，每 60s 扫描）**不在本次改动范围**，保持不变。

## 改动

- **cron**：`DAILY_DIGEST_CRON` 由 `0 9 * * *` → `0 9,21 * * *`（每天 09:00 + 21:00；croner 原生支持 `9,21` 列表）。
- **无条件触发**：`TodoReminderPoller.runDigest` 去掉 `totalCount > 0` 守卫，改为无条件回调一次。即使当前没有未完成项也照发——这条提醒除汇总未完成项外，还要顺带提示小镜「去 todo App 按自己打算做的事添几条新待办」，空待办时同样需要推动规划。
- **两段式渲染**：`TodoDigestDraft.render`
  - 有未完成项：`还有 N 件没做：《X》《Y》…（其余 M 件）。顺便想想接下来打算做什么，去 todo App 按自己的计划添几条新待办吧。`
  - 零未完成项兜底：`待办都清空了，没有未完成的事。顺便想想接下来打算做什么，去 todo App 按自己的计划添几条新待办吧。`
- **测试同步**：`runDigest` 空待办用例改为「仍回调一次」；digest draft 渲染补创建提示与零未完成项兜底用例。

## KV 缓存

两次回顾间隔 12h、共用 `sourceId="todo:digest"` 互不重叠（`merge` 取最新）。提醒仍经 NotificationCenter append 到消息尾部、不碰稳定前缀，对 provider 侧 KV 缓存中性。

## 验证

- `pnpm --filter @kagami/server test`：639 passed
- `pnpm build` / `pnpm typecheck` / `pnpm format`：全绿
- `pnpm lint`：0 error（6 个既有 warning 全在 `apps/web/src/components/ui/chart.tsx`，与本次无关）