### PR TITLE
feat(spire): 战况去噪 + 卡奖励带牌信息 + lookup 查询子工具（阶段2 UX）

### DIFF
--- a/apps/agent/src/agent/apps/spire/spire.app.ts
+++ b/apps/agent/src/agent/apps/spire/spire.app.ts
@@ -4,6 +4,7 @@ import { SpirePlayCardTool } from "../../capabilities/spire/tools/play-card.tool
 import { SpireEndTurnTool } from "../../capabilities/spire/tools/end-turn.tool.js";
 import { SpireChooseTool } from "../../capabilities/spire/tools/choose.tool.js";
 import { SpireLookTool } from "../../capabilities/spire/tools/look.tool.js";
+import { SpireLookupTool } from "../../capabilities/spire/tools/lookup.tool.js";
 import { renderSpirePortal } from "../../capabilities/spire/render/spire-screen.js";
 import type { RootAgentEffect } from "../../runtime/effect/root-agent-effect.js";
 import type { SpireClient } from "../../../spire/spire-client.js";
@@ -38,6 +39,7 @@ export class SpireApp implements App {
     SpireEndTurnTool,
     SpireChooseTool,
     SpireLookTool,
+    SpireLookupTool,
   ];
 
   public constructor({ spireClient }: SpireAppDeps) {
@@ -48,6 +50,7 @@ export class SpireApp implements App {
       new SpireEndTurnTool({ getSpireClient }),
       new SpireChooseTool({ getSpireClient }),
       new SpireLookTool({ getSpireClient }),
+      new SpireLookupTool({ getSpireClient }),
     ];
   }
 

--- a/apps/agent/src/agent/capabilities/spire/render/spire-screen.ts
+++ b/apps/agent/src/agent/capabilities/spire/render/spire-screen.ts
@@ -3,6 +3,7 @@ import type {
   SpireEnemyView,
   SpireHandCardView,
   SpirePower,
+  SpireReference,
   SpireScreen,
 } from "../../../../spire/spire-client.js";
 
@@ -89,8 +90,6 @@ export function renderSpireScreen(screen: SpireScreen): string {
       : null,
     options: screen.options.map((text, index) => ({ n: index, text })),
     hasOptions: screen.options.length > 0,
-    logLines: screen.log,
-    hasLog: screen.log.length > 0,
   });
 }
 
@@ -107,4 +106,34 @@ export function renderSpireNoRun(): string {
 /** 进入尖塔 App 的静态提示屏（onFocus / help 用，无网络 I/O）。 */
 export function renderSpirePortal(): string {
   return renderServerStaticTemplate(import.meta.url, "context/spire-portal.hbs", {});
+}
+
+const CARD_TYPE_LABELS: Record<string, string> = {
+  attack: "攻击",
+  skill: "技能",
+  power: "能力",
+  status: "状态牌",
+};
+
+/** lookup 结果 → 文字（卡牌信息 + 术语定义）。框架文案在 .hbs，游戏数据插值。 */
+export function renderSpireReference(ref: SpireReference): string {
+  return renderServerStaticTemplate(import.meta.url, "context/spire-reference.hbs", {
+    query: ref.query,
+    hasQuery: ref.query.trim().length > 0,
+    hasResults: ref.cards.length > 0 || ref.terms.length > 0,
+    hasCards: ref.cards.length > 0,
+    hasTerms: ref.terms.length > 0,
+    cards: ref.cards.map(card => ({
+      name: card.name,
+      typeLabel: CARD_TYPE_LABELS[card.type] ?? card.type,
+      playable: card.cost !== null,
+      cost: card.cost ?? 0,
+      upgradedCost: card.upgradedCost ?? 0,
+      costChanges: card.cost !== card.upgradedCost,
+      targeted: card.targeted,
+      description: card.description,
+      upgradedDescription: card.upgradedDescription,
+    })),
+    terms: ref.terms,
+  });
 }

--- a/apps/agent/src/agent/capabilities/spire/tools/lookup.tool.ts
+++ b/apps/agent/src/agent/capabilities/spire/tools/lookup.tool.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+import type { ToolKind } from "@kagami/agent-runtime";
+import { SpireToolComponent } from "./spire-tool-component.js";
+import { renderSpireReference } from "../render/spire-screen.js";
+import type { SpireClient } from "../../../../spire/spire-client.js";
+
+export const SPIRE_LOOKUP_TOOL_NAME = "lookup";
+
+const Schema = z.object({ query: z.string().optional() });
+
+export class SpireLookupTool extends SpireToolComponent<typeof Schema> {
+  public readonly name = SPIRE_LOOKUP_TOOL_NAME;
+  public readonly description =
+    "查询卡牌信息或游戏术语（不消耗任何动作）。query 可以是卡名（如 打击）或术语（如 易伤、虚弱、格挡）；不传 query 则列出全部卡牌与术语。";
+  public readonly parameters = {
+    type: "object",
+    properties: {
+      query: { type: "string", description: "卡名或术语；留空列出全部。" },
+    },
+    required: [],
+  } as const;
+  public readonly kind: ToolKind = "business";
+  protected readonly inputSchema = Schema;
+  private readonly getSpireClient: () => SpireClient;
+
+  public constructor({ getSpireClient }: { getSpireClient: () => SpireClient }) {
+    super();
+    this.getSpireClient = getSpireClient;
+  }
+
+  protected async executeTyped(input: z.infer<typeof Schema>): Promise<string> {
+    const ref = await this.getSpireClient().lookup(input.query ?? "");
+    return renderSpireReference(ref);
+  }
+}

--- a/apps/agent/src/spire/spire-client.ts
+++ b/apps/agent/src/spire/spire-client.ts
@@ -60,10 +60,28 @@ export type SpireAction =
   | { type: "end_turn" }
   | { type: "choose"; optionIndex: number };
 
+/** 参考查询结果（与服务端 ReferenceResult 同构）。 */
+export type SpireCardRef = {
+  name: string;
+  type: string;
+  cost: number | null;
+  upgradedCost: number | null;
+  targeted: boolean;
+  description: string;
+  upgradedDescription: string;
+};
+export type SpireGlossaryEntry = { term: string; aliases: string[]; definition: string };
+export type SpireReference = {
+  query: string;
+  cards: SpireCardRef[];
+  terms: SpireGlossaryEntry[];
+};
+
 export interface SpireClient {
   startRun(): Promise<SpireScreen>;
   act(action: SpireAction): Promise<SpireScreen>;
   getState(): Promise<SpireScreen | null>;
+  lookup(query: string): Promise<SpireReference>;
 }
 
 type FetchLike = typeof fetch;
@@ -112,6 +130,11 @@ export class HttpSpireClient implements SpireClient {
       this.lastVersion = screen.version;
     }
     return screen;
+  }
+
+  public async lookup(query: string): Promise<SpireReference> {
+    const path = `/reference?q=${encodeURIComponent(query)}`;
+    return (await this.get(path)) as SpireReference;
   }
 
   private async post(path: string, body: unknown): Promise<unknown> {

--- a/apps/agent/static/context/spire-portal.hbs
+++ b/apps/agent/static/context/spire-portal.hbs
@@ -7,5 +7,6 @@
   - end_turn()：结束本回合，让敌人行动。
   - choose(option_index)：在卡奖励 / 篝火等选择界面选一项。
   - look()：重新看一眼当前战况。
+  - lookup(query?)：查卡牌或术语（如 易伤、虚弱、格挡）；不传 query 列出全部。看不懂某张牌或某个状态时用它。
 每次动作后都会返回最新战况。要去别的 App，用 switch(id=...) 切过去。
 </spire_portal>

--- a/apps/agent/static/context/spire-reference.hbs
+++ b/apps/agent/static/context/spire-reference.hbs
@@ -1,0 +1,20 @@
+<spire_reference>
+{{#if hasResults}}
+{{#if hasCards}}
+————卡牌————
+{{#each cards}}
+「{{name}}」（{{typeLabel}}）　{{#if playable}}费{{cost}}{{#if costChanges}}（升级后费{{upgradedCost}}）{{/if}}{{else}}不可打{{/if}}{{#if targeted}}　需指定敌人{{/if}}
+　效果：{{description}}
+　升级：{{upgradedDescription}}
+{{/each}}
+{{/if}}
+{{#if hasTerms}}
+————术语————
+{{#each terms}}
+{{term}}：{{definition}}
+{{/each}}
+{{/if}}
+{{else}}
+没查到「{{query}}」。可以查卡名（如 打击、防御）或术语（如 易伤、虚弱、格挡）。不带查询词调用 lookup 会列出全部卡牌与术语。
+{{/if}}
+</spire_reference>

--- a/apps/agent/static/context/spire-screen.hbs
+++ b/apps/agent/static/context/spire-screen.hbs
@@ -32,11 +32,4 @@
 你击败了守卫者，登顶成功！生命 {{hp}}/{{maxHp}}。
 想再爬一次就调用 start_run。
 {{/if}}
-{{#if hasLog}}
-————刚刚发生————
-{{#each logLines}}
-{{this}}
-{{/each}}
-{{/if}}
-要去别的 App，用 switch(id=...) 切过去。
 </spire_screen>

--- a/apps/spire/src/application/reference.ts
+++ b/apps/spire/src/application/reference.ts
@@ -1,0 +1,62 @@
+import { ALL_CARDS, costOf } from "../engine/cards/cards.js";
+import { GLOSSARY, type GlossaryEntry } from "../engine/glossary.js";
+
+// === 参考查询：按 query 匹配卡牌 + 术语，返回结构化数据 ===
+//
+// 供 agent 侧 lookup 工具消费（GET /reference?q=）。数据是游戏事实，渲染框架文案在 agent .hbs。
+
+export type CardRef = {
+  name: string;
+  type: string;
+  cost: number | null;
+  upgradedCost: number | null;
+  targeted: boolean;
+  description: string;
+  upgradedDescription: string;
+};
+
+export type ReferenceResult = {
+  query: string;
+  cards: CardRef[];
+  terms: GlossaryEntry[];
+};
+
+function toCardRef(cardId: string): CardRef {
+  const def = ALL_CARDS.find(card => card.id === cardId)!;
+  return {
+    name: def.name,
+    type: def.type,
+    cost: costOf(def, false),
+    upgradedCost: costOf(def, true),
+    targeted: def.targeted,
+    description: def.description,
+    upgradedDescription: def.upgradedDescription,
+  };
+}
+
+/**
+ * query 为空 → 返回全部术语 + 全部卡；否则子串（不区分大小写）匹配卡名 / 卡 id 与术语名 / 别名。
+ */
+export function lookupReference(query: string): ReferenceResult {
+  const q = query.trim().toLowerCase();
+
+  if (q.length === 0) {
+    return {
+      query,
+      cards: ALL_CARDS.map(card => toCardRef(card.id)),
+      terms: [...GLOSSARY],
+    };
+  }
+
+  const cards = ALL_CARDS.filter(
+    card => card.name.toLowerCase().includes(q) || card.id.toLowerCase().includes(q),
+  ).map(card => toCardRef(card.id));
+
+  const terms = GLOSSARY.filter(
+    entry =>
+      entry.term.toLowerCase().includes(q) ||
+      entry.aliases.some(alias => alias.toLowerCase().includes(q)),
+  );
+
+  return { query, cards, terms };
+}

--- a/apps/spire/src/engine/cards/cards.ts
+++ b/apps/spire/src/engine/cards/cards.ts
@@ -211,6 +211,9 @@ const CARD_LIST: CardDef[] = [
   },
 ];
 
+/** 全部卡定义（lookup / 参考查询用）。 */
+export const ALL_CARDS: readonly CardDef[] = CARD_LIST;
+
 const CARD_MAP: ReadonlyMap<string, CardDef> = new Map(CARD_LIST.map(card => [card.id, card]));
 
 export function getCardDef(id: string): CardDef {

--- a/apps/spire/src/engine/glossary.ts
+++ b/apps/spire/src/engine/glossary.ts
@@ -1,0 +1,65 @@
+// === 术语表（游戏规则事实）===
+//
+// 定义是功能性游戏规则（非小镜语气），归服务作数据；agent 侧 lookup 工具经 .hbs 渲染框架文案 + 插值定义。
+// 切片范围：覆盖会出现在战况里的状态与概念。
+
+export type GlossaryEntry = {
+  /** 规范中文术语名。 */
+  term: string;
+  /** 别名（英文 / 常见叫法），用于查询匹配。 */
+  aliases: string[];
+  definition: string;
+};
+
+export const GLOSSARY: readonly GlossaryEntry[] = [
+  {
+    term: "力量",
+    aliases: ["strength", "str"],
+    definition: "每有 1 层，攻击牌每次造成的伤害 +1（对多段攻击每段都 +1）。持续整场战斗。",
+  },
+  {
+    term: "易伤",
+    aliases: ["vulnerable", "vuln"],
+    definition: "受到的攻击伤害提高 50%（×1.5，向下取整）。每回合结束 -1 层。",
+  },
+  {
+    term: "虚弱",
+    aliases: ["weak"],
+    definition: "造成的攻击伤害降低 25%（×0.75，向下取整）。每回合结束 -1 层。",
+  },
+  {
+    term: "仪式",
+    aliases: ["ritual"],
+    definition: "敌人专属：每当它的回合开始，获得等量的力量。",
+  },
+  {
+    term: "蜷缩",
+    aliases: ["curl up", "curlup"],
+    definition: "敌人专属：第一次被攻击时获得一次性格挡（能挡住那一击的一部分），随后蜷缩消失。",
+  },
+  {
+    term: "格挡",
+    aliases: ["block"],
+    definition: "抵挡伤害的护盾。受击时先扣格挡、扣完再扣生命。每当你的回合开始时清零。",
+  },
+  {
+    term: "能量",
+    aliases: ["energy"],
+    definition: "打牌的资源。每回合开始恢复到 3 点，未用完不保留到下回合。",
+  },
+  {
+    term: "消耗",
+    aliases: ["exhaust"],
+    definition: "被消耗的牌移出本场战斗，不回抽牌堆也不回弃牌堆，直到战斗结束。",
+  },
+  {
+    term: "抽牌堆",
+    aliases: ["draw pile", "draw"],
+    definition: "还没抽到的牌堆。抽牌时若抽牌堆空，则把弃牌堆洗入抽牌堆再抽。",
+  },
+  {
+    term: "弃牌堆",
+    aliases: ["discard pile", "discard"],
+    definition: "打出的牌与回合结束时手里剩的牌进入的牌堆。抽牌堆空时会被洗回抽牌堆。",
+  },
+];

--- a/apps/spire/src/engine/run/run.ts
+++ b/apps/spire/src/engine/run/run.ts
@@ -1,5 +1,5 @@
 import type { GameState, MapNode } from "../types.js";
-import { REWARD_CARD_POOL, getCardDef } from "../cards/cards.js";
+import { REWARD_CARD_POOL, getCardDef, costOf } from "../cards/cards.js";
 import { NORMAL_ENCOUNTER_POOL } from "../enemies/enemies.js";
 import { nextInt } from "../rng.js";
 import { startCombat } from "../combat/combat.js";
@@ -56,7 +56,10 @@ export function currentOptions(state: GameState): string[] {
   if (state.screen === "reward" && state.reward) {
     const cards = state.reward.cardChoices.map(choice => {
       const def = getCardDef(choice.defId);
-      return `获得「${def.name}」${choice.upgraded ? "+" : ""}`;
+      const cost = costOf(def, choice.upgraded);
+      const desc = choice.upgraded ? def.upgradedDescription : def.description;
+      // 选项带牌信息：名 (+升级) 费用 · 效果，方便挑牌时判断（用户反馈）。
+      return `${def.name}${choice.upgraded ? "+" : ""} 费${cost ?? "-"} · ${desc}`;
     });
     return [...cards, "跳过（不拿卡）"];
   }

--- a/apps/spire/src/http/spire.handler.ts
+++ b/apps/spire/src/http/spire.handler.ts
@@ -4,6 +4,7 @@ import { registerCommandRoute, registerQueryRoute } from "@kagami/http/route";
 import type { GameAction } from "../engine/engine.js";
 import type { SpireService } from "../application/spire.service.js";
 import { toScreenView } from "../application/state-view.js";
+import { lookupReference } from "../application/reference.js";
 
 // === 尖塔 HTTP 路由 ===
 //
@@ -32,6 +33,7 @@ const ActionBodySchema = z.object({
 });
 
 const StateQuerySchema = z.object({});
+const ReferenceQuerySchema = z.object({ q: z.string().optional() });
 const ResponseSchema = z.unknown();
 
 export class SpireHandler {
@@ -81,6 +83,15 @@ export class SpireHandler {
         // GET /state 的 log 恒为空（KV 字节确定性，issue #234 C3）。
         return state ? toScreenView(state, { suppressLog: true }) : null;
       },
+    });
+
+    // 卡牌 / 术语参考查询：纯静态数据，不依赖对局状态。
+    registerQueryRoute({
+      app,
+      path: "/reference",
+      querySchema: ReferenceQuerySchema,
+      responseSchema: ResponseSchema,
+      execute: ({ query }) => lookupReference(query.q ?? ""),
     });
   }
 }

--- a/apps/spire/test/reference.test.ts
+++ b/apps/spire/test/reference.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { lookupReference } from "../src/application/reference.js";
+
+describe("lookupReference", () => {
+  it("空 query 返回全部卡牌与术语", () => {
+    const ref = lookupReference("");
+    expect(ref.cards.length).toBeGreaterThan(10);
+    expect(ref.terms.length).toBeGreaterThan(5);
+  });
+
+  it("按术语名匹配", () => {
+    const ref = lookupReference("易伤");
+    expect(ref.terms.map(t => t.term)).toContain("易伤");
+    expect(ref.terms[0]?.definition).toContain("50%");
+  });
+
+  it("按术语英文别名匹配", () => {
+    const ref = lookupReference("vulnerable");
+    expect(ref.terms.map(t => t.term)).toContain("易伤");
+  });
+
+  it("按卡名匹配，带 base/upgraded 费用", () => {
+    const ref = lookupReference("打击");
+    const strike = ref.cards.find(c => c.name === "打击");
+    expect(strike).toBeDefined();
+    expect(strike?.cost).toBe(1);
+    expect(strike?.description).toContain("6");
+  });
+
+  it("力压升级后费用降为 0", () => {
+    const ref = lookupReference("力压");
+    const bodySlam = ref.cards.find(c => c.name === "力压");
+    expect(bodySlam?.cost).toBe(1);
+    expect(bodySlam?.upgradedCost).toBe(0);
+  });
+
+  it("查不到时卡与术语都为空", () => {
+    const ref = lookupReference("不存在的东西xyz");
+    expect(ref.cards).toHaveLength(0);
+    expect(ref.terms).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
小镜实打后的 UX 反馈三连。Refs #234。

## 改动
1. **战况去噪**：每轮不再显示「刚刚发生」日志块与「用 switch 切过去」提示——战况板本身已表达变化，switch 只在进 App 的 portal 提一次。
2. **卡奖励带牌信息**：奖励选项 `获得「打击」` → `打击 费1 · 造成6`（名+费+效果），挑牌不再抓瞎。
3. **新增 `lookup(query?)` 子工具**（spire 子工具、**非顶层工具**，走渐进式披露不破 KV 前缀）：查卡名或术语（易伤/虚弱/力量/仪式/蜷缩/格挡/能量/消耗…）。不传 query 列出全部。

## 实现
- 术语表 `apps/spire/src/engine/glossary.ts`（游戏规则事实，归服务）；卡数据取 `cards.ts`。
- 新 `GET /reference?q=` 端点返回结构化数据（`application/reference.ts`，静态、不依赖对局状态）。
- agent 侧 `lookup` 工具 + `HttpSpireClient.lookup` + `spire-reference.hbs` 渲染（框架文案在模板、游戏数据插值，守 AGENTS.md .hbs 红线）。

## 验证
门禁全绿：build/typecheck/lint(0 error)/format + 测试 **spire 21/21**（+reference 6）· **agent 700**。无工具名冲突。

## 部署注意
本次改动**同时动了 spire 与 agent**（新 lookup 工具在 agent 侧），上线需 `app:deploy spire` + `app:deploy agent` 两个。未部署（守部署红线）。