### PR TITLE
fix(todo): 发现待办子调用改走 invoke 子工具，不再破坏 KV 缓存前缀

### DIFF
--- a/apps/agent/src/agent/capabilities/todo/application/todo-suggestion.service.ts
+++ b/apps/agent/src/agent/capabilities/todo/application/todo-suggestion.service.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { AppLogger } from "@kagami/kernel/logger/logger";
 import type { LlmClient } from "@kagami/llm-client";
 import type { LlmMessage, Tool } from "@kagami/llm-client";
+import { INVOKE_TOOL_NAME } from "../../../runtime/root-agent/tools/invoke.tool.js";
 import { createTodoSuggestionInstructionMessage } from "../../../runtime/context/context-message-factory.js";
 import { isRetryableLlmFailure } from "../../../runtime/llm-retry.js";
 
@@ -34,34 +35,19 @@ function clampInt(value: number, min: number, max: number, fallback: number): nu
   return Math.min(max, Math.max(min, Math.trunc(value)));
 }
 
+// 「虚拟子工具」名:不在任何 InvokeSubtoolOwner 注册,只作为本子调用的约定——指令让模型
+// 调 invoke(tool="propose_todos", ...),这里直接读回 arguments,永不真正经 InvokeTool dispatch
+// (真 dispatch 会 INVOKE_TOOL_NOT_FOUND)。改动这条路径去别处复用前,先想清楚要不要落成真子工具。
 export const PROPOSE_TODOS_TOOL_NAME = "propose_todos";
 
 // 宽松接收：只要 suggestions 是字符串数组即可（空白/空串由 propose 里 trim+filter 兜底剔除）。
 // 不做 per-element min 校验——否则模型多给一条空串会让整个数组解析失败、白白丢掉其余好建议。
+// invoke 包裹层：模型被要求调用 invoke(tool="propose_todos", suggestions=[...])，
+// 这里从 invoke 的 arguments 里取 suggestions（passthrough 透传的业务字段）。tool 字段
+// 单独校验，畸形（非 propose_todos）直接降级。
 const ProposeTodosArgsSchema = z.object({
   suggestions: z.array(z.string()).default([]),
 });
-
-/**
- * 提交结构化候选待办的输出工具定义。只在本子调用的 tools 里出现（异于主工具集），
- * 因此这次调用整体 cache miss——可接受，理由同 context-summary（隔离 throwaway，
- * 换结构化输出、零解析脆弱、零误触真实工具）。
- */
-const PROPOSE_TODOS_TOOL: Tool = {
-  name: PROPOSE_TODOS_TOOL_NAME,
-  description: "提交你为小镜发现的、具体可执行的候选待办（最多 5 条；没有就提交空数组）。",
-  parameters: {
-    type: "object",
-    properties: {
-      suggestions: {
-        type: "array",
-        items: { type: "string" },
-        description:
-          "候选待办标题，每条一句话、动词开头、具体可执行；不要重复已在未完成清单里的事。",
-      },
-    },
-  },
-};
 
 export type TodoSuggestionInput = {
   /** fork 出的主 Agent system prompt（复用以命中大段消息前缀）。 */
@@ -90,22 +76,31 @@ export type TodoSuggestionInput = {
  */
 export class TodoSuggestionService {
   private readonly llmClient: LlmClient;
+  private readonly topLevelToolDefinitions: Tool[];
   private readonly maxAttempts: number;
   private readonly retryBackoffMs: number;
   private readonly sleep: (ms: number) => Promise<void>;
 
   public constructor({
     llmClient,
+    topLevelToolDefinitions,
     maxAttempts = DEFAULT_MAX_ATTEMPTS,
     retryBackoffMs = DEFAULT_RETRY_BACKOFF_MS,
     sleep = defaultSleep,
   }: {
     llmClient: LlmClient;
+    /**
+     * 主 Agent 每轮实际发送的顶层工具定义（含 invoke 这个 dispatcher）。子调用原样复用它作
+     * tools，与主 Agent 字节相等，命中 KV 缓存的 tools / system 前缀层；propose_todos 经
+     * invoke 子工具提交，不新增顶层工具、不漂移前缀。
+     */
+    topLevelToolDefinitions: Tool[];
     maxAttempts?: number;
     retryBackoffMs?: number;
     sleep?: (ms: number) => Promise<void>;
   }) {
     this.llmClient = llmClient;
+    this.topLevelToolDefinitions = topLevelToolDefinitions;
     this.maxAttempts = clampInt(maxAttempts, 1, MAX_ATTEMPTS_CEILING, DEFAULT_MAX_ATTEMPTS);
     this.retryBackoffMs = clampInt(retryBackoffMs, 0, 60_000, DEFAULT_RETRY_BACKOFF_MS);
     this.sleep = sleep;
@@ -146,20 +141,40 @@ export class TodoSuggestionService {
     const response = await this.llmClient.chat(
       {
         system: input.systemPrompt,
+        // tools / toolChoice 与主 Agent 每轮完全一致（同一份顶层工具定义 + "required"），
+        // 所以 fork 出的 system + tools + 消息前缀能命中主 Agent 的 KV 缓存。propose_todos
+        // 不是顶层工具：指令要求模型走 invoke(tool="propose_todos", suggestions=[...]) 提交。
         messages: [...input.messages, createTodoSuggestionInstructionMessage(input.openTodos)],
-        tools: [PROPOSE_TODOS_TOOL],
-        toolChoice: { tool_name: PROPOSE_TODOS_TOOL_NAME },
+        tools: this.topLevelToolDefinitions,
+        toolChoice: "required",
       },
       { usage: "todoSuggestionAgent" },
     );
 
-    const toolCall = response.message.toolCalls[0];
-    if (!toolCall || toolCall.name !== PROPOSE_TODOS_TOOL_NAME) {
+    // 只认 invoke(tool="propose_todos", ...)。toolChoice "required" 只保证至少一个工具调用，
+    // 模型可能并行发多个（如 switch + invoke），所以按名字找、不假设它在 toolCalls[0]；找不到就
+    // 当畸形降级。本子调用不真正 dispatch invoke，直接从其 arguments 取结果。
+    const toolCall = response.message.toolCalls.find(
+      call => call.name === INVOKE_TOOL_NAME && call.arguments.tool === PROPOSE_TODOS_TOOL_NAME,
+    );
+    if (!toolCall) {
+      // 换 invoke 子工具提交换来了 KV 缓存前缀命中，代价是丢了 provider 侧对 suggestions 的
+      // schema 强校验、且 "required" 不保证模型一定选 invoke。这里显式记一条：把「模型没按约定
+      // 走 invoke(propose_todos)」和「确实没有建议」区分开，让 digest 静默丢第三段可在日志里定位。
+      logger.info("Todo suggestion sub-call did not submit via invoke(propose_todos); degrading", {
+        event: "todo.suggestion_no_proposal",
+        toolNames: response.message.toolCalls.map(call => call.name),
+      });
       return [];
     }
 
     const parsed = ProposeTodosArgsSchema.safeParse(toolCall.arguments);
     if (!parsed.success) {
+      // 走了 invoke(propose_todos) 但 suggestions 字段畸形（缺失/非字符串数组）——同样区分于
+      // 「确实空」，落一条便于观测模型输出质量。
+      logger.info("Todo suggestion invoke args failed schema parse; degrading", {
+        event: "todo.suggestion_parse_failed",
+      });
       return [];
     }
 

--- a/apps/agent/src/app/agent-runtime.factory.ts
+++ b/apps/agent/src/app/agent-runtime.factory.ts
@@ -13,7 +13,7 @@ import { createWebSearchSubtoolOwner } from "../agent/capabilities/web-search/ta
 import { AppLogger } from "@kagami/kernel/logger/logger";
 import type { Config } from "@kagami/kernel/config/config.loader";
 import type { Database } from "@kagami/persistence/db/client";
-import type { LlmClient } from "@kagami/llm-client";
+import type { LlmClient, Tool } from "@kagami/llm-client";
 import { DefaultLlmPlaygroundService } from "../llm/application/llm-playground.impl.service.js";
 import type { LlmPlaygroundService } from "../llm/application/llm-playground.service.js";
 import type { MetricService } from "../metric/application/metric.service.js";
@@ -124,6 +124,12 @@ export type AgentRuntimeBundle = {
   mainAgentContextQueryService: MainAgentContextQueryService;
   llmPlaygroundService: LlmPlaygroundService;
   hasTavilyApiKey: boolean;
+  /**
+   * 主 Agent 的顶层工具定义（react-kernel 每轮实际发送的那一份）。fork 主上下文的旁路
+   * 调用（如 todo「发现待办」子调用）复用它作 tools，保证 tools 字段与主 Agent 字节相等，
+   * 命中 KV 缓存的 tools / system 层前缀（子工具经 invoke 提交，不新增顶层工具）。
+   */
+  rootAgentToolDefinitions: Tool[];
   /** QQ App：手机 OS 模型下聊天的承载者，已收纳 napcat 网关（自管生命周期 + 入站事件）。 */
   qqApp: QqApp;
   /** QQ 出站发送端口（收口）：管理台直发 HTTP 走这里，不碰裸网关。 */
@@ -455,6 +461,7 @@ export async function buildAgentRuntime({
     mainAgentContextQueryService,
     llmPlaygroundService,
     hasTavilyApiKey: Boolean(config.server.tavily.apiKey),
+    rootAgentToolDefinitions: rootAgentTools.definitions(),
     qqApp,
     qqOutboundService,
     shutdownApps: () => appManager.shutdownAll(),

--- a/apps/agent/src/app/server-runtime.ts
+++ b/apps/agent/src/app/server-runtime.ts
@@ -195,7 +195,12 @@ export async function buildServerRuntime(): Promise<ServerRuntime> {
   // TodoReminderPoller 构造放在 agentRuntime 之后：digest 第三段要 fork 主 Agent 上下文，
   // 依赖 agentRuntime.rootAgentRuntime.getContextSnapshot()。reminder-tick 路径不依赖它，故安全。
   // 提醒/汇总以纯数据回调，draft 在这层（wiring 边界）构造并 push，capabilities 层不依赖 apps 层。
-  const todoSuggestionService = new TodoSuggestionService({ llmClient });
+  const todoSuggestionService = new TodoSuggestionService({
+    llmClient,
+    // 与主 Agent 字节相等的顶层工具定义：子调用复用它命中 KV 缓存前缀，
+    // propose_todos 经 invoke 子工具提交，不新增顶层工具。
+    topLevelToolDefinitions: agentRuntime.rootAgentToolDefinitions,
+  });
   const suggestTodos = async (openTodos: { title: string }[]): Promise<string[]> => {
     try {
       const snapshot = await agentRuntime.rootAgentRuntime.getContextSnapshot();

--- a/apps/agent/static/context/todo-suggestion-instruction.hbs
+++ b/apps/agent/static/context/todo-suggestion-instruction.hbs
@@ -16,5 +16,5 @@
 （当前没有未完成待办。）
 {{/if}}
 
-用 `propose_todos` 工具提交你的候选待办（`suggestions` 为标题字符串数组；没有就提交空数组）。不要输出自由文本，只通过这个工具提交。
+通过 `invoke` 工具提交你的候选待办：`tool` 传 `"propose_todos"`，并附一个 `suggestions` 字段（标题字符串数组；没有就传空数组 `[]`）。即调用 `invoke(tool="propose_todos", suggestions=[...])`。不要输出自由文本，也不要调用其它任何工具，只用这一次 invoke 提交。
 </system_instruction>

--- a/apps/agent/test/agent/capabilities/todo/todo-suggestion.service.test.ts
+++ b/apps/agent/test/agent/capabilities/todo/todo-suggestion.service.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
-import type { LlmClient } from "@kagami/llm-client";
+import type { LlmClient, Tool } from "@kagami/llm-client";
 import { BizError } from "@kagami/kernel/errors/biz-error";
+import { INVOKE_TOOL_NAME } from "../../../../src/agent/runtime/root-agent/tools/invoke.tool.js";
 import {
   PROPOSE_TODOS_TOOL_NAME,
   TodoSuggestionService,
@@ -8,6 +9,21 @@ import {
 import { initTestLoggerRuntime } from "../../../helpers/logger.js";
 
 initTestLoggerRuntime();
+
+// 与主 Agent 字节相等的顶层工具定义在真实运行时由 factory 注入；测试只需一份含 invoke 的
+// 桩即可，服务本身不解读工具 schema，只把它原样传给 chat。
+const TOP_LEVEL_TOOLS: Tool[] = [
+  {
+    name: INVOKE_TOOL_NAME,
+    description: "invoke dispatcher",
+    parameters: { type: "object", properties: { tool: { type: "string" } } },
+  },
+  {
+    name: "switch",
+    description: "switch app",
+    parameters: { type: "object", properties: {} },
+  },
+];
 
 function makeLlmClient(chat: ReturnType<typeof vi.fn>): {
   llmClient: LlmClient;
@@ -21,23 +37,48 @@ function makeLlmClient(chat: ReturnType<typeof vi.fn>): {
   return { llmClient, chat };
 }
 
-function successResponse(args: unknown, toolName = PROPOSE_TODOS_TOOL_NAME): unknown {
+function makeService(
+  llmClient: LlmClient,
+  extra: {
+    maxAttempts?: number;
+    retryBackoffMs?: number;
+    sleep?: (ms: number) => Promise<void>;
+  } = {},
+): TodoSuggestionService {
+  return new TodoSuggestionService({
+    llmClient,
+    topLevelToolDefinitions: TOP_LEVEL_TOOLS,
+    ...extra,
+  });
+}
+
+/**
+ * 模型经 invoke 提交：顶层 toolCall 是 invoke，其 arguments 里带 tool="propose_todos" 和业务字段。
+ * topName / subtool 可覆盖，模拟「没走 invoke」或「invoke 了但子工具名不对」两种畸形。
+ */
+function successResponse(
+  args: Record<string, unknown>,
+  {
+    topName = INVOKE_TOOL_NAME,
+    subtool = PROPOSE_TODOS_TOOL_NAME,
+  }: { topName?: string; subtool?: string } = {},
+): unknown {
   return {
     provider: "openai",
     model: "gpt-4o-mini",
     message: {
       role: "assistant",
       content: "",
-      toolCalls: [{ id: "propose-1", name: toolName, arguments: args }],
+      toolCalls: [{ id: "invoke-1", name: topName, arguments: { tool: subtool, ...args } }],
     },
   };
 }
 
 function chatReturning(
-  args: unknown,
-  toolName = PROPOSE_TODOS_TOOL_NAME,
+  args: Record<string, unknown>,
+  overrides?: { topName?: string; subtool?: string },
 ): ReturnType<typeof vi.fn> {
-  return vi.fn().mockResolvedValue(successResponse(args, toolName));
+  return vi.fn().mockResolvedValue(successResponse(args, overrides));
 }
 
 /** isRetryableLlmFailure 只认这两条 message，模拟一次可重试的上游抖动。 */
@@ -55,18 +96,17 @@ const input = {
 };
 
 describe("TodoSuggestionService.propose", () => {
-  it("正常解析：读 propose_todos 的 suggestions 参数", async () => {
+  it("正常解析：从 invoke(tool=propose_todos) 的 arguments 取 suggestions", async () => {
     const { llmClient, chat } = makeLlmClient(
       chatReturning({ suggestions: ["写周报", "回复闻震"] }),
     );
-    const service = new TodoSuggestionService({ llmClient });
+    const service = makeService(llmClient);
     const result = await service.propose(input);
     expect(result).toEqual(["写周报", "回复闻震"]);
-    // 强制 propose_todos、tools 只挂这一个（异于主工具集）
+    // tools 与主 Agent 字节相等（原样传入），toolChoice 也与主循环一致（"required"），保 KV 前缀。
     const [request, options] = chat.mock.calls[0];
-    expect(request.tools).toHaveLength(1);
-    expect(request.tools[0].name).toBe(PROPOSE_TODOS_TOOL_NAME);
-    expect(request.toolChoice).toEqual({ tool_name: PROPOSE_TODOS_TOOL_NAME });
+    expect(request.tools).toBe(TOP_LEVEL_TOOLS);
+    expect(request.toolChoice).toBe("required");
     expect(options).toEqual({ usage: "todoSuggestionAgent" });
   });
 
@@ -74,7 +114,7 @@ describe("TodoSuggestionService.propose", () => {
     const { llmClient } = makeLlmClient(
       chatReturning({ suggestions: ["a", "b", "c", "d", "e", "f", "g", "   "] }),
     );
-    const service = new TodoSuggestionService({ llmClient });
+    const service = makeService(llmClient);
     const result = await service.propose(input);
     expect(result).toEqual(["a", "b", "c", "d", "e"]);
   });
@@ -86,31 +126,63 @@ describe("TodoSuggestionService.propose", () => {
       message: { role: "assistant", content: "自由文本", toolCalls: [] },
     });
     const { llmClient } = makeLlmClient(chat);
-    const service = new TodoSuggestionService({ llmClient });
+    const service = makeService(llmClient);
     expect(await service.propose(input)).toEqual([]);
   });
 
-  it("tool name 不符 → []", async () => {
-    const { llmClient } = makeLlmClient(chatReturning({ suggestions: ["x"] }, "other_tool"));
-    const service = new TodoSuggestionService({ llmClient });
+  it("顶层没走 invoke（自由选到别的工具）→ []", async () => {
+    const { llmClient } = makeLlmClient(
+      chatReturning({ suggestions: ["x"] }, { topName: "switch" }),
+    );
+    const service = makeService(llmClient);
     expect(await service.propose(input)).toEqual([]);
+  });
+
+  it("invoke 了但子工具名不对 → []", async () => {
+    const { llmClient } = makeLlmClient(
+      chatReturning({ suggestions: ["x"] }, { subtool: "something_else" }),
+    );
+    const service = makeService(llmClient);
+    expect(await service.propose(input)).toEqual([]);
+  });
+
+  it("并行多个 toolCall（invoke 不在首位）：按名字找到 invoke，不假设 [0]", async () => {
+    const chat = vi.fn().mockResolvedValue({
+      provider: "openai",
+      model: "gpt-4o-mini",
+      message: {
+        role: "assistant",
+        content: "",
+        toolCalls: [
+          { id: "call-1", name: "switch", arguments: { tool: "qq" } },
+          {
+            id: "call-2",
+            name: INVOKE_TOOL_NAME,
+            arguments: { tool: PROPOSE_TODOS_TOOL_NAME, suggestions: ["写周报"] },
+          },
+        ],
+      },
+    });
+    const { llmClient } = makeLlmClient(chat);
+    const service = makeService(llmClient);
+    expect(await service.propose(input)).toEqual(["写周报"]);
   });
 
   it("参数解析失败（suggestions 非数组）→ []", async () => {
     const { llmClient } = makeLlmClient(chatReturning({ suggestions: "not-an-array" }));
-    const service = new TodoSuggestionService({ llmClient });
+    const service = makeService(llmClient);
     expect(await service.propose(input)).toEqual([]);
   });
 
   it("chat 抛错 → []（digest 降级，不 rethrow）", async () => {
     const { llmClient } = makeLlmClient(vi.fn().mockRejectedValue(new Error("boom")));
-    const service = new TodoSuggestionService({ llmClient });
+    const service = makeService(llmClient);
     await expect(service.propose(input)).resolves.toEqual([]);
   });
 
-  it("suggestions 缺省（模型只调工具没给参数）→ []", async () => {
+  it("suggestions 缺省（模型只 invoke 没给 suggestions）→ []", async () => {
     const { llmClient } = makeLlmClient(chatReturning({}));
-    const service = new TodoSuggestionService({ llmClient });
+    const service = makeService(llmClient);
     expect(await service.propose(input)).toEqual([]);
   });
 
@@ -121,7 +193,7 @@ describe("TodoSuggestionService.propose", () => {
       .mockResolvedValueOnce(successResponse({ suggestions: ["写周报"] }));
     const { llmClient } = makeLlmClient(chat);
     immediateSleep.mockClear();
-    const service = new TodoSuggestionService({ llmClient, sleep: immediateSleep });
+    const service = makeService(llmClient, { sleep: immediateSleep });
     expect(await service.propose(input)).toEqual(["写周报"]);
     expect(chat).toHaveBeenCalledTimes(2);
     expect(immediateSleep).toHaveBeenCalledTimes(1);
@@ -131,11 +203,7 @@ describe("TodoSuggestionService.propose", () => {
     const chat = vi.fn().mockRejectedValue(retryableFailure());
     const { llmClient } = makeLlmClient(chat);
     immediateSleep.mockClear();
-    const service = new TodoSuggestionService({
-      llmClient,
-      maxAttempts: 3,
-      sleep: immediateSleep,
-    });
+    const service = makeService(llmClient, { maxAttempts: 3, sleep: immediateSleep });
     expect(await service.propose(input)).toEqual([]);
     expect(chat).toHaveBeenCalledTimes(3);
     // 最后一次不再退避
@@ -146,7 +214,7 @@ describe("TodoSuggestionService.propose", () => {
     const chat = vi.fn().mockRejectedValue(new Error("boom"));
     const { llmClient } = makeLlmClient(chat);
     immediateSleep.mockClear();
-    const service = new TodoSuggestionService({ llmClient, sleep: immediateSleep });
+    const service = makeService(llmClient, { sleep: immediateSleep });
     expect(await service.propose(input)).toEqual([]);
     expect(chat).toHaveBeenCalledTimes(1);
     expect(immediateSleep).not.toHaveBeenCalled();
@@ -155,8 +223,7 @@ describe("TodoSuggestionService.propose", () => {
   it("maxAttempts 传 Infinity/0 被归一化：不会死循环，也不会跳过首轮调用", async () => {
     const chatInfinity = vi.fn().mockRejectedValue(retryableFailure());
     immediateSleep.mockClear();
-    const serviceInfinity = new TodoSuggestionService({
-      llmClient: makeLlmClient(chatInfinity).llmClient,
+    const serviceInfinity = makeService(makeLlmClient(chatInfinity).llmClient, {
       maxAttempts: Infinity,
       sleep: immediateSleep,
     });
@@ -165,8 +232,7 @@ describe("TodoSuggestionService.propose", () => {
     expect(chatInfinity).toHaveBeenCalledTimes(2);
 
     const chatZero = chatReturning({ suggestions: ["写周报"] });
-    const serviceZero = new TodoSuggestionService({
-      llmClient: makeLlmClient(chatZero).llmClient,
+    const serviceZero = makeService(makeLlmClient(chatZero).llmClient, {
       maxAttempts: 0,
       sleep: immediateSleep,
     });
@@ -183,7 +249,7 @@ describe("TodoSuggestionService.propose", () => {
     });
     const { llmClient } = makeLlmClient(chat);
     immediateSleep.mockClear();
-    const service = new TodoSuggestionService({ llmClient, sleep: immediateSleep });
+    const service = makeService(llmClient, { sleep: immediateSleep });
     expect(await service.propose(input)).toEqual([]);
     expect(chat).toHaveBeenCalledTimes(1);
     expect(immediateSleep).not.toHaveBeenCalled();


### PR DESCRIPTION
## 问题
todo digest 的「发现待办」子调用 fork 主 Agent 的 system+messages 意在命中大段消息前缀，却在同一请求里传 `tools: [PROPOSE_TODOS_TOOL]`（临时顶层工具）并 `toolChoice` 强制它。按 Anthropic prompt cache 失效层级，改 tool 定义会同时废掉 tools/system/messages **三层**缓存——fork 的整段前缀每轮从零换入，且违反项目「能力优先做成 InvokeTool 子工具」铁律。

## 改法（对齐 WebSearchTaskAgent 范例）
- `agent-runtime.factory` 导出 `rootAgentToolDefinitions`（主 Agent 每轮实发的顶层工具定义），`server-runtime` 注入 `TodoSuggestionService`。
- 子调用改传这份**字节相等**的顶层工具集 + `toolChoice: "required"`（与主循环一致），fork 的 system+tools+messages 前缀可命中缓存。
- `propose_todos` 不再是顶层工具：指令让模型走 `invoke(tool="propose_todos", suggestions=[...])` 提交，服务直接读回 `arguments`（单次调用不真正 dispatch InvokeTool）。

## Review 加固
- 按名字在 `toolCalls` 里找 invoke 调用，不假设它在 `[0]`（`"required"` 允许并行多调用）。
- 无 `invoke(propose_todos)` / `suggestions` 畸形时各记一条 info 日志，把「模型没按约定提交」与「确实没有建议」区分开（换 invoke 提交后 provider 侧不再对 `suggestions` 做 schema 强校验，这是可监控的取舍）。
- 补并行多 toolCall 测试。

## 取舍说明
KV 缓存命中与「provider 侧 schema 强校验 suggestions」不可兼得（强校验需独立工具 + 强制 tool_choice，正是破坏缓存的根因）。本 PR 选缓存命中，用日志让退化可观测。同款模式已在 `WebSearchTaskAgent`（`invoke(finalize_web_search, summary=…)`）生产验证。

## 验证
review（Claude 结构化 + 对抗 + 可维护性 + Codex 对抗，四路）→ 加固后 build / typecheck / lint(0 err) / format 全绿，agent 测试 702 passed。未部署。