### PR TITLE
refactor(agent): 删除死的 getCurrentGroupId 抽象泄漏 API

### DIFF
--- a/apps/server/src/agent/runtime/root-agent/session/root-agent-session.ts
+++ b/apps/server/src/agent/runtime/root-agent/session/root-agent-session.ts
@@ -50,7 +50,6 @@ export type RootAgentSessionController = {
   setCurrentApp(appId: AppId): void;
   clearCurrentApp(): void;
   getCurrentChatTarget(): NapcatChatTarget | undefined;
-  getCurrentGroupId(): string | undefined;
   getAvailableInvokeTools(): string[];
   getStateView(): Promise<RootAgentSessionStateView>;
   exportPersistedSnapshot(): CurrentPersistedRootAgentSessionSnapshot;
@@ -108,11 +107,6 @@ export class RootAgentSession implements RootAgentSessionController {
 
   public getCurrentChatTarget(): NapcatChatTarget | undefined {
     return this.chatTargetProvider?.() ?? undefined;
-  }
-
-  public getCurrentGroupId(): string | undefined {
-    const chatTarget = this.getCurrentChatTarget();
-    return chatTarget?.chatType === "group" ? chatTarget.groupId : undefined;
   }
 
   public getAvailableInvokeTools(): string[] {

--- a/apps/server/test/agent/root-agent-session.test.ts
+++ b/apps/server/test/agent/root-agent-session.test.ts
@@ -79,7 +79,6 @@ describe("RootAgentSession (App 启动器)", () => {
     expect(session.getCurrentChatTarget()).toBeUndefined();
     holder.target = { chatType: "group", groupId: "group-1" };
     expect(session.getCurrentChatTarget()).toEqual({ chatType: "group", groupId: "group-1" });
-    expect(session.getCurrentGroupId()).toBe("group-1");
   });
 
   it("tracks the current app", () => {


### PR DESCRIPTION
## 背景

四面向技术债扫描里的「抽象泄漏快赢」之一。`RootAgentSession.getCurrentGroupId()` 把「群聊 groupId」概念焊进了通用 runtime 会话接口,违反项目理念(QQ/群聊语义不得渗进 runtime 核心抽象)。

核实:全仓**生产代码零调用**,仅 `root-agent-session.test.ts` 有一处断言。属死的泄漏 API。延续上个 commit(`e551758` 清理 ToolContext.groupId)的同源工作,这次把会话层这处也清掉。

## 改动

- 删 `RootAgentSession` 接口的 `getCurrentGroupId()` 声明
- 删其实现(基于 `getCurrentChatTarget()` 派生 groupId)
- 删测试里的 `expect(session.getCurrentGroupId()).toBe(...)` 断言;同用例对 `getCurrentChatTarget()` 的覆盖**保留**(它是活的)

零行为变化。`getCurrentChatTarget()`(返回中立的 `NapcatChatTarget`)不动 —— 它有真实消费者,本次不在范围内。

## 校验

- `pnpm build` ✅
- `pnpm --filter @kagami/server typecheck` ✅
- `pnpm --filter @kagami/server test` ✅ 639 passed
- `pnpm lint` ✅ 0 error
- `pnpm format` ✅