### PR TITLE
docs: 精简 AGENTS.md 为 AI 操作手册，抽出配置文档并修 ARCHITECTURE 漂移

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,23 @@
 
 你的一切交流和汇报，使用简体中文。
 
+这份文件是**给 AI 协作者的操作手册**：最高优先级规则 + 常用入口。详情分散在同级文档：
+
+- **架构 / 包拓扑 / 模块 DAG / 数据流** → [ARCHITECTURE.md](./ARCHITECTURE.md)
+- **配置分区 / SQLite 布局 / Prisma 迁移** → [docs/configuration.md](./docs/configuration.md)
+- **视觉 / UI 设计系统** → [DESIGN.md](./DESIGN.md)
+- **项目理念与使用入口** → [README.md](./README.md)
+- **待办** → [TODOS.md](./TODOS.md)
+
+## 阅读路径（按任务选）
+
+- 第一次上手，想理解 Kagami 是什么 → 本文「项目理念」+ README.md
+- **动手写任何新 capability / tool / operation 之前** → 本文「开发原则：KV 缓存命中率优先」（必读，含三个参考实现）
+- 找代码放哪、模块怎么依赖 → ARCHITECTURE.md
+- 改配置或 DB schema、跑迁移 → 本文「硬约束」+ docs/configuration.md
+- 改前端视觉 → DESIGN.md
+- 提交前检查、部署 → 本文「硬约束」+「部署红线」
+
 ## 项目理念（必读）
 
 Kagami **不是一个 QQ 群聊机器人**，而是一个**拥有自己生活的 Agent**。
@@ -75,38 +92,13 @@ Kagami **不是一个 QQ 群聊机器人**，而是一个**拥有自己生活的
 - **进上下文的散文一律走模板，禁止在 TS 里内联字面量**：任何最终会进 LLM 上下文的成句文案（system prompt、各类 reminder、`<notification>` / `<story_recall>` / `<async_tool_result>` 等伪标签内容、通知 draft 的渲染文本）都必须落在 `apps/agent/static/` 下的 `.hbs` 模板，经 `renderServerStaticTemplate(import.meta.url, ...)` 渲染。TS 侧只负责算 view-model（计数、数组、布尔 flag、预格式化好的日期/截断文本），不写成句文案。这样调小镜的语气只改 `static/` 一棵树、不碰代码，也让"所有会进上下文的文本"始终收在同一处可审。**例外（留 TS 常量）**：分组 key / 结构标识（如 `"QQ"`、`"IT之家"`、`"待办"`）这类不是语气的标识符；以及工具 description 与工具 result 的 error/status note（前者绑 param schema 属渐进式披露垂直切片，后者进易变尾部且与控制流交织，见 `TODOS.md`）。
 - Review 新 capability / operation / tool 时，把"会不会破坏 KV 缓存命中"以及"进上下文的散文是否走了模板"作为显式检查项写进自检清单。
 
-## 项目定位
-
-Kagami 是一个基于 pnpm workspace 的全栈 TypeScript Monorepo，当前包含十五个工作空间包：
-
-- `apps/agent`：Fastify 后端服务（`@kagami/agent`）
-- `apps/console`：管理台后端独立进程（`@kagami/console`，服务前端纯 DB 查询，经 @kagami/persistence 共享 DAO 直读 SQLite）
-- `apps/web`：React 前端管理台（`@kagami/web`）
-- `apps/gateway`：前门网关进程（`@kagami/gateway`，独立进程、零 `@kagami/*` 依赖；托管 `apps/web/dist` 静态资源 + `/api/*` 反向代理分流到 console/agent）
-- `apps/oss`：自建对象存储服务（`@kagami/oss`，独立进程、零 `@kagami/*` 依赖）
-- `apps/browser`：独立浏览器进程（`@kagami/browser`，server-core-based Fastify、仅绑 127.0.0.1；持有 CloakBrowser 与凭据注入，agent 经 HTTP 客户端驱动。拆成独立进程让 agent 重启不杀浏览器）
-- `apps/llm`：LLM 网关 + OAuth 凭据中心进程（`@kagami/llm-service`，Fastify 仅绑 127.0.0.1；import `@kagami/llm-client` + `@kagami/auth` 作内脏，持有全部 provider + OAuth callback server(1455/54545) + 刷新 timer，服务内落 `llm_chat_call`/读写 `embedding_cache`。对外暴露 agent-facing `/internal/{chat,chat-direct,providers,embed}` 与 console-facing `/auth/:provider/*`；agent 经 `HttpLlmClient`/`HttpEmbeddingClient` 直连。中心化是为「多 Agent 共享一个 LLM+凭据网关」——不能各 agent 各持凭据/各抢绑 callback 端口）
-- `packages/agent-runtime`：通用 Agent / App 框架内核（`@kagami/agent-runtime`）
-- `packages/llm`：前后端 / 内核共用的 LLM 消息与工具类型契约（`@kagami/llm`，零依赖契约叶子）
-- `packages/llm-client`：LLM chat client + provider + embedding client 运行时（`@kagami/llm-client`，位于 kernel 之上、与 persistence 平级且互不依赖；只发 `LlmChatCallObservation` 事件，落库/缓存归 agent 装配层订阅，故对 persistence/Prisma 零依赖。出口 `.` 与 `./embedding`）
-- `packages/kernel`：后端纯净基础设施内核（config、logger、common 契约与错误、`isRecord` 等纯工具，`@kagami/kernel`，无 fastify / 无 Prisma / 无 better-sqlite3，可被不碰 DB / 不提供 HTTP 的服务复用）
-- `packages/http`：HTTP 路由辅助（`route.helper`，`@kagami/http`，仅依赖 fastify + zod，零 `@kagami/*` 依赖；不提供 HTTP 接口的服务无需引入）
-- `packages/persistence`：持久化基础设施（Prisma 客户端与 generated client、db、所有业务 DAO、Prisma JSON helper，`@kagami/persistence`，依赖 `@kagami/kernel` + Prisma + better-sqlite3）
-- `packages/shared`：前后端共享的 Schema 与工具（`@kagami/shared`）
-- `packages/auth`：OAuth 凭据管理全套（`@kagami/auth`，含 OAuth PKCE 登录 / 拉浏览器的 callback server / 刷新 scheduler / secret store / 配额快照 / 统一认证 Fastify handler；`createAuthModule` 装配入口。依赖 kernel/persistence/shared/http/llm + fastify/zod，不依赖 llm-client——其 `OAuthAuthService` 的 token 形态与 llm-client 的凭据端口逐字段一致，故 agent 装配层直接把 auth service 作为 authProvider 注入 provider 工厂，结构化满足接口、无适配器）
-
-workspace 定义位于仓库根目录 `pnpm-workspace.yaml`，当前仅包含 `apps/*` 与 `packages/*`。
-
 ## 硬约束
 
 - 除非任务明确要求，否则一切交流与汇报统一使用简体中文。
 - 除非任务明确要求，否则默认在仓库根目录执行命令。
-- 数据库相关命令统一读取仓库根目录 `config.yaml` 中的 `server.databaseUrl`。
-- 修改配置 schema 时，必须同步更新：
-  - `packages/kernel/src/config/config.loader.ts`
-  - `config.yaml`（非隐私，纳入版本控制）
-  - `config.secret.yaml.example`（隐私模板；新增隐私字段在这里补占位）
-- 提交前至少执行：
+- 数据库相关命令统一读取仓库根 `config.yaml` 中的 `server.databaseUrl`。
+- **改配置 schema 必须同步三处**：`packages/kernel/src/config/config.loader.ts`、`config.yaml`（非隐私，纳入版本控制）、`config.secret.yaml.example`（隐私模板，新增隐私字段在这里补占位）。
+- **提交前至少执行**以下四项，且全部成功：
 
 ```sh
 pnpm build
@@ -115,270 +107,70 @@ pnpm lint
 pnpm format
 ```
 
-需保证全部成功。
+## 代码放哪（边界铁律）
+
+完整的包拓扑与模块 DAG 见 [ARCHITECTURE.md](./ARCHITECTURE.md)。写代码时守住这几条边界：
+
+- 后端 `apps/agent` 用「扁平模块 + 模块内分层」（`domain / application / infra / http`）。新代码放进所属模块，从模块根入口或分层路径导入；**不要**新增全局 `handler / service / dao / event / tools / rag` 风格目录。
+- 通用 Agent Runtime 内核放 `packages/agent-runtime`（`TaskAgent` / `Operation` / `Tool` / `App` 框架）；**不要**把 NapCat 事件模型、Kagami system prompt、`RootAgentRuntime`、具体 capability 塞进去。Kagami 项目语义放 `apps/agent/src/agent`。
+- `apps/agent/src/agent` 按 `runtime / capabilities / apps` 分层；新实现只进 `runtime/` 或 `capabilities/`，不要回填旧风格的 `agents / service / dao / tools/*` 目录。
+- `Tool` 只是上层调用入口，不承载能力本体；业务语义放 capability service / task-agent / operation。
+- 群聊相关逻辑只属于 `messaging` capability，不要扩散到 runtime 或其他 capability。
 
 ## 常用命令
 
-### 根目录命令
-
 ```bash
-pnpm build # 按 workspace 依赖拓扑构建所有包
-pnpm typecheck # 对所有包执行 TypeScript 类型检查
-pnpm test # 运行声明了 test 脚本的包
-pnpm lint # ESLint 检查
-pnpm lint:fix # ESLint 自动修复
-pnpm format # Prettier 格式检查
-pnpm format:write # Prettier 自动格式化
-pnpm app:deploy # 无参=全量：build -> prisma migrate deploy -> PM2 reload/startOrReload(全部) -> pm2 save
-pnpm app:deploy <agent|console|gateway|oss|browser|llm> # 单服务：只重建并重载该服务，不跑迁移、不动其它进程
+pnpm build        # 按 workspace 依赖拓扑构建所有包
+pnpm typecheck    # 全部包类型检查
+pnpm test         # 运行声明了 test 脚本的包（当前：agent / agent-runtime / oss）
+pnpm lint         # ESLint 检查（lint:fix 自动修复）
+pnpm format       # Prettier 检查（format:write 自动格式化）
+
+pnpm --filter @kagami/agent <script>   # 单包命令，如 test / test:watch / db:*
+
+pnpm app:deploy                        # 全量部署：build → prisma migrate deploy → PM2 reload(全部) → pm2 save
+pnpm app:deploy <agent|console|gateway|oss|browser|llm>  # 单服务：只重建重载该服务，不跑迁移、不动其它进程
 ```
 
-### 单包命令
-
-```bash
-pnpm --filter @kagami/agent <script>
-pnpm --filter @kagami/web <script>
-pnpm --filter @kagami/agent-runtime <script>
-pnpm --filter @kagami/shared <script>
-```
-
-### 当前开发现状
-
-- 当前仓库没有统一的根目录 `pnpm dev` 脚本。
-- `apps/agent` 当前提供 `build`、`typecheck`、`test`、`test:watch`、`db:*` 脚本。
-- `apps/web` 当前提供 `build`、`typecheck` 脚本。
-- `packages/agent-runtime` 当前提供 `build`、`typecheck`、`test`、`test:watch` 脚本。
-- `packages/shared` 当前提供 `build`、`typecheck` 脚本。
-- 因此前后端联调时，需要按实际情况分别启动或补充本地开发脚本，不要假设仓库已经内置一键 dev 流程。
-
-### 测试
-
-```bash
-pnpm test # 运行整个 Monorepo 中声明了 test 脚本的包
-pnpm --filter @kagami/agent test # 运行后端 Vitest
-pnpm --filter @kagami/agent test:watch # 以后端 watch 模式运行测试
-```
-
-补充说明：
-
-- 当前 `@kagami/agent`、`@kagami/agent-runtime`、`@kagami/oss` 声明了测试脚本（agent-runtime 用 vitest 直接测源码，覆盖 Effect / 队列 / 串行执行器 / 工具组件的不变量）。
-
-## 数据库与配置
-
-- 数据库为**进程内 SQLite 文件**（默认 `data/sqlite/kagami.db`），不再依赖外部 PostgreSQL 服务；ORM 仍是 Prisma，driver adapter 为 `@prisma/adapter-better-sqlite3`。
-- 直接查库可使用 `sqlite3` CLI；库文件路径以仓库根目录 `config.yaml` 中的 `server.databaseUrl`（`file:` 路径，运行时解析为绝对路径）为准。
-- Story 向量记忆不再用 pgvector，改为**进程内 HNSW 索引（hnswlib-node）**：向量以 JSON 字符串存于 `story_memory_document.embedding`（SQLite 为唯一事实来源），HNSW 索引在启动时从 SQLite 重建、并持久化派生快照到 `data/vector/story-memory.hnsw`。
-- 所有持久化数据统一放在仓库根 `data/` 目录下并按类别分子目录（`data/sqlite/`、`data/vector/`）；整个 `data/` 已在 `.gitignore` 中。
-
-### 数据库迁移
-
-```bash
-pnpm db:migrate:dev -- --name <migration_name> # 生成迁移（脚本会自动补上 --create-only）
-pnpm db:migrate:deploy # 部署/上线时应用已有迁移
-pnpm db:migrate:status # 查看迁移状态
-pnpm db:migrate:reset # 重置数据库（危险）
-pnpm db:migrate:resolve -- --applied <migration_id> # 标记迁移已应用
-```
-
-数据库变更流程：
-
-1. 修改 `packages/persistence/prisma/schema.prisma`。
-2. 在仓库根目录执行 `pnpm db:migrate:dev -- --name <migration_name>`。
-3. 提交 schema 变更和 `packages/persistence/prisma/migrations/*`。
-4. 在目标环境执行 `pnpm db:migrate:deploy`，或通过 `pnpm app:deploy` 一并完成。
-
-已有数据库接入 Prisma Migrate（基线）：
-
-1. 如果数据库结构已与当前 schema 对齐，先执行 `pnpm db:migrate:resolve -- --applied <baseline_migration_id>`。
-2. 后续再按标准流程使用 `db:migrate:dev` 和 `db:migrate:deploy`。
-
-### 配置文件
-
-- 配置拆成两份：`config.yaml`（非隐私，纳入版本控制，直接改）+ `config.secret.yaml`（隐私：密钥/PII，gitignore，从 `config.secret.yaml.example` 复制填写）。启动时由 `@kagami/config` 定位并深合并两者，再交 `packages/kernel/src/config/config.loader.ts` 的 `ConfigSchema` 校验。
-- `config.secret.yaml` 可覆盖任意字段（无隐私路径白名单）；**约定上**只往里放凭据 / PII（apiKey / bot / napcat.listenGroupIds / 浏览器凭据 / 高德 key 等），拓扑（`services.*`、`server.databaseUrl`）仍留在 `config.yaml`。原型污染由 `@kagami/config` 深合并的 `DANGEROUS_KEYS` 兜底丢弃。
-- 配置读取（repo-root 定位 + 两文件合并）统一由零依赖叶子包 `@kagami/config` 承载；kernel / gateway / oss / `scripts/read-config.mjs` 都复用它。gateway / oss 只读非隐私的 `services.*`，不需要 `config.secret.yaml`。
-- 关键配置分区包括：
-  - `server.databaseUrl`（SQLite `file:` 路径）、`server.port`
-  - `server.agent.contextCompactionTotalTokenThreshold`、`llmRetryBackoffMs`、`waitToolMaxWaitMs`、`notificationLeadingWindowMs`、`notificationBatchWindowMs`
-  - `server.agent.story.enabled`、`batchSize`、`idleFlushMs`、`memory.embedding`、`memory.vectorIndexPath`、`memory.retrieval`、`recall.topK`、`recall.scoreThreshold`
-  - `server.agent.messaging.aiTone`（小镜发言 AI 味实时门控的权重与阈值）
-  - `server.ithome.pollIntervalMs`、`recentArticleLimit`、`articleMaxChars`
-  - `server.napcat.wsUrl`、`server.napcat.reconnectMs`、`server.napcat.requestTimeoutMs`
-  - `server.napcat.listenGroupIds`、`server.napcat.startupContextRecentMessageCount`
-  - `server.llm.timeoutMs`、`authUsageRefreshIntervalMs`
-  - `server.llm.codexAuth`、`server.llm.claudeCodeAuth`
-  - `server.llm.providers.deepseek`、`server.llm.providers.openai`、`server.llm.providers.openaiCodex`、`server.llm.providers.claudeCode`
-  - `server.llm.usages.agent`、`storyAgent`、`contextSummarizer`、`vision`、`webSearchAgent`
-  - 顶层 `services`（与 `server` 平级）：各服务监听端口与地址的唯一事实来源，`services.{agent,console,gateway,oss,browser}.{host,port}`，所有进程读它寻址（见 issue #162）；`services.browser` 仅 localhost（见 issue #173）
-  - `server.oss.enabled`（自建对象存储启用开关；地址来自 `services.oss`，整段省略=禁用、优雅降级）
-  - `server.apps.*`（App 级配置，如 `calc.precision`、`terminal.*`、`hn.*`、`amap.*`；`amap.apiKey` 为凭据，走 `config.secret.yaml`）
-  - `server.tavily.apiKey`
-  - `server.bot.qq`、`server.bot.creator`
-
-> 历史遗留说明：早期配置中的 `server.rag.*` 已经迁移到 `server.agent.story.memory.*`，`config.yaml` 中不应再存在独立的 `server.rag` 分区。
+- 仓库当前**没有**统一的根 `pnpm dev`。前后端联调需按实际分别启动，不要假设有一键 dev。
+- DB 迁移命令与流程见 [docs/configuration.md](./docs/configuration.md)。
 
 ## 代码规范
 
-### Prettier
+**Prettier**：双引号、分号、2 空格缩进、行宽 100、尾逗号 `all`。
 
-- 双引号（`singleQuote: false`）
-- 分号（`semi: true`）
-- 缩进 2 空格（`tabWidth: 2`，`useTabs: false`）
-- 行宽 100 字符
-- 尾逗号（`trailingComma: "all"`）
+**TypeScript**：所有包继承 `tsconfig.base.json`（`strict: true`）。后端与 shared 用 `module/moduleResolution: NodeNext`，前端用 `Bundler` 并额外开 `noUnusedLocals` / `noUnusedParameters`。路径别名以各包 `tsconfig.json` 实际配置为准，不要臆测。
 
-### TypeScript
+**ESLint**：忽略 `dist/` / `build/` / `node_modules/` / `prisma/generated/`；前端启用 `react-hooks` / `react-refresh`。
 
-- 所有包继承 `tsconfig.base.json`，开启 `strict: true`。
-- 后端与 shared 使用 `module: NodeNext`、`moduleResolution: NodeNext`。
-- 前端应用使用 `moduleResolution: Bundler`。
-- 前端额外开启 `noUnusedLocals` 与 `noUnusedParameters`。
+**导入约定**：
 
-路径别名现状：
-
-- 后端 `apps/agent/tsconfig.json` 为 `@kagami/shared/*` 配置了源码路径映射。
-- 后端 `apps/agent/tsconfig.json` 也为 `@kagami/agent-runtime` 和 `@kagami/agent-runtime/*` 配置了源码路径映射。
-- 前端显式配置了 `@/* -> apps/web/src/*`。
-- 不要假设前端也单独声明了 `@kagami/shared` 的源码路径别名；它当前通过 workspace 依赖使用该包。
-
-### ESLint
-
-- 忽略 `dist/`、`build/`、`node_modules/`、`prisma/generated/`
-- 前端应用启用 `react-hooks` 和 `react-refresh` 规则
-
-### Shared 包约定
-
-- `packages/shared` 主要承载前后端共用的 Zod Schema、响应模型和工具函数。
-- `packages/shared` 不再提供根入口 barrel；统一使用显式子路径导入，例如 `@kagami/shared/schemas/health`、`@kagami/shared/utils`。
-- 当前 shared 包不会导出 `z`；如果需要直接定义 Zod schema，按现状应从 `zod` 导入。
-- 新代码不要在项目内新增 re-export/barrel 文件，优先直接导入真实实现路径或包的显式子路径。
-
-### Agent Runtime 包约定
-
-- `packages/agent-runtime` 只承载通用 Agent Runtime 内核，不承载 Kagami 项目语义。
-- 允许放入该包的内容包括：`TaskAgent`、`BaseTaskAgent`、`Operation`、`Tool` 抽象、`App` / `AppManager` / `AppStateStore` 框架、`ToolCatalog`、`ToolSet`、`ToolExecutor` 等纯运行时能力。
-- 不要把 NapCat 事件模型、Kagami system prompt、`RootAgentRuntime`、具体 capability 实现放入该包。
-- `apps/agent` 中如果需要使用这些通用能力，优先直接从 `@kagami/agent-runtime` 导入，而不是继续依赖 server 内部的兼容 re-export 路径。
+- `packages/shared` **不提供根 barrel**，用显式子路径导入（`@kagami/shared/schemas/health`、`@kagami/shared/utils`）；需要 Zod 从 `zod` 导入。
+- 新代码不要新增 re-export / barrel 文件，优先直接导入真实实现路径或包的显式子路径。
+- 后端构造函数统一用对象参数风格（`{ dep1, dep2 }`）。
 
 ## 设计系统
 
-任何视觉 / UI 改动前，先读仓库根目录 `DESIGN.md`。字体、颜色、间距、布局、美术方向全部定义在那里，未经用户明确批准不要偏离。
+任何视觉 / UI 改动前，**先读 [DESIGN.md](./DESIGN.md)**。字体、颜色、间距、布局、美术方向都在那里，未经用户明确批准不要偏离。要点：
 
 - 方向代号：**晒褪了色的蒙德里安 / The Painted Ledger**（蒙德里安骨架 + 文艺复兴 / 印象派颜料色）。
-- 前端**不再使用 shadcn 的有样式组件与默认 slate 主题**；保留 Radix 无样式行为基元（焦点 / 键盘可访问性），其余 class 体系与组件外观自定义。
-- 配色铁律：颜色是配给不是涂抹，90% 中性 + 暖近黑，饱和色只落在「活着 / 有语义」的数据上（红=错/主动发言、蓝=LLM/context、黄=scheduler/等待、绿=Story/记忆、茜=高成本）。
-- QA / Review 时，发现不符合 `DESIGN.md` 的代码要标出来。
+- 前端不再用 shadcn 的有样式组件与默认 slate 主题；保留 Radix 无样式行为基元，其余外观自定义。
+- 配色铁律：颜色是配给不是涂抹，90% 中性 + 暖近黑，饱和色只落在「活着 / 有语义」的数据上（红 = 错/主动发言、蓝 = LLM/context、黄 = scheduler/等待、绿 = Story/记忆、茜 = 高成本）。
+- QA / Review 时，发现不符合 DESIGN.md 的代码要标出来。
 
-## 架构概览
+## 部署速查
 
-### 后端（`@kagami/agent`）
+进程拓扑与端口见 [ARCHITECTURE.md](./ARCHITECTURE.md)「部署」。操作层面：
 
-后端当前已经重组为“扁平模块 + 模块内分层”的结构，顶级目录直接位于 `apps/agent/src/<module>`，以模块 DAG 为主，而不是旧的全局 `service / handler / dao / agents` 横向分层。
+- `pnpm app:deploy`（无参）= 全量：build → Prisma 迁移 → PM2 reload/startOrReload → `pm2 save`。**涉及 DB schema 变更必须走这个**（会跑 `prisma migrate deploy`）。
+- `pnpm app:deploy <服务名>` = 单服务：只重建重载该服务。改单个服务时优先用它——重载 `console` / `gateway` / `browser` / `llm` 不会打断 `kagami-agent` 的热状态（KV 缓存前缀、HNSW 索引、活内存），符合 KV 缓存优先。（`web` 是 `gateway` 的已弃用别名。）
+- `kagami-browser` 与 `kagami-llm` 是独立进程，`app:deploy agent` 不触及它们，让「agent 重启不杀浏览器 / 不打断 LLM 服务与登录态」。
 
-当前主要模块如下（非穷举）：
+## 部署红线（用户硬约束）
 
-- `common/`：无业务语义的公共能力与跨模块契约，当前包括 `contracts/`、`errors/`、`http/`、`runtime/`
-- `config/`：配置 schema、配置加载、运行时配置管理
-- `db/`：Prisma 客户端、数据库连接与事务基础设施
-- `logger/`：日志 runtime、serializer、sink、日志 DAO
-- `llm/`：agent 侧只剩 LLM 的 HTTP 客户端与 playground——`HttpLlmClient`/`HttpEmbeddingClient`（实现 `@kagami/llm-client` 的接口，直连 `kagami-llm` 服务的 `/internal/*`）+ playground（HTTP handler + service，`playground-tools` 依赖 agent 工具目录故留 agent，chat/providers 走 HttpLlmClient）。provider 本体、OAuth 凭据、`llm_chat_call` 落库、`embedding_cache` 全在 `apps/llm` 服务进程。（agent 已不再有 `auth/` 目录：OAuth 全套随 `@kagami/auth` 进 `kagami-llm` 服务，刷新 timer 也在服务内。）
-- `napcat/`：NapCat 协议适配（gateway transport、入站归一化、图片分析、持久化写入）；网关实例由 QQ App 持有，只是 Agent 的一种事件源
-- `metric/`：运行时指标与可视化数据接口
-- `scheduler/`：后台定时任务（auth 刷新、IThome 轮询、数据保留清理等）
-- `oss/`：server 侧对象存储 HTTP 客户端，把图片 PUT 进自建 `apps/oss`
-- `agent/`：Kagami 的 Agent 业务层，负责手机 OS 运行时（Portal / App / NotificationCenter）、capabilities、上下文压缩、故事记忆、RAG 等
-- `ops/`：后台查询与观测接口，例如 app log、LLM history、embedding cache、Story、main-agent-context、NapCat history
-- `app/`：最高层运行时装配，负责模块 wiring、Fastify 路由注册、健康检查、Agent / Story / 网关生命周期编排
-
-模块内优先按垂直分层组织，常见层次包括：
-
-- `domain/`：实体、值对象、模块内 port、纯规则
-- `application/`：use case、workflow、query/command service
-- `infra/`：Prisma/HTTP/外部系统适配实现
-- `http/`：Fastify handler 与路由注册
-
-补充说明：
-
-- 不是每个模块都会把 `domain / application / infra / http` 四层补齐，是否拆层以实际复杂度为准。
-- 模块之间按 DAG 依赖，一个模块可以依赖多个更底层模块，但禁止出现循环依赖。
-
-后端代码约定：
-
-- 构造函数统一使用对象参数风格（`{ dep1, dep2 }`）。
-- 新代码优先放入所属模块内部，并优先从模块根入口或模块内分层路径导入；不要继续新增全局 `handler / service / dao / event / tools / rag` 风格目录。
-
-Agent 相关补充约定：
-
-- 通用 Agent Runtime 内核放在 `packages/agent-runtime`，Kagami 项目语义放在 `apps/agent/src/agent`。
-- `apps/agent/src/agent` 当前按 `runtime / capabilities / apps` 分层组织：
-  - `runtime/`：Kagami 定制运行时，如 `RootAgentRuntime`、session（App 启动器）、NotificationCenter、事件队列、上下文渲染、App 状态持久化
-  - `capabilities/`：按能力聚合的实现，当前包括 `messaging`、`context-summary`、`story`、`ithome`、`vision`、`web-search`、`browser`、`terminal`、`todo`
-  - `apps/`：手机 OS 的 App（Portal 下可 switch 进入的地点），当前包括 `qq`、`ithome`、`hn`、`amap`、`calc`、`clock`、`browser`、`terminal`、`todo`
-- 新增 capability 应当符合"给 Agent 的生活添一种新的存在方式"的视角；群聊相关逻辑只属于 `messaging`，不要让它的概念扩散到 runtime 或其他 capability。
-- `context-summary` 归类为 `Operation`，不是 `TaskAgent`。
-- `web-search` 是标准 `TaskAgent` 能力；其对主 Agent 暴露的是 tool，私有工具跟随 task-agent 放在能力目录内。
-- `Tool` 的职责是上层调用入口，不承载能力本体；业务语义应放在 capability service、task-agent 或 operation 中。
-- 新实现只放在 `runtime/` 或 `capabilities/`；不要重新向 `apps/agent/src/agent/agents`、`apps/agent/src/agent/service`、`apps/agent/src/agent/dao`、`apps/agent/src/agent/tools/*` 等旧风格目录补内容。
-
-后端当前对外接口大致分为：
-
-- 健康检查：`/health`
-- OAuth 与配额管理：`/auth/:provider/status`、`/auth/:provider/login-url`、`/auth/:provider/logout`、`/auth/:provider/refresh`、`/auth/:provider/usage-limits`、`/auth/:provider/usage-trend`
-- LLM Playground：`/llm/providers`、`/llm/playground-tools`、`/llm/chat`
-- Napcat 主动发送：`/napcat/group/send`、`/napcat/private/send`
-- 观测与历史查询：`/app-log/query`、`/llm-chat-call/query`、`/llm-chat-call/:id`、`/napcat-event/query`、`/napcat-group-message/query`、`/story/query`
-- Agent 状态与指标：`/main-agent-context/recent`、`/main-agent-context/compact`、`/metric-chart/*`、`/scheduler/*`
-
-### 前端（`@kagami/web`）
-
-前端是一个 React 管理台，用于观测 Agent 的"生活状态"。使用 `react-router-dom`，当前主要页面包括：
-
-- `/main-agent-context`：主 Agent 当前上下文（默认入口）
-- `/auth/:provider`：认证管理页
-- `/control-panel`：控制面板（含上下文压缩等操作）
-- `/scheduler-tasks`：后台任务面板
-- `/llm-playground`：LLM Playground
-- `/llm-history`：LLM 调用历史
-- `/app-log-history`：应用日志历史
-- `/napcat-event-history`：Napcat 事件历史
-- `/napcat-group-message-history`：群消息历史
-- `/story-history`：Story 记忆历史
-- `/metric-charts`：运行时指标可视化
-
-补充说明：
-
-- 页面组件当前按业务域组织在 `apps/web/src/pages/*`。
-- 布局组件位于 `apps/web/src/components/layout/*`。
-- 需要新增或复用组件时，优先考虑使用 shadcn 现有组件，再评估是否自定义实现。
-- 如果缺少所需的 shadcn 组件，可以优先通过 shadcn CLI 下载并接入。
-- 当前 Vite 配置仅提供 `@ -> apps/web/src` 别名，没有内置开发代理。
-
-### 共享包（`@kagami/shared`）
-
-- 共享包用于承载前后端共用的 schema、DTO、工具函数。
-- 后端接口 schema 与前端消费模型尽量优先收敛到该包，避免重复定义。
-
-## 部署说明
-
-### 前端代理与静态托管
-
-- 生产环境中，PM2 托管的网关进程 `kagami-gateway`（`apps/gateway`）会提供 `apps/web/dist`，并按路径前缀分流 `/api/*`：`/app-log`、`/llm-chat-call`、`/napcat-event`、`/napcat-group-message`、`/metric-chart` 这几类纯查询代理到管理台后端进程 `kagami-console`（默认 `20006`），其余仍代理到 `kagami-agent`（默认 `20003`）。上游地址不再走 env，由网关自读 `config.yaml` 顶层 `services` 块寻址（见 issue #162）。
-- 该静态服务还暴露 `/health`。
-- 当前仓库中的 Vite 配置未内置开发代理；如需本地前后端分离调试，需要自行在 `apps/web/vite.config.ts` 中补充 `server.proxy`。
-
-### PM2
-
-- PM2 配置文件位于仓库根目录 `ecosystem.config.cjs`。
-- 后端（`kagami-agent`）：单进程 `fork` 模式运行 `apps/agent/dist/index.js`，默认监听 `20003`。承载 Agent 生活运行时与依赖其活内存的接口（实时上下文、story、auth、scheduler、LLM playground、QQ 主动发送）。
-- 管理台后端（`kagami-console`）：单进程运行 `apps/console/dist/index.js`，默认监听 `20006`（端口取 `config.yaml` 的 `services.console.port`）。服务前端的纯 DB 查询（app-log / llm-chat-call / napcat-event / napcat-group-message / metric-chart），经 `@kagami/persistence` 的共享 DAO 直读同一个 SQLite 库；与 `kagami-agent` 并发读写靠库文件级 WAL（两进程启动均 `configureSqlite`）。
-- 网关（`kagami-gateway`）：单进程运行 `apps/gateway/dist/index.js`（TS，零 `@kagami/*` 依赖），默认监听 `20004`，托管 `apps/web/dist` 静态资源并按前缀把 `/api/*` 分流到 `kagami-console` 或 `kagami-agent`。监听端口与上游地址全部自读 `config.yaml` 的 `services` 块。
-- 对象存储（`kagami-oss`）：单进程运行 `apps/oss`，默认监听 `20005`（仅 localhost），端口取 `config.yaml` 的 `services.oss.port`。
-- 浏览器（`kagami-browser`）：单进程运行 `apps/browser/dist/index.js`，默认监听 `20007`（仅 localhost，端口取 `config.yaml` 的 `services.browser.port`）。持有 CloakBrowser 与凭据注入；PM2 `cwd` 固定仓库根，让 `userDataDir`（`data/browser/default`）落在仓库根 `data/` 下，登录态跨 agent 重启留存。独立生命周期是「agent 重启不杀浏览器」的根——`app:deploy agent` 不触及它（见 issue #173）。
-- LLM 网关（`kagami-llm`）：单进程运行 `apps/llm/dist/index.js`，默认监听 `20009`（仅 localhost，端口取 `config.yaml` 的 `services.llm.port`）。持有全部 LLM provider + OAuth 凭据中心（callback server 绑 1455/54545）+ 刷新 timer，服务内落 `llm_chat_call` / 读写 `embedding_cache`；PM2 `cwd` 固定仓库根。独立生命周期让「agent 重启不打断 LLM 服务与登录态」，为多 Agent 共享一个中心化 LLM+凭据网关铺路。它写库，故**有 DB 迁移时 `deploy.sh` 会连它一并停服**再迁。`app:deploy agent` 不触及它。gateway 把 `/auth/*` 路由到它，agent 经 `HttpLlmClient` 直连 `/internal/*`。
-- `pnpm app:deploy` 会执行构建、Prisma 迁移、PM2 reload/startOrReload，以及 `pm2 save`。
-- `pnpm app:deploy <agent|console|gateway|oss|browser|llm>`（带服务名）只重建并重载该服务（含其依赖包），不跑迁移、不动其它进程。改了某个服务时用它即可——尤其重载 `console` / `gateway` / `browser` 不会打断 `kagami-agent` 的热状态（KV 缓存前缀、HNSW 索引、活内存上下文），符合 KV 缓存优先原则。涉及 DB schema 变更仍走无参 `pnpm app:deploy`。（`web` 作为 `gateway` 的已弃用别名仍可用。）
-- 数据库为进程内 SQLite 文件（`data/sqlite/kagami.db`），宿主机不再需要运行 PostgreSQL；Napcat 仍作为外部依赖运行，`config.yaml` 中通常使用 `localhost` 地址访问。
-- 部署机需要能编译/安装原生模块（`better-sqlite3`、`hnswlib-node`）；这些依赖的构建脚本已在 `pnpm-workspace.yaml` 的 `onlyBuiltDependencies` 中放行。
+- **未经用户明确要求，绝不自行执行 `pnpm app:deploy` 或任何部署动作。**
+- gstack 的 `/land-and-deploy` **仅用于合并 PR**：跑到合并 PR（Step 4）即停，绝不进入后续的自动部署（Step 5/6）与 canary（Step 7）。它默认的「merge → 自动 deploy」尾巴与 Kagami 的本地 PM2 模型不匹配，必须砍掉。
+- 部署一律单独走 `pnpm app:deploy`，且只在用户当轮明确要求时执行。
 
 # gstack
 
@@ -423,9 +215,3 @@ Key routing rules:
 - Deploy trigger: pnpm app:deploy（= bash ./scripts/deploy.sh：build → prisma migrate deploy → PM2 reload/startOrReload → pm2 save）
 - Deploy status: pm2 status
 - Health check: curl -sf http://localhost:20003/health
-
-### ⚠️ 部署红线（用户硬约束）
-
-- **未经用户明确要求，绝不自行执行 `pnpm app:deploy` 或任何部署动作。**
-- gstack 的 `/land-and-deploy` **仅用于合并 PR**：跑到合并 PR（Step 4）即停，绝不进入它后续的自动部署（Step 5/6）与 canary 验证（Step 7）。它默认的「merge→自动 deploy」尾巴与 Kagami 的本地 PM2 模型不匹配，必须砍掉。
-- 部署一律单独走 `pnpm app:deploy`，且只在用户当轮明确要求时执行。

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 ## Workspace 拓扑
 
-pnpm workspace 当前由 12 个包组成，依赖单向（apps → packages）：
+pnpm workspace 当前由 16 个包组成（7 个 apps + 9 个 packages），依赖单向（apps → packages）：
 
 ```
 apps/agent  ──→ packages/agent-runtime ──→ packages/llm
@@ -12,23 +12,31 @@ apps/agent  ──→ packages/agent-runtime ──→ packages/llm
       └────────→ packages/http
 apps/console ──→ packages/persistence ──→ packages/kernel ──→ packages/shared
       └────────→ packages/http
+apps/llm     ──→ packages/llm-client + packages/auth ──→ packages/kernel / persistence  （独立进程，LLM + OAuth 网关）
 apps/web     ──→ packages/shared
 apps/oss     （独立进程，零 @kagami 依赖）
 apps/browser ──→ packages/persistence / kernel / http  （独立进程，持有 CloakBrowser）
 ```
 
+> `@kagami/config` 是零依赖叶子包（repo-root 定位 + 两文件合并），被 kernel / gateway / oss / 脚本复用。
+
 | 包                      | 角色                                                                                                                                                                                  |
 | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `@kagami/agent`         | Fastify 后端、Agent 业务装配、NapCat 网关、Agent 活内存接口（实时上下文 / story / auth / scheduler / LLM playground / QQ 发送）                                                       |
 | `@kagami/console`       | 管理台后端独立进程（Fastify），服务前端纯 DB 查询（app-log / llm-chat-call / napcat-event / napcat-group-message / metric-chart），经 @kagami/persistence 共享 DAO 直读 SQLite        |
-| `@kagami/kernel`        | 后端纯净基础设施：config / logger / 后端 common 契约与错误 / `isRecord` 等纯工具（无 fastify / 无 Prisma / 无 better-sqlite3）                                                        |
-| `@kagami/http`          | HTTP 路由辅助（`route.helper`，仅 fastify + zod，零 `@kagami/*` 依赖）                                                                                                                |
-| `@kagami/persistence`   | 持久化基础设施：Prisma client / generated client / 所有业务 DAO / Prisma JSON helper（依赖 `@kagami/kernel`）                                                                         |
+| `@kagami/gateway`       | 前门网关进程（独立进程，零 `@kagami/*` 依赖）：托管 `apps/web/dist` 静态资源 + 按前缀把 `/api/*` 反代分流到 console / agent，`/auth/*` 分流到 llm                                     |
+| `@kagami/llm-service`   | LLM 网关 + OAuth 凭据中心进程（`apps/llm`，仅 localhost）：持有全部 provider + OAuth callback server + 刷新 timer，落 `llm_chat_call` / `embedding_cache`；agent 经 HTTP 直连         |
 | `@kagami/web`           | React 19 + Vite 管理台                                                                                                                                                                |
 | `@kagami/oss`           | 自建对象存储服务（独立进程，`node:http` + 裸 better-sqlite3，零 `@kagami/*` 依赖）                                                                                                    |
 | `@kagami/browser`       | 独立浏览器进程（基于 kernel/http/persistence 的 Fastify，仅 localhost）：持有 CloakBrowser 与凭据注入，agent 经 `HttpBrowserClient` 驱动；拆成独立进程让 agent 重启不杀浏览器（#173） |
 | `@kagami/agent-runtime` | 与 Kagami 项目语义无关的通用 Agent 内核（TaskAgent / BaseTaskAgent / Operation / Tool / App 框架）                                                                                    |
-| `@kagami/llm`           | 前后端 / 内核共用的 LLM 消息与工具类型契约（`LlmMessage` / `LlmTool` 等）                                                                                                             |
+| `@kagami/llm`           | 前后端 / 内核共用的 LLM 消息与工具类型契约（`LlmMessage` / `LlmTool` 等，零依赖契约叶子）                                                                                             |
+| `@kagami/llm-client`    | LLM chat client + provider + embedding client 运行时；只发 observation 事件，落库 / 缓存归 agent 装配层，对 persistence 零依赖                                                        |
+| `@kagami/auth`          | OAuth 凭据管理全套（PKCE 登录 / callback server / 刷新 scheduler / secret store / 配额快照 / 认证 handler）；随 `kagami-llm` 进程装配                                                 |
+| `@kagami/kernel`        | 后端纯净基础设施：config / logger / 后端 common 契约与错误 / `isRecord` 等纯工具（无 fastify / 无 Prisma / 无 better-sqlite3）                                                        |
+| `@kagami/http`          | HTTP 路由辅助（`route.helper`，仅 fastify + zod，零 `@kagami/*` 依赖）                                                                                                                |
+| `@kagami/persistence`   | 持久化基础设施：Prisma client / generated client / 所有业务 DAO / Prisma JSON helper（依赖 `@kagami/kernel`）                                                                         |
+| `@kagami/config`        | 零依赖叶子包：repo-root 定位 + `config.yaml` / `config.secret.yaml` 两文件深合并，被 kernel / gateway / oss / 脚本复用                                                                |
 | `@kagami/shared`        | Zod schema、DTO、前后端共用工具                                                                                                                                                       |
 
 ## 后端模块 DAG
@@ -198,7 +206,7 @@ LLM API 暴露的顶层 tools 集合是少量结构性 / 能力级元工具（`e
 
 ## 部署
 
-- PM2（`ecosystem.config.cjs`）托管五个进程：`kagami-agent`（Fastify，Agent 运行时 + 活内存接口，默认 20003）、`kagami-console`（管理台后端，服务前端纯 DB 查询，默认 20006）、`kagami-gateway`（`apps/gateway`，静态 + 按前缀把 `/api/*` 分流到 console/agent，默认 20004）、`kagami-oss`（对象存储，默认 20005，仅 localhost）、`kagami-browser`（`apps/browser`，持有 CloakBrowser，默认 20007，仅 localhost；`cwd` 固定仓库根，agent 重启不杀浏览器，`app:deploy agent` 不触及它，见 #173）。后端进程并发读写同一 SQLite 库靠库文件级 WAL。
+- PM2（`ecosystem.config.cjs`）托管六个进程：`kagami-agent`（Fastify，Agent 运行时 + 活内存接口，默认 20003）、`kagami-console`（管理台后端，服务前端纯 DB 查询，默认 20006）、`kagami-gateway`（`apps/gateway`，静态 + 按前缀把 `/api/*` 分流到 console/agent、`/auth/*` 到 llm，默认 20004）、`kagami-oss`（对象存储，默认 20005，仅 localhost）、`kagami-browser`（`apps/browser`，持有 CloakBrowser，默认 20007，仅 localhost；`cwd` 固定仓库根，agent 重启不杀浏览器，`app:deploy agent` 不触及它，见 #173）、`kagami-llm`（`apps/llm`，LLM + OAuth 凭据网关，默认 20009，仅 localhost；持有 provider + callback server + 刷新 timer，`app:deploy agent` 不触及它，有 DB 迁移时 `deploy.sh` 会连它一并停服再迁）。后端进程并发读写同一 SQLite 库靠库文件级 WAL。
 - `pnpm app:deploy` 串起 build → Prisma migrate deploy → PM2 reload → `pm2 save`。
 - 数据库为进程内 SQLite，宿主机无需外部数据库；**NapCat** 仍作为外部依赖运行，`config.yaml` 一般用 `localhost` 访问。
 - 部署机需能编译原生模块（better-sqlite3、hnswlib-node）。
@@ -206,6 +214,7 @@ LLM API 暴露的顶层 tools 集合是少量结构性 / 能力级元工具（`e
 ## 进一步阅读
 
 - [README.md](./README.md) — 项目理念与使用入口
-- [AGENTS.md](./AGENTS.md) — 面向 LLM agent 的协作指引（KV 缓存优先、capability 设计原则、代码规范、命令清单）
+- [AGENTS.md](./AGENTS.md) — 面向 LLM agent 的操作手册（KV 缓存优先、硬约束、命令、部署红线）
+- [docs/configuration.md](./docs/configuration.md) — 配置分区、SQLite 布局、Prisma 迁移
 - [docs/effect-model.md](./docs/effect-model.md) — Effect 模型设计
 - [TODOS.md](./TODOS.md) — 待办清单

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,67 @@
+# 配置与数据库
+
+Kagami 的配置读取、配置分区、SQLite 存储布局与 Prisma 迁移流程。面向 LLM agent 的最高优先级规则见 [AGENTS.md](../AGENTS.md)，代码组织见 [ARCHITECTURE.md](../ARCHITECTURE.md)。
+
+## 配置文件
+
+配置拆成两份，启动时由 `@kagami/config` 定位仓库根、深合并两者，再交 `packages/kernel/src/config/config.loader.ts` 的 `ConfigSchema` 校验：
+
+- `config.yaml` — 非隐私，纳入版本控制，直接改。
+- `config.secret.yaml` — 隐私（密钥 / PII），gitignore，从 `config.secret.yaml.example` 复制填写。
+
+约定：
+
+- `config.secret.yaml` 可覆盖任意字段（无隐私路径白名单），但**约定上只放凭据 / PII**（apiKey、bot、`napcat.listenGroupIds`、浏览器凭据、高德 key 等）。拓扑（`services.*`、`server.databaseUrl`）留在 `config.yaml`。
+- 原型污染由 `@kagami/config` 深合并的 `DANGEROUS_KEYS` 兜底丢弃。
+- 配置读取（repo-root 定位 + 两文件合并）统一由零依赖叶子包 `@kagami/config` 承载；kernel / gateway / oss / `scripts/read-config.mjs` 都复用它。gateway / oss 只读非隐私的 `services.*`，不需要 `config.secret.yaml`。
+
+> **改配置 schema 是硬约束**：必须同步 `config.loader.ts`、`config.yaml`、`config.secret.yaml.example` 三处（详见 AGENTS.md「硬约束」）。
+
+## 关键配置分区
+
+- `server.databaseUrl`（SQLite `file:` 路径）、`server.port`
+- `server.agent.contextCompactionTotalTokenThreshold`、`llmRetryBackoffMs`、`waitToolMaxWaitMs`、`notificationLeadingWindowMs`、`notificationBatchWindowMs`
+- `server.agent.story.enabled`、`batchSize`、`idleFlushMs`、`memory.embedding`、`memory.vectorIndexPath`、`memory.retrieval`、`recall.topK`、`recall.scoreThreshold`
+- `server.agent.messaging.aiTone`（小镜发言 AI 味实时门控的权重与阈值）
+- `server.ithome.pollIntervalMs`、`recentArticleLimit`、`articleMaxChars`
+- `server.napcat.wsUrl`、`reconnectMs`、`requestTimeoutMs`、`listenGroupIds`、`startupContextRecentMessageCount`
+- `server.llm.timeoutMs`、`authUsageRefreshIntervalMs`、`codexAuth`、`claudeCodeAuth`
+- `server.llm.providers.{deepseek,openai,openaiCodex,claudeCode}`
+- `server.llm.usages.{agent,storyAgent,contextSummarizer,vision,webSearchAgent}`
+- 顶层 `services`（与 `server` 平级）：各服务监听端口与地址的唯一事实来源，`services.{agent,console,gateway,oss,browser,llm}.{host,port}`，所有进程读它寻址；`services.browser` / `services.llm` 仅 localhost。
+- `server.oss.enabled`（对象存储启用开关；地址来自 `services.oss`，整段省略 = 禁用、优雅降级）
+- `server.apps.*`（App 级配置，如 `calc.precision`、`terminal.*`、`hn.*`、`amap.*`；`amap.apiKey` 为凭据，走 `config.secret.yaml`）
+- `server.tavily.apiKey`、`server.bot.qq`、`server.bot.creator`
+
+> 历史遗留：早期的 `server.rag.*` 已迁移到 `server.agent.story.memory.*`，`config.yaml` 中不应再有独立的 `server.rag` 分区。
+
+## 数据库与存储布局
+
+- 数据库为**进程内 SQLite 文件**（默认 `data/sqlite/kagami.db`），不依赖外部 PostgreSQL；ORM 仍是 Prisma，driver adapter 为 `@prisma/adapter-better-sqlite3`。
+- 直接查库用 `sqlite3` CLI；库文件路径以 `config.yaml` 的 `server.databaseUrl`（`file:` 路径，运行时解析为绝对路径）为准。
+- Story 向量记忆用**进程内 HNSW 索引（hnswlib-node）**：向量以 JSON 字符串存于 `story_memory_document.embedding`（SQLite 为唯一事实来源），索引启动时从 SQLite 重建、并持久化派生快照到 `data/vector/story-memory.hnsw`。
+- 所有持久化数据放在仓库根 `data/` 下并按类别分子目录（`data/sqlite/`、`data/vector/`）；整个 `data/` 已在 `.gitignore` 中。
+
+## Prisma 迁移
+
+```bash
+pnpm db:migrate:dev -- --name <migration_name> # 生成迁移（脚本自动补 --create-only）
+pnpm db:migrate:deploy                          # 部署 / 上线时应用已有迁移
+pnpm db:migrate:status                          # 查看迁移状态
+pnpm db:migrate:reset                           # 重置数据库（危险）
+pnpm db:migrate:resolve -- --applied <migration_id> # 标记迁移已应用
+```
+
+变更流程：
+
+1. 修改 `packages/persistence/prisma/schema.prisma`。
+2. 在仓库根执行 `pnpm db:migrate:dev -- --name <migration_name>`。
+3. 提交 schema 变更和 `packages/persistence/prisma/migrations/*`。
+4. 在目标环境执行 `pnpm db:migrate:deploy`，或通过 `pnpm app:deploy` 一并完成。
+
+已有数据库接入 Prisma Migrate（基线）：
+
+1. 若数据库结构已与当前 schema 对齐，先 `pnpm db:migrate:resolve -- --applied <baseline_migration_id>`。
+2. 后续按标准流程使用 `db:migrate:dev` 和 `db:migrate:deploy`。
+
+> **迁移涉及 DB schema 变更时，部署必须走无参 `pnpm app:deploy`**（会跑 `prisma migrate deploy`），不能用单服务部署（详见 AGENTS.md「部署速查」）。


### PR DESCRIPTION
## 背景

以人类读者角度审阅 CLAUDE.md（= AGENTS.md 符号链接），并请 Codex 独立复审。两方独立结论高度一致（核心诊断约 90% 重合）：内容含金量高，但形态是"维护者脑内状态转储"——信息过载无阅读路径、长期规范与临时状态混杂、多职责长 bullet 读起来像压缩包、新人 onboarding 不友好。

## 改动

- **AGENTS.md 431 → 217 行**
  - 保留 crown jewels：项目理念、KV 缓存命中率优先（三段模型 + InvokeTool + 三范例 + 红线，被多处代码 `设计依据见 CLAUDE.md` 引用，原文保留）、硬约束、部署红线、skill routing。
  - 删除与 ARCHITECTURE.md 重复的「项目定位包列表」「架构概览」「部署进程细节」，改为指针。
  - 新增「阅读路径（按任务选）」，解决新人不知从何读起。
  - 剥离临时状态：包数量、冗长开发现状、穷举配置分区列表。
  - 拆散同时承载「定义+原因+实现+例外+迁移」的长 bullet。
  - 把「部署红线」从末尾 gstack 段提升为独立顶层小节，更显眼。
- **新增 docs/configuration.md**：承载配置双份机制、`@kagami/config`、关键配置分区、SQLite 布局、Prisma 迁移流程与命令。
- **修 ARCHITECTURE.md 漂移**（避免指针指向陈旧内容）：包数 12 → 16、部署进程 五 → 六（补 `kagami-llm`）；workspace 拓扑与包表补齐 `apps/llm` 与 `llm-client` / `auth` / `config` / `gateway`。

## 验证

- 纯 markdown 改动，不涉及 TS；`prettier --check` 通过。
- CLAUDE.md → AGENTS.md 符号链接完好。
- 代码里 `设计依据见 CLAUDE.md "工具组织：InvokeTool..."` 等引用的章节标题原文保留。