### PR TITLE
refactor(llm-api): chat/chat-direct/embed 收敛到契约驱动 client（信封级，#230）

### DIFF
--- a/apps/agent/src/llm/http-embedding-client.ts
+++ b/apps/agent/src/llm/http-embedding-client.ts
@@ -1,64 +1,34 @@
-import { BizError } from "@kagami/kernel/errors/biz-error";
-import { bizErrorFromWire, isBizErrorWire } from "@kagami/kernel/errors/biz-error-wire";
+import { createClient, type JsonClient } from "@kagami/rpc-client/client";
+import { llmApiContract } from "@kagami/llm-api/contract";
 import type {
   EmbeddingClient,
   EmbeddingRequest,
   EmbeddingResponse,
 } from "@kagami/llm-client/embedding";
 
-type FetchLike = typeof fetch;
+// 与 HttpLlmClient 同源：isRetryableLlmFailure 精确匹配的兜底 message。
+const LLM_UNREACHABLE_MESSAGE = "LLM 上游服务调用失败";
 
-const EMBED_CLIENT_TIMEOUT_MS = 60_000;
+type FetchLike = typeof fetch;
 
 /**
  * 把 embedding 调用经 HTTP 打到独立的 kagami-llm 进程。实现 EmbeddingClient 接口，供 agent 侧
- * 任何需要文本向量化的能力复用（构造点 new HttpEmbeddingClient 即可）。embedding_cache 读写全在
- * 服务侧。错误按 BizError 富信封重建 / 不可达归一。当前无消费者，保留待将来记忆系统接线。
+ * 任何需要文本向量化的能力复用（构造点 new HttpEmbeddingClient 即可）。走 @kagami/llm-api 契约驱动
+ * 的 createClient（embed 路由，信封级 output `z.unknown()`），wire / 超时 / 错误通道统一在 rpc-client。
+ * embedding_cache 读写全在服务侧。当前无消费者，保留待将来记忆系统接线。
  */
 export class HttpEmbeddingClient implements EmbeddingClient {
-  private readonly baseUrl: string;
-  private readonly fetchImpl: FetchLike;
+  private readonly api: JsonClient<typeof llmApiContract>;
 
   public constructor({ baseUrl, fetch: fetchImpl }: { baseUrl: string; fetch?: FetchLike }) {
-    this.baseUrl = baseUrl.replace(/\/+$/, "");
-    this.fetchImpl = fetchImpl ?? fetch;
+    this.api = createClient(llmApiContract, {
+      baseUrl: baseUrl.replace(/\/+$/, ""),
+      ...(fetchImpl === undefined ? {} : { fetch: fetchImpl }),
+      unreachableMessage: LLM_UNREACHABLE_MESSAGE,
+    });
   }
 
   public async embed(request: EmbeddingRequest): Promise<EmbeddingResponse> {
-    let response: Response;
-    try {
-      response = await this.fetchImpl(`${this.baseUrl}/internal/embed`, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ request }),
-        signal: AbortSignal.timeout(EMBED_CLIENT_TIMEOUT_MS),
-      });
-    } catch (error) {
-      throw new BizError({
-        message: "LLM 上游服务调用失败",
-        meta: { reason: "unreachable" },
-        cause: error,
-      });
-    }
-
-    if (!response.ok) {
-      const payload = (await response.json().catch(() => null)) as { error?: unknown } | null;
-      if (payload && isBizErrorWire(payload.error)) {
-        throw bizErrorFromWire(payload.error);
-      }
-      throw new BizError({
-        message: "LLM 上游服务调用失败",
-        meta: { reason: "bad_status", status: response.status },
-      });
-    }
-
-    try {
-      return (await response.json()) as EmbeddingResponse;
-    } catch {
-      throw new BizError({
-        message: "LLM 上游服务调用失败",
-        meta: { reason: "invalid_response_body" },
-      });
-    }
+    return (await this.api.embed({ request })) as EmbeddingResponse;
   }
 }

--- a/apps/agent/src/llm/http-llm-client.ts
+++ b/apps/agent/src/llm/http-llm-client.ts
@@ -1,5 +1,3 @@
-import { BizError } from "@kagami/kernel/errors/biz-error";
-import { bizErrorFromWire, isBizErrorWire } from "@kagami/kernel/errors/biz-error-wire";
 import { createClient, type JsonClient } from "@kagami/rpc-client/client";
 import { llmApiContract } from "@kagami/llm-api/contract";
 import type {
@@ -13,42 +11,35 @@ import type {
 } from "@kagami/llm-client";
 import type { LlmProviderOption } from "@kagami/shared/schemas/llm-chat";
 
-// isRetryableLlmFailure 精确匹配这个 message 决定退避重试；createClient 的兜底错误必须沿用它。
+// isRetryableLlmFailure 精确匹配这个 message 决定退避重试；createClient 的兜底错误（不可达/超时/
+// 非 2xx 无富信封/响应体无效）必须沿用它。富错误信封 { error: BizErrorWire } 由 createClient 默认
+// decodeError 重建成等价 BizError，保住 retry 语义与"未知工具走 tool_result"路径。
 const LLM_UNREACHABLE_MESSAGE = "LLM 上游服务调用失败";
 
-type FetchLike = typeof fetch;
+// createClient 的默认超时（服务真挂/半开兜底）。chat/chat-direct 各自的 600s、providers 的 30s
+// 都由 llmApiContract 的 timeoutMs 逐路由覆盖，此默认只在契约未指定时兜底。
+const DEFAULT_CLIENT_TIMEOUT_MS = 30_000;
 
-// 客户端超时是「服务真挂/半开」的兜底，不是每次 chat 的时限。服务端每个 provider attempt 有自己的
-// timeoutMs、且可能多 attempt 串行（usageConfig.attempts），总耗时可达 attempts × timeoutMs。这里给
-// 一个远高于任何现实多-attempt 总时长的上限（10 分钟），确保**服务端 provider 超时永远先触发**、
-// 回出规整 BizError，避免 client 先 abort 却让服务端 in-flight 上游请求继续跑（重复调用 + 成本放大）。
-const CHAT_CLIENT_TIMEOUT_MS = 600_000;
-const QUERY_CLIENT_TIMEOUT_MS = 30_000;
+type FetchLike = typeof fetch;
 
 /**
  * 把 LLM 调用经 HTTP 打到独立的 kagami-llm 进程。实现 @kagami/llm-client 的 LlmClient 接口，
  * 因此 agent-runtime.factory 及所有下游消费者只把构造点从 createLlmClient 换成 new
  * HttpLlmClient，其余零改动。
  *
- * - 非 2xx 且带富错误信封 `{ error: BizErrorWire }`：重建等价 BizError 抛出（含 message/meta/
- *   statusCode）——保住 isRetryableLlmFailure 的 retry 语义与"未知工具走 tool_result"路径。
- * - 服务不可达 / 超时 / 无效响应：统一映射成 BizError("LLM 上游服务调用失败")——它既是
- *   isRetryableLlmFailure 的重试消息之一，语义上也正是"上游 LLM 服务调用失败"，让 agent 退避重试。
+ * 三条路由（chat / chat-direct / providers）全走 @kagami/llm-api 契约驱动的 createClient：wire 序列化、
+ * 超时、错误通道（BizError 富信封重建 + 不可达归一为 LLM_UNREACHABLE_MESSAGE）统一在 rpc-client。
+ * chat/chat-direct 是信封级（契约 output `z.unknown()`，复杂 union 不逐字段校验），故对返回值按 LlmClient
+ * 接口类型断言；providers 是全类型化路由，返回类型由契约 output 反推、与服务端 handler 同源。
  */
 export class HttpLlmClient implements LlmClient {
-  private readonly baseUrl: string;
-  private readonly fetchImpl: FetchLike;
-  // providers 走契约驱动的 client（@kagami/llm-api）：门面 == 契约，改契约 output 则此处与
-  // 服务端 handler 同时编译报错。chat / chat-direct 仍走下方手写 post（复杂 union，信封级留后续）。
   private readonly api: JsonClient<typeof llmApiContract>;
 
   public constructor({ baseUrl, fetch: fetchImpl }: { baseUrl: string; fetch?: FetchLike }) {
-    this.baseUrl = baseUrl.replace(/\/+$/, "");
-    this.fetchImpl = fetchImpl ?? fetch;
     this.api = createClient(llmApiContract, {
-      baseUrl: this.baseUrl,
-      fetch: this.fetchImpl,
-      timeoutMs: QUERY_CLIENT_TIMEOUT_MS,
+      baseUrl: baseUrl.replace(/\/+$/, ""),
+      ...(fetchImpl === undefined ? {} : { fetch: fetchImpl }),
+      timeoutMs: DEFAULT_CLIENT_TIMEOUT_MS,
       unreachableMessage: LLM_UNREACHABLE_MESSAGE,
     });
   }
@@ -57,80 +48,28 @@ export class HttpLlmClient implements LlmClient {
     request: LlmChatRequest,
     options: LlmChatOptions,
   ): Promise<LlmChatResponsePayload> {
-    return (await this.post(
-      "/internal/chat",
-      {
-        request,
-        usage: options.usage,
-        ...(options.recordCall === undefined ? {} : { recordCall: options.recordCall }),
-      },
-      CHAT_CLIENT_TIMEOUT_MS,
-    )) as LlmChatResponsePayload;
+    return (await this.api.chat({
+      request,
+      usage: options.usage,
+      ...(options.recordCall === undefined ? {} : { recordCall: options.recordCall }),
+    })) as LlmChatResponsePayload;
   }
 
   public async chatDirect(
     request: LlmChatRequest,
     options: LlmChatDirectOptions,
   ): Promise<LlmChatDirectResult> {
-    return (await this.post(
-      "/internal/chat-direct",
-      {
-        request,
-        providerId: options.providerId,
-        model: options.model,
-        ...(options.recordCall === undefined ? {} : { recordCall: options.recordCall }),
-      },
-      CHAT_CLIENT_TIMEOUT_MS,
-    )) as LlmChatDirectResult;
+    return (await this.api.chatDirect({
+      request,
+      providerId: options.providerId,
+      model: options.model,
+      ...(options.recordCall === undefined ? {} : { recordCall: options.recordCall }),
+    })) as LlmChatDirectResult;
   }
 
   public async listAvailableProviders(
     options: LlmListAvailableProvidersOptions,
   ): Promise<LlmProviderOption[]> {
     return this.api.listProviders({ usage: options.usage });
-  }
-
-  private async post(path: string, body: unknown, timeoutMs: number): Promise<unknown> {
-    return this.request(path, timeoutMs, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(body),
-    });
-  }
-
-  private async request(path: string, timeoutMs: number, init: RequestInit): Promise<unknown> {
-    let response: Response;
-    try {
-      response = await this.fetchImpl(`${this.baseUrl}${path}`, {
-        ...init,
-        signal: AbortSignal.timeout(timeoutMs),
-      });
-    } catch (error) {
-      throw new BizError({
-        message: "LLM 上游服务调用失败",
-        meta: { reason: "unreachable" },
-        cause: error,
-      });
-    }
-
-    if (!response.ok) {
-      const payload = (await response.json().catch(() => null)) as { error?: unknown } | null;
-      if (payload && isBizErrorWire(payload.error)) {
-        throw bizErrorFromWire(payload.error);
-      }
-      throw new BizError({
-        message: "LLM 上游服务调用失败",
-        meta: { reason: "bad_status", status: response.status },
-      });
-    }
-
-    try {
-      return await response.json();
-    } catch {
-      throw new BizError({
-        message: "LLM 上游服务调用失败",
-        meta: { reason: "invalid_response_body" },
-      });
-    }
   }
 }

--- a/apps/agent/test/llm-api-contract.test.ts
+++ b/apps/agent/test/llm-api-contract.test.ts
@@ -32,4 +32,23 @@ describe("llm-api 契约：编译期类型强制", () => {
     });
     expect(typeof api.listProviders).toBe("function");
   });
+
+  it("chat/chatDirect/embed 是信封级：request/output 是 unknown，但信封字段仍编译期强制", () => {
+    const api = createClient(llmApiContract, { baseUrl: "http://llm" });
+    void (async (): Promise<void> => {
+      // request 是 unknown：任意结构放行（信封级刻意不逐字段校验）
+      await api.chat({ request: { whatever: true }, usage: "agent" });
+      // @ts-expect-error 信封字段 usage 必填，缺失必须报错
+      await api.chat({ request: {} });
+      // @ts-expect-error chatDirect 信封要求 providerId/model，缺失必须报错
+      await api.chatDirect({ request: {}, usage: "agent" });
+      await api.chatDirect({ request: {}, providerId: "openai", model: "gpt" });
+      // output 是 unknown：不暴露具体字段类型（信封级，门面按接口断言）
+      const res: unknown = await api.chat({ request: {}, usage: "agent" });
+      void res;
+      await api.embed({ request: { content: "hi" } });
+    });
+    expect(typeof api.chat).toBe("function");
+    expect(typeof api.embed).toBe("function");
+  });
 });

--- a/apps/llm/src/http/internal-llm.handler.ts
+++ b/apps/llm/src/http/internal-llm.handler.ts
@@ -1,5 +1,4 @@
 import type { FastifyInstance } from "fastify";
-import { z } from "zod";
 import { registerJsonRoute } from "@kagami/http/contract";
 import { llmApiContract } from "@kagami/llm-api/contract";
 import type { LlmProviderId } from "@kagami/llm";
@@ -7,25 +6,10 @@ import type { LlmUsageId } from "@kagami/kernel/contracts/llm";
 import type { LlmClient, LlmChatRequest } from "@kagami/llm-client";
 import type { EmbeddingClient, EmbeddingRequest } from "@kagami/llm-client/embedding";
 
-// Agent-facing 内部 RPC。请求体是可信的内部契约（agent HttpLlmClient 直连、仅 localhost），
-// 故 request/EmbeddingRequest 用 z.unknown() 透传后按类型断言——复杂 union（LlmMessage/Tool）
-// 不做逐字段 zod，只校验信封外壳。抛出的 BizError 由 runtime setErrorHandler 统一序列化成
-// 富错误信封，agent 侧据此重建 BizError。
-const ChatBody = z.object({
-  request: z.unknown(),
-  usage: z.string().min(1),
-  recordCall: z.boolean().optional(),
-});
-const ChatDirectBody = z.object({
-  request: z.unknown(),
-  providerId: z.string().min(1),
-  model: z.string().min(1),
-  recordCall: z.boolean().optional(),
-});
-const EmbedBody = z.object({
-  request: z.unknown(),
-});
-
+// Agent-facing 内部 RPC，全量走 @kagami/llm-api 契约（单一事实源，与 agent 侧 createClient 共享 schema）。
+// chat/chat-direct/embed 的 request 是可信内部契约（agent 直连、仅 localhost）的复杂 union（LlmMessage/
+// Tool/EmbeddingRequest），契约刻意用 z.unknown() 只校验信封、透传后按类型断言——见 llm-api/contract。
+// 抛出的 BizError 由 runtime setErrorHandler 统一序列化成富错误信封，agent 侧据此重建 BizError。
 export class InternalLlmHandler {
   private readonly llmClient: LlmClient;
   private readonly embeddingClient: EmbeddingClient;
@@ -42,32 +26,29 @@ export class InternalLlmHandler {
   }
 
   public register(app: FastifyInstance): void {
-    app.post("/internal/chat", async request => {
-      const body = ChatBody.parse(request.body);
-      return await this.llmClient.chat(body.request as LlmChatRequest, {
-        usage: body.usage as LlmUsageId,
-        ...(body.recordCall === undefined ? {} : { recordCall: body.recordCall }),
+    registerJsonRoute(app, llmApiContract.chat, async ({ input }) => {
+      return await this.llmClient.chat(input.request as LlmChatRequest, {
+        usage: input.usage as LlmUsageId,
+        ...(input.recordCall === undefined ? {} : { recordCall: input.recordCall }),
       });
     });
 
-    app.post("/internal/chat-direct", async request => {
-      const body = ChatDirectBody.parse(request.body);
-      return await this.llmClient.chatDirect(body.request as LlmChatRequest, {
-        providerId: body.providerId as LlmProviderId,
-        model: body.model,
-        ...(body.recordCall === undefined ? {} : { recordCall: body.recordCall }),
+    registerJsonRoute(app, llmApiContract.chatDirect, async ({ input }) => {
+      return await this.llmClient.chatDirect(input.request as LlmChatRequest, {
+        providerId: input.providerId as LlmProviderId,
+        model: input.model,
+        ...(input.recordCall === undefined ? {} : { recordCall: input.recordCall }),
       });
     });
 
-    // providers 路由走契约（@kagami/llm-api）：input/output 由 llmApiContract.listProviders 反推，
-    // 与 agent 侧 createClient 共享同一份 schema —— 改契约 output，此 execute 返回类型与 agent 调用点同时红。
+    // providers 路由是编译期强制样板：input/output 由 llmApiContract.listProviders 反推，与 agent 侧
+    // createClient 共享同一份 schema —— 改契约 output，此 execute 返回类型与 agent 调用点同时红。
     registerJsonRoute(app, llmApiContract.listProviders, async ({ input }) => {
       return await this.llmClient.listAvailableProviders({ usage: input.usage as LlmUsageId });
     });
 
-    app.post("/internal/embed", async request => {
-      const body = EmbedBody.parse(request.body);
-      return await this.embeddingClient.embed(body.request as EmbeddingRequest);
+    registerJsonRoute(app, llmApiContract.embed, async ({ input }) => {
+      return await this.embeddingClient.embed(input.request as EmbeddingRequest);
     });
   }
 }

--- a/packages/llm-api/src/contract.ts
+++ b/packages/llm-api/src/contract.ts
@@ -2,12 +2,29 @@ import { defineJsonRoute } from "@kagami/http/contract";
 import { LlmProviderOptionSchema } from "@kagami/shared/schemas/llm-chat";
 import { z } from "zod";
 
+// chat / chat-direct 的客户端超时是「服务真挂/半开」的兜底，不是每次 chat 的时限：服务端每个
+// provider attempt 有自己的 timeout、可能多 attempt 串行，总耗时可达 attempts × timeoutMs。给一个
+// 远高于任何现实多-attempt 总时长的上限（10 分钟），确保服务端 provider 超时永远先触发、回出规整
+// BizError，避免 client 先 abort 却让服务端 in-flight 上游请求继续跑（重复调用 + 成本放大）。
+const CHAT_TIMEOUT_MS = 600_000;
+const QUERY_TIMEOUT_MS = 30_000;
+const EMBED_TIMEOUT_MS = 60_000;
+
+/**
+ * chat / chat-direct / embed 的 `request` 是复杂 union（LlmMessage / Tool / EmbeddingRequest），刻意
+ * 用 `z.unknown()` 只校验信封外壳、不逐字段 zod —— 这是既有设计（见 internal-llm.handler 注释），非
+ * 技术债。output 同理留 `z.unknown()`：**信封级**，服务端返回结构不进 Zod，消费端门面按类型断言。
+ * 这三条路由的价值是统一 HTTP 管线 + 错误通道 + 超时，而非给复杂 union 加编译期字段校验（那属
+ * listProviders 这类真 JSON schema 的路由）。
+ */
+const EnvelopeRequest = z.unknown();
+
 /**
  * kagami-llm 进程对 agent 暴露的内部 RPC 契约（单一事实源）。服务端 handler 与 agent 侧 client
  * 都从这里派生类型 —— 改 output，两端一起编译报错（issue #230）。
  *
- * 现阶段只覆盖 `/internal/providers`（最干净的 JSON 往返，作样板证明编译期强制）。chat / chat-direct /
- * embed 的响应是刻意不逐字段校验的复杂 union（服务端 z.unknown），留作后续「信封级」迁移，不在此契约内。
+ * - `listProviders`：真 JSON schema，output 全类型化，是编译期强制的样板。
+ * - `chat` / `chatDirect` / `embed`：信封级（output `z.unknown()`），复杂 union 不逐字段校验，见上。
  */
 export const llmApiContract = {
   listProviders: defineJsonRoute({
@@ -16,6 +33,36 @@ export const llmApiContract = {
     input: z.object({ usage: z.string().min(1) }),
     output: z.array(LlmProviderOptionSchema),
     // providers 是轻查询：服务真挂/半开的兜底超时，非每次调用时限。
-    timeoutMs: 30_000,
+    timeoutMs: QUERY_TIMEOUT_MS,
+  }),
+  chat: defineJsonRoute({
+    method: "POST",
+    path: "/internal/chat",
+    input: z.object({
+      request: EnvelopeRequest,
+      usage: z.string().min(1),
+      recordCall: z.boolean().optional(),
+    }),
+    output: z.unknown(),
+    timeoutMs: CHAT_TIMEOUT_MS,
+  }),
+  chatDirect: defineJsonRoute({
+    method: "POST",
+    path: "/internal/chat-direct",
+    input: z.object({
+      request: EnvelopeRequest,
+      providerId: z.string().min(1),
+      model: z.string().min(1),
+      recordCall: z.boolean().optional(),
+    }),
+    output: z.unknown(),
+    timeoutMs: CHAT_TIMEOUT_MS,
+  }),
+  embed: defineJsonRoute({
+    method: "POST",
+    path: "/internal/embed",
+    input: z.object({ request: EnvelopeRequest }),
+    output: z.unknown(),
+    timeoutMs: EMBED_TIMEOUT_MS,
   }),
 };


### PR DESCRIPTION
## 背景
epic #230 的剩余项之一。#233 已落地契约原语 + `listProviders` 样板；本 PR 把 llm 内部 RPC 的
另外三条（chat / chat-direct / embed）从 agent 侧手写 fetch 收敛到 `@kagami/rpc-client` 的
`createClient`，服务端改走 `registerJsonRoute`。

## 改动
- `@kagami/llm-api`：契约新增 chat/chatDirect/embed（信封级，request/output 刻意 `z.unknown()`）。
- `apps/llm` handler：三条改 `registerJsonRoute`，删内联 schema。
- `apps/agent` HttpLlmClient/HttpEmbeddingClient：删手写 post/request，走 `this.api.*`。

## 为什么是信封级
chat/chat-direct/embed 的 request 是复杂 union（LlmMessage/Tool/EmbeddingRequest），服务端历来
用 `z.unknown()` 只校验信封（非技术债，见注释）。本 PR 保持这一边界：价值是统一 HTTP 管线 +
错误通道 + 超时，不是给复杂 union 加字段校验（那是 `listProviders` 那类真 schema 路由的事）。

## 等价性（纯重构）
- wire 字节：`JSON.stringify({request,usage,recordCall?})` 与旧 post 逐字节一致；响应经 `z.unknown()` 透传不变。
- 错误：`createClient` 默认 decodeError 重建 BizError 富信封；`unreachableMessage="LLM 上游服务调用失败"` 保 `isRetryableLlmFailure` 语义。
- 超时：chat/chat-direct 600s、embed 60s、providers 30s，逐路由 `contract.timeoutMs`。

## 门禁
build / typecheck / lint(0 error) / format 全绿；`@kagami/llm-service` 3 测试、`@kagami/agent` 676 测试全过（含新增 chat/chatDirect/embed 信封字段编译期强制断言）。

Refs #230