### PR TITLE
feat(qq): 会话列表未读数封顶显示 99+

### DIFF
--- a/apps/agent/src/agent/apps/qq/qq.app.ts
+++ b/apps/agent/src/agent/apps/qq/qq.app.ts
@@ -457,7 +457,7 @@ export class QqApp implements App {
     const lines = ["<qq_conversation_list>", "你的 QQ 会话："];
     for (const conversation of this.conversations.values()) {
       const unread = conversation.getUnreadCount();
-      const unreadText = unread > 0 ? `（未读 ${unread}）` : "";
+      const unreadText = unread > 0 ? `（未读 ${unread > 99 ? "99+" : unread}）` : "";
       const currentMark = conversation.id === this.currentConversationId ? "  ← 当前会话" : "";
       lines.push(
         `- ${conversation.getDisplayName()}${unreadText} [id: ${conversation.id}]${currentMark}`,


### PR DESCRIPTION
## 改动

`renderConversationList` 渲染 QQ 会话列表未读条数时，超过 99 显示「99+」，避免超大未读数直接铺进主 Agent 上下文。

## 边界说明

- 底层 `Conversation.unreadCount` 仍是**不封顶的真实计数**（只增不减，`open_conversation` 才清零），本次只改**渲染层**。
- 99 及以内照原样显示；现有测试断言 `未读 2`（2 < 99）不受影响。

## 校验

- `pnpm build` / `typecheck` / `format` 全过
- `pnpm --filter @kagami/agent test`：689 passed
- lint 仅存量 warning（apps/web chart.tsx，与本次无关）