### PR TITLE
fix(llm-service): 放开 Fastify bodyLimit，修 /internal/chat 大请求被 413 挡下

### DIFF
--- a/apps/llm/src/app/llm-service-runtime.ts
+++ b/apps/llm/src/app/llm-service-runtime.ts
@@ -164,7 +164,16 @@ export function createLlmServiceApp({
 }: {
   handlers: AppRouteHandler[];
 }): FastifyInstance {
-  const app = Fastify({ logger: false, disableRequestLogging: true });
+  // /internal/chat 承载完整 LLM 请求：system + 整段历史 + base64 图片（单张资源可达 4 MiB，
+  // 见 server.resource.maxBytes；context 阈值 60w token）。Fastify 默认 1 MB bodyLimit 远不够——
+  // in-process 时没有这道限制，拆 HTTP 后必须放开，否则大请求被 413「Request body is too large」
+  // 挡在 handler 之前、LLM 调用直接失败。给 100 MB 富余上限（localhost 内部 RPC，ceiling 非分配）。
+  const LLM_SERVICE_BODY_LIMIT_BYTES = 100 * 1024 * 1024;
+  const app = Fastify({
+    logger: false,
+    disableRequestLogging: true,
+    bodyLimit: LLM_SERVICE_BODY_LIMIT_BYTES,
+  });
 
   app.addHook("onRequest", (_request, reply, done) => {
     const traceId = randomUUID();


### PR DESCRIPTION
kagami-llm 上线后发现 `/internal/chat` 报 `Request body is too large`：Fastify 默认 1 MB `bodyLimit` 远低于完整 LLM 请求（system + 整段历史 + base64 图片；单张资源可达 4 MiB、context 阈值 60w token）。in-process 时无此限制，拆 HTTP 后大请求在 handler 之前就被 413 拒掉，agent 的 LLM 调用全挂（HttpLlmClient 映射成可重试的「LLM 上游服务调用失败」，退避重试仍每次 413）。

修复：给 kagami-llm 的 Fastify 设 100 MB `bodyLimit`（localhost 内部 RPC，ceiling 非分配）。embedding / auth / 其它端点不受影响。

生产热修：#214 上线后由 health check + kagami-llm 日志发现。build/typecheck/lint/format + llm-service 测试全绿。部署走单服务 `pnpm app:deploy llm`（无 schema 变更）。

Refs #214