### PR TITLE
fix(deploy): app:deploy 单服务白名单补上 spire

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -21,8 +21,9 @@ if [ -n "$SERVICE" ]; then
     browser) PKG="@kagami/browser"; PM2_NAME="kagami-browser" ;;
     llm) PKG="@kagami/llm-service"; PM2_NAME="kagami-llm" ;;
     metric) PKG="@kagami/metric"; PM2_NAME="kagami-metric" ;;
+    spire) PKG="@kagami/spire-service"; PM2_NAME="kagami-spire" ;;
     *)
-      echo "用法: pnpm app:deploy [<agent|console|gateway|oss|browser|llm|metric>]" >&2
+      echo "用法: pnpm app:deploy [<agent|console|gateway|oss|browser|llm|metric|spire>]" >&2
       echo "  无参：全量构建 + Prisma 迁移 + 重载所有进程。" >&2
       echo "  带服务名：只重建并重载该服务，不跑迁移、不动其它进程。" >&2
       exit 1


### PR DESCRIPTION
#234 加了 kagami-spire 进程、也更新了 ecosystem 与 AGENTS.md 的服务清单，但漏改 `scripts/deploy.sh` 自己的 case 白名单——`pnpm app:deploy spire` 因此直接报「用法」退出（本轮部署 spire 是手动跑 build+startOrReload 绕过的）。

补上 `spire → @kagami/spire-service / kagami-spire` 映射 + usage 文案。以后单独重载尖塔引擎可直接 `pnpm app:deploy spire`。

bash 语法检查通过、format 干净。纯脚本改动，无需部署（下次 pull 即生效）。