### PR TITLE
fix(spire): 按 sts_lightspeed 校准四个普通敌人数值/意图规则（阶段2）

### DIFF
--- a/apps/spire/src/application/state-view.ts
+++ b/apps/spire/src/application/state-view.ts
@@ -132,6 +132,14 @@ function computeIntent(state: GameState, enemy: EnemyState): IntentView {
         hits: effect.times,
       };
     }
+    if (effect.kind === "deal_damage_rolled") {
+      // 红虱咬击：基础值是本敌人出生时掷定的固定值。
+      return {
+        kind: "attack",
+        value: computeAttackDamage(enemy.rolledDamage, enemy.powers, playerPowers),
+        hits: 1,
+      };
+    }
   }
   // 无攻击：按意图分类给玩家看。
   return { kind: move.intent };

--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -23,6 +23,8 @@ const GUARDIAN_MODE_SHIFT_STEP = 10;
 const GUARDIAN_SHIFT_BLOCK = 20;
 const LOUSE_CURL_UP_MIN = 3;
 const LOUSE_CURL_UP_MAX = 7;
+const LOUSE_BITE_MIN = 5;
+const LOUSE_BITE_MAX = 7;
 
 type ActorRef = { side: "player" } | { side: "enemy"; index: number };
 
@@ -42,10 +44,13 @@ export function startCombat(state: GameState, encounterId: string): void {
   const enemies: EnemyState[] = encounter.enemies.map(defId => {
     const def = getEnemyDef(defId);
     const powers: PowerInstance[] = [];
+    let rolledDamage = 0;
     if (defId === "louse") {
       // 红虱开局自带蜷缩（首次被攻击获得格挡），block 值随机。
       const curl = nextRange(state.rng, LOUSE_CURL_UP_MIN, LOUSE_CURL_UP_MAX);
       powers.push({ id: "curl_up", amount: curl });
+      // 咬击基础伤害出生时掷一次、整场固定（5~7）。
+      rolledDamage = nextRange(state.rng, LOUSE_BITE_MIN, LOUSE_BITE_MAX);
     }
     const hp = nextRange(state.rng, def.hpMin, def.hpMax);
     return {
@@ -59,6 +64,7 @@ export function startCombat(state: GameState, encounterId: string): void {
       rotationIndex: 0,
       currentMove: "",
       curlUpConsumed: false,
+      rolledDamage,
       modeShiftAccum: 0,
       modeShiftThreshold: def.modeShiftThreshold ?? null,
       stance: def.stanceMoves ? "offensive" : null,
@@ -144,6 +150,13 @@ function applyEffect(
         }
       } else {
         dealDamageToPlayer(state, effect.amount, powers);
+      }
+      break;
+    }
+    case "deal_damage_rolled": {
+      // 敌人专用：用出生时掷定、整场固定的基础值攻击玩家（红虱咬击）。
+      if (actor.side === "enemy") {
+        dealDamageToPlayer(state, combat.enemies[actor.index]!.rolledDamage, powers);
       }
       break;
     }

--- a/apps/spire/src/engine/enemies/enemies.ts
+++ b/apps/spire/src/engine/enemies/enemies.ts
@@ -78,8 +78,9 @@ const ENEMY_LIST: EnemyDef[] = [
     moves: [
       {
         id: "bite",
+        // 咬击基础伤害在出生时掷定（5~7）、整场固定，见 startCombat 的 rolledDamage。
         name: "啃咬",
-        effects: [{ kind: "deal_damage", amount: 6 }],
+        effects: [{ kind: "deal_damage_rolled" }],
         intent: "attack",
       },
       {
@@ -92,8 +93,8 @@ const ENEMY_LIST: EnemyDef[] = [
     intentRule: {
       scripted: [],
       weighted: [
-        { move: "bite", weight: 75, maxInARow: 3 },
-        { move: "grow", weight: 25, maxInARow: 1 },
+        { move: "bite", weight: 75, maxInARow: 2 },
+        { move: "grow", weight: 25, maxInARow: 2 },
       ],
     },
   },
@@ -128,9 +129,9 @@ const ENEMY_LIST: EnemyDef[] = [
     intentRule: {
       scripted: [],
       weighted: [
-        { move: "corrosive_spit", weight: 40, maxInARow: 2 },
-        { move: "tackle", weight: 40, maxInARow: 2 },
-        { move: "lick", weight: 20, maxInARow: 1 },
+        { move: "corrosive_spit", weight: 30, maxInARow: 2 },
+        { move: "tackle", weight: 40, maxInARow: 1 },
+        { move: "lick", weight: 30, maxInARow: 2 },
       ],
     },
   },

--- a/apps/spire/src/engine/types.ts
+++ b/apps/spire/src/engine/types.ts
@@ -24,6 +24,8 @@ export type Effect =
   | { kind: "deal_damage_all"; amount: number }
   | { kind: "deal_damage_multi"; amount: number; times: number }
   | { kind: "deal_damage_equal_to_block" }
+  // 敌人用：伤害取自本敌人出生时掷定的固定值（红虱咬击：整场用同一个 5~7 基础值）。
+  | { kind: "deal_damage_rolled" }
   | { kind: "gain_block"; amount: number }
   | { kind: "apply_power"; power: PowerId; amount: number; on: "self" | "target" | "all_enemies" }
   | { kind: "draw"; amount: number }
@@ -99,6 +101,8 @@ export type EnemyState = {
   currentMove: string;
   /** 蜷缩是否已消耗。 */
   curlUpConsumed: boolean;
+  /** 出生时掷定、整场固定的攻击基础值（红虱咬击 5~7）。0 表示该敌人不用此机制。 */
+  rolledDamage: number;
   /** 守卫者：进攻姿态下累计受到的伤害（达阈值切姿态后清零，非每回合重置——复刻 StS 累计语义）。 */
   modeShiftAccum: number;
   modeShiftThreshold: number | null;


### PR DESCRIPTION
对照 MIT 许可的 RNG 精确复刻模拟器 [`gamerpuppy/sts_lightspeed`](https://github.com/gamerpuppy/sts_lightspeed)（ascension 0）校准切片里凭记忆填错的敌人参数。四个普通敌人现与真机一致。Refs #234。

## 校准（数值为功能性游戏规则）
- **酸液史莱姆(中)**：意图权重 `40/40/20 → 30/40/30`；连续限制 `spit2/tackle2/lick1 → spit2/tackle1/lick2`
- **红虱**：连续限制 `bite3/grow1 → bite2/grow2`
- **红虱咬击**：从写死 6 → **出生时掷定、整场固定的 5~7 基础值**（新增 `deal_damage_rolled` 效果原语 + `EnemyState.rolledDamage` 字段，力量/易伤再叠加）

## 全 MATCH（凭记忆填对的）
Cultist、Jaw Worm（含权重 25/30/45 与连续限制 1/2/1）、所有 HP 区间、全部 15 张铁甲战士卡的攻击数值、守卫者的 Mode Shift 阈值 30 与进攻姿态出招——都和真机一致，无需改。

## 刻意留到下一个 PR
守卫者的**忠实化**（防御姿态三招链：Sharp Hide 反甲 3 → Roll Attack 9 → Twin Slam 8×2；切换 +20 格挡已实现）——它是独立的引擎特性（新的反甲触发机制），不混进本轮纯校准。

## 验证
门禁全绿：build/typecheck/lint(0 error)/format + 测试 15/15。自动对战模拟器无回归（四普通敌人仍稳定清完）；胜率仍由未忠实化的守卫者 + 贪心策略封顶,属预期。

未部署（守部署红线）。