### PR TITLE
refactor(agent): 删除快照 schema 的 napcat legacy 字段,持久化层脱离 QQ 类型

### DIFF
--- a/apps/server/src/agent/runtime/root-agent/persistence/root-agent-runtime-snapshot.ts
+++ b/apps/server/src/agent/runtime/root-agent/persistence/root-agent-runtime-snapshot.ts
@@ -6,13 +6,6 @@ import type {
   LlmTextContentPart,
   LlmToolCall,
 } from "../../../../llm/types.js";
-import type {
-  NapcatFriendInfo,
-  NapcatGetGroupInfoResult,
-  NapcatGroupMessageData,
-  NapcatPrivateMessageData,
-} from "../../../../napcat/application/napcat-gateway.service.js";
-import { NapcatReceiveMessageSegmentSchema } from "../../../../napcat/domain/napcat-segment.js";
 
 const DateValueSchema = z.coerce.date();
 const JsonRecordSchema = z.record(z.string(), z.unknown());
@@ -62,79 +55,18 @@ const LlmMessageSchema: z.ZodType<LlmMessage> = z.union([
   }),
 ]);
 
-const NapcatGetGroupInfoResultSchema: z.ZodType<NapcatGetGroupInfoResult> = z.object({
-  groupId: z.string().min(1),
-  groupName: z.string(),
-  memberCount: z.number().int().nonnegative(),
-  maxMemberCount: z.number().int().nonnegative(),
-  groupRemark: z.string(),
-  groupAllShut: z.boolean(),
-});
-
-const NapcatFriendInfoSchema: z.ZodType<NapcatFriendInfo> = z.object({
-  userId: z.string().min(1),
-  nickname: z.string(),
-  remark: z.string().nullable(),
-});
-
-const NapcatGroupMessageDataSchema: z.ZodType<NapcatGroupMessageData> = z.object({
-  groupId: z.string().min(1),
-  userId: z.string().min(1),
-  nickname: z.string(),
-  rawMessage: z.string(),
-  messageSegments: z.array(NapcatReceiveMessageSegmentSchema),
-  messageId: z.number().int().nullable(),
-  time: z.number().int().nullable(),
-});
-
-const NapcatPrivateMessageDataSchema: z.ZodType<NapcatPrivateMessageData> = z.object({
-  userId: z.string().min(1),
-  nickname: z.string(),
-  remark: z.string().nullable(),
-  rawMessage: z.string(),
-  messageSegments: z.array(NapcatReceiveMessageSegmentSchema),
-  messageId: z.number().int().nullable(),
-  time: z.number().int().nullable(),
-});
-
 export const PersistedAgentContextSnapshotSchema = z.object({
   messages: z.array(LlmMessageSchema),
 });
 
 export type PersistedAgentContextSnapshot = z.infer<typeof PersistedAgentContextSnapshotSchema>;
 
-const PersistedRootAgentSessionGroupStateSchema = z.object({
-  groupId: z.string().min(1),
-  groupInfo: NapcatGetGroupInfoResultSchema.nullable(),
-  unreadMessages: z.array(NapcatGroupMessageDataSchema),
-  hasEntered: z.boolean(),
-});
-
-export type PersistedRootAgentSessionGroupState = z.infer<
-  typeof PersistedRootAgentSessionGroupStateSchema
->;
-
-const PersistedRootAgentSessionPrivateChatStateSchema = z.object({
-  userId: z.string().min(1),
-  friendInfo: NapcatFriendInfoSchema.nullable(),
-  unreadMessages: z.array(NapcatPrivateMessageDataSchema),
-  hasEntered: z.boolean(),
-});
-
-export type PersistedRootAgentSessionPrivateChatState = z.infer<
-  typeof PersistedRootAgentSessionPrivateChatStateSchema
->;
-
 export const PersistedRootAgentSessionSnapshotSchema = z.object({
   // 手机 OS 模型下 session 退化为 App 启动器，不再持聊天状态。stateStack 恒为
-  // ["portal"]；保留字段只为兼容老快照的反序列化。
+  // ["portal"]。状态树时代的 legacy 字段（waitOverlay / groups / privateChats /
+  // ithomeFeedState）已不再声明：会话状态归 QqApp，旧快照里若仍带这些键，非 strict
+  // 对象解析会自动 strip，反序列化照常成功。
   stateStack: z.array(z.string().min(1)).min(1).default(["portal"]),
-  // Legacy 字段：状态树时代持久化的 wait overlay / 聊天会话（groups/privateChats）/
-  // ithome 焦点。会话状态已归 QqApp（本次重置），这些字段接受但反序列化后忽略。
-  waitOverlay: z.unknown().optional(),
-  groups: z.array(PersistedRootAgentSessionGroupStateSchema).optional(),
-  privateChats: z.array(PersistedRootAgentSessionPrivateChatStateSchema).optional(),
-  ithomeFeedState: z.unknown().optional(),
 });
 
 export type PersistedRootAgentSessionSnapshot = z.infer<


### PR DESCRIPTION
## 背景

四面向技术债扫描里的「抽象泄漏快赢」之二。`root-agent-runtime-snapshot.ts` 里状态树时代的 legacy 会话字段(`waitOverlay`/`groups`/`privateChats`/`ithomeFeedState`)是 runtime 持久化层**硬依赖 napcat/QQ 类型**的唯一来源,违反「群聊概念不得渗进 runtime 核心抽象」。

核实:
- 反序列化 `restorePersistedSnapshot(_snapshot)` 直接 `void _snapshot`,这些字段从不被读
- 生产端 `exportPersistedSnapshot()` 只写 `{ stateStack }`,不写 legacy 字段
- 导出的 `PersistedRootAgentSession{Group,PrivateChat}State` 类型全仓无外部引用

## 改动

- 删四个 legacy 字段声明
- 删只服务它们的 `PersistedRootAgentSession{Group,PrivateChat}StateSchema` 及导出类型
- 删四个 `Napcat*` 子 schema(`NapcatGetGroupInfoResult`/`NapcatFriendInfo`/`NapcatGroupMessageData`/`NapcatPrivateMessageData`)
- 删全部 napcat import(类型 + `NapcatReceiveMessageSegmentSchema`)

净 -71/+3 行。runtime 持久化层不再 import 任何 napcat 类型。

## 兼容性

`PersistedRootAgentSessionSnapshotSchema` 是**非 strict** `z.object`,DB 里旧快照若仍带这些键,解析时被自动 **strip**、反序列化照常成功。删除比保留**更宽容**(旧字段形态漂移也不再让恢复失败)。零行为变化。

## 校验

- `pnpm build` ✅
- `pnpm --filter @kagami/server typecheck` ✅
- `pnpm --filter @kagami/server test` ✅ 661 passed
- `pnpm lint` ✅ 0 error
- `pnpm format` ✅