### PR TITLE
fix(amap): static_map paths UNKNOWN_ERROR + 数字型 adcode 参数被拒

### DIFF
--- a/apps/agent/src/agent/apps/amap/client/amap-client.ts
+++ b/apps/agent/src/agent/apps/amap/client/amap-client.ts
@@ -481,7 +481,11 @@ function buildMarkers(markers?: StaticMapMarker[]): string | null {
   return groups.length > 0 ? groups.join("|") : null;
 }
 
-/** 把结构化 paths 拼成高德线协议串；样式 `weight,color:loc;loc`，最多 4 条折线、每条 ≤100 点。 */
+/**
+ * 把结构化 paths 拼成高德线协议串，最多 4 条折线、每条 ≤100 点。样式必须是 **5 字段**
+ * `weight,color,transparency,fillcolor,fillTransparency`——只给 `weight,color`（2 字段）高德会
+ * 直接回 UNKNOWN_ERROR(20003)。我们只画折线不填充多边形，故 transparency=1、fill 两项留空。
+ */
 function buildPaths(paths?: StaticMapPath[]): string | null {
   if (!paths || paths.length === 0) {
     return null;
@@ -492,7 +496,8 @@ function buildPaths(paths?: StaticMapPath[]): string | null {
     const color = safeColor(p.color, "0x0000FF");
     const locs = p.points.slice(0, PATH_MAX_POINTS).map(pt => normalizeLngLat(pt, "path.points"));
     if (locs.length > 0) {
-      groups.push(`${weight},${color}:${locs.join(";")}`);
+      // weight,color,transparency(1 不透明),fillcolor(空),fillTransparency(空):loc;loc
+      groups.push(`${weight},${color},1,,:${locs.join(";")}`);
     }
   }
   return groups.length > 0 ? groups.join("|") : null;

--- a/apps/agent/src/agent/apps/amap/tools/geocode.tool.ts
+++ b/apps/agent/src/agent/apps/amap/tools/geocode.tool.ts
@@ -8,7 +8,11 @@ export const GEOCODE_TOOL_NAME = "geocode";
 
 const Schema = z.object({
   address: z.string().min(1),
-  city: z.string().optional(),
+  // city 可能是 adcode/citycode，模型易当数字传——收下数字并转字符串。
+  city: z
+    .union([z.string().min(1), z.number()])
+    .transform(v => String(v))
+    .optional(),
 });
 
 type Deps = { getClient: () => AmapClient; getMaxChars: () => number };

--- a/apps/agent/src/agent/apps/amap/tools/plan-transit.tool.ts
+++ b/apps/agent/src/agent/apps/amap/tools/plan-transit.tool.ts
@@ -6,11 +6,14 @@ import type { RootAgentEffect } from "../../../runtime/effect/root-agent-effect.
 
 export const PLAN_TRANSIT_TOOL_NAME = "plan_transit";
 
+// city1/city2 是 citycode，模型易当数字传——收下数字并转字符串（注意：带前导零的 citycode 如
+// "010" 必须由模型以字符串传，数字 10 已丢前导零，此处无法还原，只是不再硬拒）。
+const CityCode = z.union([z.string().min(1), z.number()]).transform(v => String(v));
 const Schema = z.object({
   origin: z.string().min(1),
   destination: z.string().min(1),
-  city1: z.string().min(1),
-  city2: z.string().min(1),
+  city1: CityCode,
+  city2: CityCode,
 });
 
 type Deps = {

--- a/apps/agent/src/agent/apps/amap/tools/search-poi.tool.ts
+++ b/apps/agent/src/agent/apps/amap/tools/search-poi.tool.ts
@@ -10,7 +10,11 @@ const Schema = z
   .object({
     keywords: z.string().max(80).optional(),
     types: z.string().optional(),
-    region: z.string().optional(),
+    // region 可能是 adcode/citycode，模型易当数字传——收下数字并转字符串。
+    region: z
+      .union([z.string().min(1), z.number()])
+      .transform(v => String(v))
+      .optional(),
     city_limit: z.boolean().optional(),
     page_size: z.number().int().positive().optional(),
     page_num: z.number().int().positive().optional(),

--- a/apps/agent/src/agent/apps/amap/tools/weather.tool.ts
+++ b/apps/agent/src/agent/apps/amap/tools/weather.tool.ts
@@ -7,7 +7,8 @@ import type { RootAgentEffect } from "../../../runtime/effect/root-agent-effect.
 export const WEATHER_TOOL_NAME = "weather";
 
 const Schema = z.object({
-  adcode: z.string().min(1),
+  // 模型常把 adcode（如 110000）当数字传，zod 会拒成 "Expected string received number"——收下数字并转字符串。
+  adcode: z.union([z.string().min(1), z.number()]).transform(v => String(v)),
   kind: z.enum(["base", "all"]).optional(),
 });
 

--- a/apps/agent/test/agent/apps/amap/amap-client.test.ts
+++ b/apps/agent/test/agent/apps/amap/amap-client.test.ts
@@ -174,6 +174,32 @@ describe("AmapClient URL building", () => {
     expect(decoded).toContain("mid,0xFF0000,A:116.39,39.9");
   });
 
+  it("static_map builds paths with the 5-field style (weight,color,transparency,fill,fillT)", async () => {
+    const calls: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((url: string) => {
+        calls.push(url);
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          headers: {
+            get: (k: string) => (k.toLowerCase() === "content-type" ? "image/png" : null),
+          },
+          arrayBuffer: async () => new ArrayBuffer(2),
+        } as unknown as Response);
+      }),
+    );
+    await buildClient().staticMap({
+      size: "600*400",
+      scale: 2,
+      paths: [{ weight: 8, color: "0x0000FF", points: ["116.39,39.90", "116.47,39.87"] }],
+    });
+    const decoded = decodeURIComponent(calls[0]);
+    // 只给 2 字段(weight,color)高德会回 UNKNOWN_ERROR；必须 5 字段。
+    expect(decoded).toContain("paths=8,0x0000FF,1,,:116.39,39.9;116.47,39.87");
+  });
+
   it("parses a driving path into distance/duration/steps", async () => {
     const { mock } = recordingFetch({
       route: {

--- a/apps/agent/test/agent/apps/amap/weather.tool.test.ts
+++ b/apps/agent/test/agent/apps/amap/weather.tool.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+import { WeatherTool } from "../../../../src/agent/apps/amap/tools/weather.tool.js";
+import type { AmapClient } from "../../../../src/agent/apps/amap/client/amap-client.js";
+
+function buildTool(
+  weather = vi.fn().mockResolvedValue({ kind: "base", lives: [], forecasts: [] }),
+): {
+  tool: WeatherTool;
+  weather: ReturnType<typeof vi.fn>;
+} {
+  const client = { weather } as unknown as AmapClient;
+  return {
+    tool: new WeatherTool({ getClient: () => client, getMaxChars: () => 8000 }),
+    weather,
+  };
+}
+
+describe("WeatherTool adcode coercion", () => {
+  it('accepts a numeric adcode (model passes 110000, not "110000") and coerces to string', async () => {
+    const { tool, weather } = buildTool();
+    const result = await tool.execute({ adcode: 110000 }, {});
+    expect(JSON.parse(result.content).ok).toBe(true);
+    expect(weather).toHaveBeenCalledWith({ adcode: "110000", kind: "base" });
+  });
+
+  it("still accepts a string adcode", async () => {
+    const { tool, weather } = buildTool();
+    await tool.execute({ adcode: "330100", kind: "all" }, {});
+    expect(weather).toHaveBeenCalledWith({ adcode: "330100", kind: "all" });
+  });
+});


### PR DESCRIPTION
用户实测高德地图两个 bug：

## 1. static_map 用 `paths` 报 UNKNOWN_ERROR(20003)

根因：高德静态地图 `paths` 样式必须是 **5 字段** `weight,color,transparency,fillcolor,fillTransparency`，`buildPaths` 只拼了 2 字段 `weight,color` → 高德直接回 UNKNOWN_ERROR。改为 `weight,color,1,,`（transparency=1 不透明，不填充多边形）。`markers` 一直是对的、不受影响。真机复测 paths 现返回 `image/png`（181KB）。

## 2. weather 传 `adcode` 报 "Expected string received number"

模型把 adcode（`110000`）当 **JSON 数字**传，工具入参 `z.string()` 硬拒。把 adcode / `geocode.city` / `search_poi.region` / `plan_transit.city1/city2` 这些"像整数"的 ID 参数改为 `union(string, number)` 后 `String()` 收下。（注：带前导零的 citycode 如 `010` 仍需模型以字符串传——数字 10 已丢前导零，无法还原，此处只是不再硬拒。）

## 验证

- 补 `buildPaths` 5 字段 + weather 数字 adcode 回归测试；amap 41 测试全过，build/typecheck/lint/format 全绿。
- 真机复测 static_map paths 出图正常。