### PR TITLE
chore(config): todoSuggestionAgent 模型改为 claude-opus-4-6

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -129,8 +129,9 @@ server:
             times: 3
       todoSuggestionAgent:
         attempts:
-          - provider: openai
-            model: gpt-4o-mini
+          - provider: claude-code
+            model: claude-opus-4-6
+            times: 3
   # tavily.apiKey、bot.qq / bot.creator 是密钥 / PII，放 config.secret.yaml
   # 自建对象存储（@kagami/oss）启用开关。地址不在这里——统一来自顶层 services.oss。
   # 整段可省略 → 关闭图片存档（resid 恒为 null，只走 vision 文字描述，优雅降级）；


### PR DESCRIPTION
把 `server.llm.usages.todoSuggestionAgent` 的推理模型从 `gpt-4o-mini`（provider openai）改为 `claude-opus-4-6`（provider claude-code），与其它 agent usages 保持一致。