### PR TITLE
test(shared,kernel,auth): 补 shared/kernel 测试脚手架与首批高价值单测

### DIFF
--- a/packages/auth/test/pkce.test.ts
+++ b/packages/auth/test/pkce.test.ts
@@ -1,0 +1,38 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { createPkcePair } from "../src/shared/pkce.js";
+import { safeParseJson } from "../src/shared/safe-parse-json.js";
+
+describe("createPkcePair — PKCE 对生成", () => {
+  it("codeChallenge 是 codeVerifier 的 sha256 base64url（RFC 7636 S256）", () => {
+    const pair = createPkcePair();
+    const expected = createHash("sha256").update(pair.codeVerifier).digest("base64url");
+    expect(pair.codeChallenge).toBe(expected);
+  });
+
+  it("verifier 为 base64url 字符集且长度符合 RFC 7636（43-128）", () => {
+    const pair = createPkcePair();
+    expect(pair.codeVerifier).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(pair.codeVerifier.length).toBeGreaterThanOrEqual(43);
+    expect(pair.codeVerifier.length).toBeLessThanOrEqual(128);
+    expect(pair.state).toMatch(/^[0-9a-f]{48}$/);
+  });
+
+  it("多次调用产物互不相同（随机性冒烟）", () => {
+    const first = createPkcePair();
+    const second = createPkcePair();
+    expect(first.codeVerifier).not.toBe(second.codeVerifier);
+    expect(first.state).not.toBe(second.state);
+  });
+});
+
+describe("safeParseJson — 宽松 JSON 解析", () => {
+  it("合法 JSON 解析成功", () => {
+    expect(safeParseJson<{ a: number }>('{"a":1}')).toEqual({ a: 1 });
+  });
+
+  it("非 JSON（OAuth 端点的 HTML 错误页等）返回 null 而非抛错", () => {
+    expect(safeParseJson("<html>502</html>")).toBeNull();
+    expect(safeParseJson("")).toBeNull();
+  });
+});

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -11,7 +11,8 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@kagami/config": "workspace:*",
@@ -22,6 +23,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.10.1",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/kernel/test/config-loader.test.ts
+++ b/packages/kernel/test/config-loader.test.ts
@@ -1,0 +1,67 @@
+import { mkdtempSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { loadStaticConfig } from "../src/config/config.loader.js";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+
+/**
+ * 最小必需 secrets：schema 里 non-empty 的隐私字段。注意 config.secret.yaml.example
+ * 的空占位过不了 schema（新 clone 照 example 起会失败），故这里给测试值。
+ */
+const MINIMAL_SECRET_YAML = `server:
+  tavily:
+    apiKey: test-tavily-key
+  napcat:
+    wsUrl: ws://127.0.0.1:3001
+    listenGroupIds:
+      - 123456
+  bot:
+    qq: 10001
+    creator:
+      name: tester
+      qq: 10002
+`;
+
+/**
+ * 用仓库里真实的 config.yaml + 最小 secrets 当夹具：守护「提交的 config.yaml 永远
+ * 能通过 loader schema」（三处同步硬约束的机器检查）。
+ */
+function createFixtureDir(mutate?: (configText: string) => string): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "kagami-config-test-"));
+  const configText = readFileSync(path.join(repoRoot, "config.yaml"), "utf8");
+  writeFileSync(path.join(dir, "config.yaml"), mutate ? mutate(configText) : configText);
+  writeFileSync(path.join(dir, "config.secret.yaml"), MINIMAL_SECRET_YAML);
+  return dir;
+}
+
+describe("loadStaticConfig — 配置装载", () => {
+  it("仓库的 config.yaml + 最小 secrets 能通过 schema（三处同步守护）", async () => {
+    const dir = createFixtureDir();
+    const config = await loadStaticConfig({ configPath: path.join(dir, "config.yaml") });
+    expect(config.services.gateway.port).toBeTypeOf("number");
+    expect(config.server.llm.timeoutMs).toBeGreaterThan(0);
+    expect(Array.isArray(config.server.llm.usages.agent.attempts)).toBe(true);
+  });
+
+  it("SQLite 相对路径锚定到 config.yaml 所在目录（file: 绝对化）", async () => {
+    const dir = createFixtureDir();
+    const config = await loadStaticConfig({ configPath: path.join(dir, "config.yaml") });
+    if (config.server.databaseUrl.startsWith("file:")) {
+      const filePath = config.server.databaseUrl.slice("file:".length);
+      expect(path.isAbsolute(filePath)).toBe(true);
+      expect(filePath.startsWith(dir)).toBe(true);
+    }
+  });
+
+  it("非法配置值抛 ConfigError（含出错字段路径）", async () => {
+    const dir = createFixtureDir(text =>
+      text.replace(/timeoutMs:\s*\d+/, 'timeoutMs: "not-a-number"'),
+    );
+    await expect(loadStaticConfig({ configPath: path.join(dir, "config.yaml") })).rejects.toThrow(
+      "配置值不合法",
+    );
+  });
+});

--- a/packages/kernel/vitest.config.ts
+++ b/packages/kernel/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+    clearMocks: true,
+    restoreMocks: true,
+    maxWorkers: 4,
+  },
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -15,13 +15,15 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@kagami/llm": "workspace:*",
     "zod": "^3.24.4"
   },
   "devDependencies": {
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/shared/test/utils.test.ts
+++ b/packages/shared/test/utils.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { assertNever, stripLoneSurrogates, truncateWithEllipsis } from "../src/utils.js";
+
+describe("stripLoneSurrogates — 剥除落单代理项（事故：半个 emoji 打挂会话）", () => {
+  it("完整代理对（emoji）成对保留", () => {
+    expect(stripLoneSurrogates("你好😀world")).toBe("你好😀world");
+  });
+
+  it("孤立高代理被丢弃", () => {
+    const loneHigh = "abc" + "\uD83D" + "def";
+    expect(stripLoneSurrogates(loneHigh)).toBe("abcdef");
+  });
+
+  it("孤立低代理被丢弃", () => {
+    const loneLow = "abc" + "\uDE00" + "def";
+    expect(stripLoneSurrogates(loneLow)).toBe("abcdef");
+  });
+
+  it("被 .slice 劈开的 emoji（尾部半个高代理）被清理，产物是合法 JSON 字符串", () => {
+    const split = "引用😀".slice(0, 3); // "引用" + 高代理半个
+    const cleaned = stripLoneSurrogates(split);
+    expect(cleaned).toBe("引用");
+    expect(() => JSON.stringify(cleaned)).not.toThrow();
+    expect(JSON.parse(JSON.stringify(cleaned))).toBe("引用");
+  });
+});
+
+describe("truncateWithEllipsis — 按码点截断，绝不劈代理对", () => {
+  it("不超限时原样返回，不加省略号", () => {
+    expect(truncateWithEllipsis("hello", 10)).toBe("hello");
+  });
+
+  it("超限时截到码点数并追加省略号", () => {
+    expect(truncateWithEllipsis("abcdef", 3)).toBe("abc…");
+  });
+
+  it("emoji 记 1 个码点，截断落在 emoji 边界而非中间", () => {
+    const text = "😀😁😂🤣😃";
+    const truncated = truncateWithEllipsis(text, 3);
+    expect(truncated).toBe("😀😁😂…");
+    // 产物不含落单代理：再过一遍 strip 应无变化
+    expect(stripLoneSurrogates(truncated)).toBe(truncated);
+  });
+
+  it("自定义省略号生效", () => {
+    expect(truncateWithEllipsis("abcdef", 2, "...")).toBe("ab...");
+  });
+
+  it("输入自带落单代理时先清理再计数", () => {
+    const dirty = "ab" + "\uD83D" + "cd";
+    expect(truncateWithEllipsis(dirty, 10)).toBe("abcd");
+  });
+});
+
+describe("assertNever", () => {
+  it("被调用即抛错并带上值", () => {
+    expect(() => assertNever("boom" as never)).toThrow("Unexpected value: boom");
+  });
+});

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+    clearMocks: true,
+    restoreMocks: true,
+    maxWorkers: 4,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -557,6 +557,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@24.11.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/llm:
     devDependencies:
@@ -704,6 +707,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@24.11.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
 
 packages:
 


### PR DESCRIPTION
## 背景

审计「包测试真空」的收尾（承接 #244）。重新核实后范围缩小：**llm-client 与 auth 的测试套 master 已随 #236/#237 补齐**（llm-client 3588 行含 claude-code-provider 971 行行为测试；auth 6 个文件），真正零测试的只剩 shared 和 kernel。

## 改动

- **shared**（0→10 条）：`stripLoneSurrogates` / `truncateWithEllipsis` 码点截断——「半个 emoji 打挂小镜」事故（#187 修复）的回归保护，含「被 .slice 劈开的 emoji 清理后可安全 JSON 序列化」用例。
- **kernel**（0→3 条）：`loadStaticConfig` 以仓库真实 config.yaml + 最小 secrets 为夹具，等于给「三处同步」硬约束上了机器检查（config.yaml 改坏 schema 会在 CI 红）；另锁 SQLite `file:` 路径锚定到 config 目录、非法值抛 ConfigError。
- **auth**（+2 文件里的 5 条）：pkce（S256 挑战 = sha256(verifier) base64url、RFC 7636 长度、随机性冒烟）+ safeParseJson。

## 过程发现（未修，留决策）

`config.secret.yaml.example` 的空占位（tavily.apiKey 等）**过不了 schema 的 non-empty 校验**——新 clone 照 example 复制后服务起不来，会直接 ConfigError。要么 example 放假值占位，要么 schema 对这类字段允许空串+运行时降级。本 PR 只在测试注释记录，不擅动 example。

## 验证

build / typecheck / lint / format 全绿；全仓测试 0 failed（新增 shared 10 + kernel 3 + auth 5）。