### PR TITLE
feat(todo): 待办推荐子调用对偶发上游失败加退避重试

### DIFF
--- a/apps/agent/src/agent/capabilities/todo/application/todo-suggestion.service.ts
+++ b/apps/agent/src/agent/capabilities/todo/application/todo-suggestion.service.ts
@@ -3,11 +3,36 @@ import { AppLogger } from "@kagami/kernel/logger/logger";
 import type { LlmClient } from "@kagami/llm-client";
 import type { LlmMessage, Tool } from "@kagami/llm-client";
 import { createTodoSuggestionInstructionMessage } from "../../../runtime/context/context-message-factory.js";
+import { isRetryableLlmFailure } from "../../../runtime/llm-retry.js";
 
 const logger = new AppLogger({ source: "todo.suggestion-service" });
 
 /** 单次子调用最多采纳的候选待办条数（模型多返回也在此截断）。 */
 const MAX_SUGGESTIONS = 5;
+
+/**
+ * 一次 digest 里「发现待办」子调用的总尝试次数（含首次）；耗尽仍失败则降级为两段。
+ * 底层 llm-client 已按 usage 配置（todoSuggestionAgent: times 3）对每次 chat 做无退避的
+ * 立即重试，两层是乘法关系（外层 N × 底层 times 次 provider 调用）——外层只留 2，
+ * 专补底层没有的「隔一段再试」，不把最坏调用数推得更高。
+ */
+const DEFAULT_MAX_ATTEMPTS = 2;
+
+/** 两次尝试之间的固定退避；这是后台 digest，不抢主循环，短退避即可。 */
+const DEFAULT_RETRY_BACKOFF_MS = 2_000;
+
+/** 归一化上限：外层重试是补充不是主力，不给配置出「调度器长期占坑」的空间。 */
+const MAX_ATTEMPTS_CEILING = 5;
+
+const defaultSleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+/** 把外部传入的次数/毫秒归一到安全区间（防 Infinity/NaN/负数/小数这类 footgun）。 */
+function clampInt(value: number, min: number, max: number, fallback: number): number {
+  if (!Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.min(max, Math.max(min, Math.trunc(value)));
+}
 
 export const PROPOSE_TODOS_TOOL_NAME = "propose_todos";
 
@@ -57,47 +82,90 @@ export type TodoSuggestionInput = {
  *
  * 全程 try/catch：无 provider / 超时 / 无 toolCall / 参数解析失败 / 空 —— 一律返回 []，绝不 rethrow，
  * 让 digest 降级为只发原两段。
+ *
+ * 重试：只有「真正的调用失败」（provider 不可用 / 上游服务调用失败，判定复用主循环的
+ * isRetryableLlmFailure）才会退避后重试，最多 DEFAULT_MAX_ATTEMPTS 次，抹平偶发抖动。
+ * 模型返回畸形（无 toolCall / 参数解析失败）属于调用成功但内容不合规，不重试、直接降级；
+ * 其它非可重试异常同样立即降级。
  */
 export class TodoSuggestionService {
   private readonly llmClient: LlmClient;
+  private readonly maxAttempts: number;
+  private readonly retryBackoffMs: number;
+  private readonly sleep: (ms: number) => Promise<void>;
 
-  public constructor({ llmClient }: { llmClient: LlmClient }) {
+  public constructor({
+    llmClient,
+    maxAttempts = DEFAULT_MAX_ATTEMPTS,
+    retryBackoffMs = DEFAULT_RETRY_BACKOFF_MS,
+    sleep = defaultSleep,
+  }: {
+    llmClient: LlmClient;
+    maxAttempts?: number;
+    retryBackoffMs?: number;
+    sleep?: (ms: number) => Promise<void>;
+  }) {
     this.llmClient = llmClient;
+    this.maxAttempts = clampInt(maxAttempts, 1, MAX_ATTEMPTS_CEILING, DEFAULT_MAX_ATTEMPTS);
+    this.retryBackoffMs = clampInt(retryBackoffMs, 0, 60_000, DEFAULT_RETRY_BACKOFF_MS);
+    this.sleep = sleep;
   }
 
   public async propose(input: TodoSuggestionInput): Promise<string[]> {
-    try {
-      const response = await this.llmClient.chat(
-        {
-          system: input.systemPrompt,
-          messages: [...input.messages, createTodoSuggestionInstructionMessage(input.openTodos)],
-          tools: [PROPOSE_TODOS_TOOL],
-          toolChoice: { tool_name: PROPOSE_TODOS_TOOL_NAME },
-        },
-        { usage: "todoSuggestionAgent" },
-      );
-
-      const toolCall = response.message.toolCalls[0];
-      if (!toolCall || toolCall.name !== PROPOSE_TODOS_TOOL_NAME) {
-        return [];
+    for (let attempt = 1; attempt <= this.maxAttempts; attempt += 1) {
+      try {
+        return await this.proposeOnce(input);
+      } catch (error) {
+        const canRetry = attempt < this.maxAttempts && isRetryableLlmFailure(error);
+        logger.warn(
+          canRetry
+            ? "Failed to propose todo suggestions; will retry"
+            : "Failed to propose todo suggestions; digest degrades to two sections",
+          {
+            event: canRetry ? "todo.suggestion_retry" : "todo.suggestion_failed",
+            attempt,
+            maxAttempts: this.maxAttempts,
+            errorName: error instanceof Error ? error.name : "Error",
+            errorMessage: error instanceof Error ? error.message : String(error),
+          },
+        );
+        if (!canRetry) {
+          return [];
+        }
+        await this.sleep(this.retryBackoffMs);
       }
+    }
+    return [];
+  }
 
-      const parsed = ProposeTodosArgsSchema.safeParse(toolCall.arguments);
-      if (!parsed.success) {
-        return [];
-      }
+  /**
+   * 单次子调用：畸形响应（无 toolCall / 参数解析失败）正常返回 []（调用成功，不触发重试）；
+   * chat 抛出的异常向上抛给 propose，由那里按可重试性决定是重试还是降级。
+   */
+  private async proposeOnce(input: TodoSuggestionInput): Promise<string[]> {
+    const response = await this.llmClient.chat(
+      {
+        system: input.systemPrompt,
+        messages: [...input.messages, createTodoSuggestionInstructionMessage(input.openTodos)],
+        tools: [PROPOSE_TODOS_TOOL],
+        toolChoice: { tool_name: PROPOSE_TODOS_TOOL_NAME },
+      },
+      { usage: "todoSuggestionAgent" },
+    );
 
-      return parsed.data.suggestions
-        .map(suggestion => suggestion.trim())
-        .filter(suggestion => suggestion.length > 0)
-        .slice(0, MAX_SUGGESTIONS);
-    } catch (error) {
-      logger.warn("Failed to propose todo suggestions; digest degrades to two sections", {
-        event: "todo.suggestion_failed",
-        errorName: error instanceof Error ? error.name : "Error",
-        errorMessage: error instanceof Error ? error.message : String(error),
-      });
+    const toolCall = response.message.toolCalls[0];
+    if (!toolCall || toolCall.name !== PROPOSE_TODOS_TOOL_NAME) {
       return [];
     }
+
+    const parsed = ProposeTodosArgsSchema.safeParse(toolCall.arguments);
+    if (!parsed.success) {
+      return [];
+    }
+
+    return parsed.data.suggestions
+      .map(suggestion => suggestion.trim())
+      .filter(suggestion => suggestion.length > 0)
+      .slice(0, MAX_SUGGESTIONS);
   }
 }

--- a/apps/agent/test/agent/capabilities/todo/todo-suggestion.service.test.ts
+++ b/apps/agent/test/agent/capabilities/todo/todo-suggestion.service.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { LlmClient } from "@kagami/llm-client";
+import { BizError } from "@kagami/kernel/errors/biz-error";
 import {
   PROPOSE_TODOS_TOOL_NAME,
   TodoSuggestionService,
@@ -20,11 +21,8 @@ function makeLlmClient(chat: ReturnType<typeof vi.fn>): {
   return { llmClient, chat };
 }
 
-function chatReturning(
-  args: unknown,
-  toolName = PROPOSE_TODOS_TOOL_NAME,
-): ReturnType<typeof vi.fn> {
-  return vi.fn().mockResolvedValue({
+function successResponse(args: unknown, toolName = PROPOSE_TODOS_TOOL_NAME): unknown {
+  return {
     provider: "openai",
     model: "gpt-4o-mini",
     message: {
@@ -32,8 +30,23 @@ function chatReturning(
       content: "",
       toolCalls: [{ id: "propose-1", name: toolName, arguments: args }],
     },
-  });
+  };
 }
+
+function chatReturning(
+  args: unknown,
+  toolName = PROPOSE_TODOS_TOOL_NAME,
+): ReturnType<typeof vi.fn> {
+  return vi.fn().mockResolvedValue(successResponse(args, toolName));
+}
+
+/** isRetryableLlmFailure 只认这两条 message，模拟一次可重试的上游抖动。 */
+function retryableFailure(): BizError {
+  return new BizError({ message: "LLM 上游服务调用失败" });
+}
+
+/** 注入即时 sleep，避免测试真的等退避。 */
+const immediateSleep = vi.fn(async () => {});
 
 const input = {
   systemPrompt: "sys",
@@ -99,5 +112,80 @@ describe("TodoSuggestionService.propose", () => {
     const { llmClient } = makeLlmClient(chatReturning({}));
     const service = new TodoSuggestionService({ llmClient });
     expect(await service.propose(input)).toEqual([]);
+  });
+
+  it("可重试失败后重试成功：先抖动一次，第二次拿到结果", async () => {
+    const chat = vi
+      .fn()
+      .mockRejectedValueOnce(retryableFailure())
+      .mockResolvedValueOnce(successResponse({ suggestions: ["写周报"] }));
+    const { llmClient } = makeLlmClient(chat);
+    immediateSleep.mockClear();
+    const service = new TodoSuggestionService({ llmClient, sleep: immediateSleep });
+    expect(await service.propose(input)).toEqual(["写周报"]);
+    expect(chat).toHaveBeenCalledTimes(2);
+    expect(immediateSleep).toHaveBeenCalledTimes(1);
+  });
+
+  it("可重试失败耗尽尝试次数 → []（试满 maxAttempts 次）", async () => {
+    const chat = vi.fn().mockRejectedValue(retryableFailure());
+    const { llmClient } = makeLlmClient(chat);
+    immediateSleep.mockClear();
+    const service = new TodoSuggestionService({
+      llmClient,
+      maxAttempts: 3,
+      sleep: immediateSleep,
+    });
+    expect(await service.propose(input)).toEqual([]);
+    expect(chat).toHaveBeenCalledTimes(3);
+    // 最后一次不再退避
+    expect(immediateSleep).toHaveBeenCalledTimes(2);
+  });
+
+  it("不可重试异常不重试：只调一次即降级", async () => {
+    const chat = vi.fn().mockRejectedValue(new Error("boom"));
+    const { llmClient } = makeLlmClient(chat);
+    immediateSleep.mockClear();
+    const service = new TodoSuggestionService({ llmClient, sleep: immediateSleep });
+    expect(await service.propose(input)).toEqual([]);
+    expect(chat).toHaveBeenCalledTimes(1);
+    expect(immediateSleep).not.toHaveBeenCalled();
+  });
+
+  it("maxAttempts 传 Infinity/0 被归一化：不会死循环，也不会跳过首轮调用", async () => {
+    const chatInfinity = vi.fn().mockRejectedValue(retryableFailure());
+    immediateSleep.mockClear();
+    const serviceInfinity = new TodoSuggestionService({
+      llmClient: makeLlmClient(chatInfinity).llmClient,
+      maxAttempts: Infinity,
+      sleep: immediateSleep,
+    });
+    expect(await serviceInfinity.propose(input)).toEqual([]);
+    // Infinity 非法 → 回落默认 2 次
+    expect(chatInfinity).toHaveBeenCalledTimes(2);
+
+    const chatZero = chatReturning({ suggestions: ["写周报"] });
+    const serviceZero = new TodoSuggestionService({
+      llmClient: makeLlmClient(chatZero).llmClient,
+      maxAttempts: 0,
+      sleep: immediateSleep,
+    });
+    // 0 被抬到 1：首轮照常调用
+    expect(await serviceZero.propose(input)).toEqual(["写周报"]);
+    expect(chatZero).toHaveBeenCalledTimes(1);
+  });
+
+  it("畸形响应（无 toolCall）不重试：调用成功但内容不合规，直接降级", async () => {
+    const chat = vi.fn().mockResolvedValue({
+      provider: "openai",
+      model: "gpt-4o-mini",
+      message: { role: "assistant", content: "自由文本", toolCalls: [] },
+    });
+    const { llmClient } = makeLlmClient(chat);
+    immediateSleep.mockClear();
+    const service = new TodoSuggestionService({ llmClient, sleep: immediateSleep });
+    expect(await service.propose(input)).toEqual([]);
+    expect(chat).toHaveBeenCalledTimes(1);
+    expect(immediateSleep).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## 概要

todo App 全局通知（每日 digest）里的「发现待办」推荐子调用，之前一次 `llmClient.chat` 失败就直接降级为两段通知。本 PR 给 `TodoSuggestionService.propose` 加退避重试，抹平偶发的上游抖动。

## 设计要点

- **只重试真正的调用失败**：复用主循环统一口径 `isRetryableLlmFailure`（provider 不可用 / 上游服务调用失败）。畸形响应（无 toolCall / 参数解析失败）属于调用成功但内容不合规，不重试、照旧立即降级；其它异常同样立即降级。
- **两层重试相乘，外层刻意收敛为 2**：底层 llm-client 已按 usage 配置（`todoSuggestionAgent: times 3`）对每次 chat 做无退避立即重试；外层默认 2 次尝试 × 2s 固定退避，只补底层没有的「隔一段再试」能力，最坏 6 次 provider 调用（外层若取 3 则是 9 次）。
- **参数归一化**：`maxAttempts` clamp 到 [1, 5]（非法值回落默认），`retryBackoffMs` clamp 到 [0, 60s]，防 `Infinity` 死循环 / 负数跳过首轮的 footgun。
- **降级语义不变**：耗尽仍失败 → 返回 `[]`，digest 照发两段，绝不 rethrow。
- **KV 缓存无影响**：隔离 fork 子调用（不持有 AgentContext），重试只是重发同一次隔离调用。
- `runDigest` 是独立 cron 任务，与 60s 提醒 tick 分离，重试退避不阻塞到点提醒。

## Review

- /review 已跑：结构化检查干净；Codex 对抗评审揪出「与底层 usage `times: 3` 重试叠加」+「参数无归一化」，两项均已按方案 A 修复（外层 3→2 + clamp）。
- 无文档影响（document-release 审计：公共表面无变化）。

## 测试

- 单测 12 个全过（原 7 个降级行为一字未变 + 新增 5 个：重试成功 / 耗尽降级 / 不可重试不重试 / 畸形不重试 / 参数归一化）。
- `pnpm build` / `typecheck` / `lint`(0 error) / `format` / 全仓 `pnpm test` 合并 master 后全绿（agent 111 文件 681 用例）。