### PR TITLE
fix(llm-client): 序列化 native error 时保留 cause 链与网络诊断字段

### DIFF
--- a/packages/llm-client/src/provider.ts
+++ b/packages/llm-client/src/provider.ts
@@ -73,13 +73,31 @@ function toSerializableLlmNativeValue(value: unknown): unknown {
   try {
     const serialized = JSON.stringify(value, (_key: string, currentValue: unknown) => {
       if (currentValue instanceof Error) {
-        const withStatus = currentValue as Error & { status?: unknown; code?: unknown };
+        const withExtra = currentValue as Error & {
+          status?: unknown;
+          code?: unknown;
+          errno?: unknown;
+          syscall?: unknown;
+          address?: unknown;
+          port?: unknown;
+          hostname?: unknown;
+          errors?: unknown;
+        };
         return {
           name: currentValue.name,
           message: currentValue.message,
           stack: currentValue.stack,
-          status: typeof withStatus.status === "number" ? withStatus.status : undefined,
-          code: typeof withStatus.code === "string" ? withStatus.code : undefined,
+          status: typeof withExtra.status === "number" ? withExtra.status : undefined,
+          code: typeof withExtra.code === "string" ? withExtra.code : undefined,
+          errno: typeof withExtra.errno === "number" ? withExtra.errno : undefined,
+          syscall: typeof withExtra.syscall === "string" ? withExtra.syscall : undefined,
+          address: typeof withExtra.address === "string" ? withExtra.address : undefined,
+          port: typeof withExtra.port === "number" ? withExtra.port : undefined,
+          hostname: typeof withExtra.hostname === "string" ? withExtra.hostname : undefined,
+          // `cause` 与 `errors` 是嵌套的 Error（如 undici 的 `fetch failed` 把 ECONNREFUSED
+          // 放在 cause 里，AggregateError 把子错误放在 errors 里）。原样透传，replacer 会递归展开。
+          cause: currentValue.cause ?? undefined,
+          errors: Array.isArray(withExtra.errors) ? withExtra.errors : undefined,
         };
       }
 

--- a/packages/llm-client/test/native-error-serialization.test.ts
+++ b/packages/llm-client/test/native-error-serialization.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { toSerializableLlmNativeRecord } from "../src/provider.js";
+
+describe("toSerializableLlmNativeRecord", () => {
+  it("展开 undici `fetch failed` 的 cause 链与网络诊断字段", () => {
+    // 复现 undici 的形状：外层 TypeError 无细节，真正的 errno 在 cause 里。
+    const cause = new Error("connect ECONNREFUSED 198.18.0.103:443");
+    Object.assign(cause, {
+      code: "ECONNREFUSED",
+      errno: -61,
+      syscall: "connect",
+      address: "198.18.0.103",
+      port: 443,
+    });
+    const error = new TypeError("fetch failed", { cause });
+
+    const record = toSerializableLlmNativeRecord(error);
+
+    expect(record.name).toBe("TypeError");
+    expect(record.message).toBe("fetch failed");
+    const serializedCause = record.cause as Record<string, unknown>;
+    expect(serializedCause.code).toBe("ECONNREFUSED");
+    expect(serializedCause.errno).toBe(-61);
+    expect(serializedCause.syscall).toBe("connect");
+    expect(serializedCause.address).toBe("198.18.0.103");
+    expect(serializedCause.port).toBe(443);
+  });
+
+  it("展开 AggregateError 的 errors 子错误", () => {
+    const error = new AggregateError(
+      [new Error("attempt A failed"), new Error("attempt B failed")],
+      "all attempts failed",
+    );
+
+    const record = toSerializableLlmNativeRecord(error);
+
+    const errors = record.errors as Array<Record<string, unknown>>;
+    expect(errors).toHaveLength(2);
+    expect(errors[0].message).toBe("attempt A failed");
+    expect(errors[1].message).toBe("attempt B failed");
+  });
+
+  it("循环 cause 不抛异常，降级为字符串", () => {
+    const error = new Error("self-referential");
+    Object.assign(error, { cause: error });
+
+    expect(() => toSerializableLlmNativeRecord(error)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## 背景

排查「中午 12 点 LLM 报错」时发现：`llm_chat_call.native_error` 里所有失败都只有一句 `TypeError: fetch failed`，看不出真正原因。根因是 `packages/llm-client/src/provider.ts` 的 Error 序列化器只抽 `name/message/stack/status/code`，把 undici 真正的诊断信息所在的 `Error.cause` 整个丢弃了。

## 改动

`toSerializableLlmNativeValue` 的 Error 分支现在额外捕获：

- `cause`：原样透传，`JSON.stringify` 的 replacer 会递归展开整条 cause 链（undici 把 `ECONNREFUSED` 等放在 cause 里）；
- `errors`：`AggregateError` 的子错误数组；
- `errno / syscall / address / port / hostname`：区分 `ECONNREFUSED` / `ENOTFOUND` / `ETIMEDOUT` 的网络层字段。

循环 `cause` 由既有 `try/catch` 兜底降级为字符串，不抛异常。

改动后 `native_error` 形如：

```json
{
  "name": "TypeError", "message": "fetch failed",
  "cause": { "code": "ECONNREFUSED", "errno": -61, "syscall": "connect",
             "address": "198.18.0.103", "port": 443 }
}
```

## 影响面

- 只在 LLM 调用失败路径序列化落库，**不进 LLM 上下文前缀**，零 KV 缓存影响。
- `address/hostname/port` 只写本地 DB、不外发。
- 无 DB schema 变更（`native_error` 已是 JSONB 列）。

## 测试

- 新增 `packages/llm-client/test/native-error-serialization.test.ts`：3 例覆盖 undici cause 链、AggregateError、循环 cause。
- `@kagami/llm-client` 52 项测试全过。
- `pnpm build` / `typecheck` / `lint` / `format` 四项门禁全绿。