### PR TITLE
feat(agent): QQ 通知附带最新消息预览，通知节流窗口调至 30 秒

### DIFF
--- a/apps/agent/src/agent/apps/qq/qq.app.ts
+++ b/apps/agent/src/agent/apps/qq/qq.app.ts
@@ -17,6 +17,7 @@ import type {
   NapcatPrivateMessageData,
 } from "../../../napcat/application/napcat-gateway.service.js";
 import {
+  buildChatNotificationPreview,
   ChatNotificationDraft,
   detectBotMentioned,
 } from "../../capabilities/messaging/chat-notification-draft.js";
@@ -103,7 +104,7 @@ type QqAppDeps = {
  * 消息分流（手机 OS 的「屏幕 vs 横幅」）：QQ 在前台且消息属于当前会话时走前台实时
  * 路径——入缓冲 + 敲门（foreground_input 事件），drain 时经 drainForegroundInput 把增量
  * 直接刷进上下文尾部，不经 center；其余（别的会话 / QQ 在后台）照旧走 center 成通知
- * （只报信号不报正文）。小镜自己的回声（botQQ）只入缓冲不敲门不推 center。退化收口在
+ * （标签 + 最新一条预览）。小镜自己的回声（botQQ）只入缓冲不敲门不推 center。退化收口在
  * onBlur / 切会话：未投递的未读补推 center draft，绝不静默丢。
  */
 export class QqApp implements App, ForegroundInputSource {
@@ -434,9 +435,9 @@ export class QqApp implements App, ForegroundInputSource {
    * - 前台 + 当前会话：入缓冲 + 敲门（实时路径，不推 center）；小镜自己的回声只入缓冲
    *   （不计未读、不敲门、不推 center——回声防御，防「自己发言→自己被唤醒」的自持振荡，
    *   见 2026-05-30 空转事故同款拓扑）。
-   * - 其余：照旧走 center。通知只报信号（未读条数 / 有人@），不带消息正文：用会话当前的
-   *   权威未读状态现造 draft，计数与 @ 跨窗口累积，open 才清零。想看内容一律
-   *   open_conversation。
+   * - 其余：照旧走 center。通知报信号（未读条数 / 有人@）+ 最新一条真实未读的预览（群聊
+   *   带发言人）：用会话当前的权威未读状态现造 draft，计数与 @ 跨窗口累积，open 才清零。
+   *   预览只有最新一条且截断，想看全量上下文一律 open_conversation。
    */
   private ingestMessage(
     conversation: Conversation,
@@ -516,14 +517,20 @@ export class QqApp implements App, ForegroundInputSource {
     );
   }
 
-  /** 用会话当前的权威未读状态现造一条 draft 推给 center（ingest 横幅路径与退化补推共用）。 */
+  /**
+   * 用会话当前的权威未读状态现造一条 draft 推给 center（ingest 横幅路径与退化补推共用）。
+   * 附带最新一条真实未读的预览（群聊带发言人）；缓冲空（restore 裸计数）时无预览，
+   * draft 退回纯标签格式。
+   */
   private pushDraftFor(conversation: Conversation): void {
+    const latest = conversation.getLatestUnread();
     this.notificationCenter.push(
       new ChatNotificationDraft(
         conversation.id,
         conversation.getShortName(),
         conversation.hasUnreadMention(),
         conversation.getUnreadCount(),
+        latest ? buildChatNotificationPreview(latest, conversation.kind) : null,
       ),
     );
   }

--- a/apps/agent/src/agent/capabilities/messaging/chat-notification-draft.ts
+++ b/apps/agent/src/agent/capabilities/messaging/chat-notification-draft.ts
@@ -1,28 +1,46 @@
 import { renderServerStaticTemplate } from "@kagami/kernel/runtime/read-static-text";
+import { truncateWithEllipsis } from "@kagami/shared/utils";
 import type { NotificationDraft } from "../../runtime/root-agent/notification/notification-draft.js";
-import type { NapcatReceiveMessageSegment } from "../../../napcat/application/napcat-gateway/shared.js";
+import type { ConversationMessage } from "./conversation.js";
+import {
+  renderSupportedMessageSegments,
+  type NapcatReceiveMessageSegment,
+} from "../../../napcat/application/napcat-gateway/shared.js";
 
 const MAX_DISPLAY_COUNT = 99;
+/** 预览正文截断上限（码点数）：一行通知里给正文留的空间，超出截断加省略号。 */
+const PREVIEW_MAX_CHARS = 50;
+
+/**
+ * 通知里的最新一条消息预览。senderName 只在群聊时有（发言人昵称）；私聊会话名
+ * 本身就是对方，不重复标发送人。text 已折叠空白并截断，直接可渲染。
+ */
+export type ChatNotificationPreview = {
+  senderName: string | null;
+  text: string;
+};
 
 /**
  * 一个 QQ 会话的后台通知 draft（手机 OS 模型）。
  *
- * 通知是**诱饵不是内容**：它只告诉小镜"这个会话有事、值得进去看看"，绝不把消息正文
- * 预先摊开——否则小镜不进群也能被动跟上，反而没了进群参与的动机。想知道具体说了啥，
- * 一律 `open_conversation`。
+ * 通知带**最新一条消息的预览**：会话名 + 标签之外，附上最近一条真实未读的正文
+ * （群聊还带发言人），让小镜不用进会话就能判断值不值得进去。但预览只有最新一条
+ * 且会截断——想看全量上下文，仍然要 `open_conversation`。
  *
  * 归到 "QQ" 段下，每会话一行：
- *   `{会话名}: {条数标签}{@标签}`
+ *   `{会话名}: {条数标签}{@标签} {发言人}: {预览正文}`
  * - 条数标签：未读条数 > 1 时显示 `[N 条消息]`（N 超 99 显 `99+`）。
  * - @标签：未读里有人 @ 过小镜时显示 `[有人 @ 你]`。
- * - 两个标签都没有（只 1 条且没 @）时兜底显示 `有新消息`。
+ * - 预览：缓冲里有真实未读时显示（restoreUnread 恢复的裸计数没有缓冲，无预览）；
+ *   群聊带 `{发言人}: ` 前缀，私聊只有正文。
+ * - 标签和预览都没有时兜底显示 `有新消息`。
  *
  * **计数与 @ 都不在这里累积**：每条新消息进来时，QQ App 都用会话当前的权威未读状态
  * （`Conversation.getUnreadCount()` / `hasUnreadMention()`）现造一个新 draft。这两者只在
- * open_conversation 时清零，所以未读会跨通知窗口持续累积，而不是每个 30s 窗口重新计数。
+ * open_conversation 时清零，所以未读会跨通知窗口持续累积，而不是每个通知窗口重新计数。
  *
- * 因此折叠约定是**最新快照覆盖**：`merge(prev)` 直接取 `this`（最新快照已带全量未读计数，
- * prev 是过期快照）。sourceId = 会话 id（每会话一个源）。
+ * 因此折叠约定是**最新快照覆盖**：`merge(prev)` 直接取 `this`（最新快照已带全量未读计数
+ * 和最新预览，prev 是过期快照）。sourceId = 会话 id（每会话一个源）。
  *
  * 渲染文案在 `static/context/notifications/qq-chat.hbs`；这里只算 view-model。
  */
@@ -34,23 +52,47 @@ export class ChatNotificationDraft implements NotificationDraft {
     public readonly displayName: string,
     private readonly mentioned: boolean,
     private readonly unreadCount: number,
+    private readonly preview: ChatNotificationPreview | null = null,
   ) {}
 
   public merge(_prev: NotificationDraft): NotificationDraft {
-    // 最新快照已携带权威未读计数 + @ 标记，过期的 prev 直接丢弃。
+    // 最新快照已携带权威未读计数 + @ 标记 + 最新预览，过期的 prev 直接丢弃。
     return this;
   }
 
   public render(): string {
     const hasCount = this.unreadCount > 1;
+    const hasTags = hasCount || this.mentioned;
     return renderServerStaticTemplate(import.meta.url, "context/notifications/qq-chat.hbs", {
       displayName: this.displayName,
-      hasTags: hasCount || this.mentioned,
+      hasTags,
       hasCount,
       countLabel: formatCount(this.unreadCount),
       mentioned: this.mentioned,
+      preview: this.preview,
+      showFallback: !hasTags && !this.preview,
     });
   }
+}
+
+/**
+ * 从一条未读消息现算通知预览 view-model：段渲染（@/图片/表情等转占位文本）→ 折叠
+ * 空白成单行 → 截断。正文渲染出来是空（如纯不支持段）时返回 null，退回无预览格式。
+ */
+export function buildChatNotificationPreview(
+  message: ConversationMessage,
+  kind: "group" | "private",
+): ChatNotificationPreview | null {
+  const body =
+    message.messageSegments.length > 0
+      ? renderSupportedMessageSegments(message.messageSegments)
+      : message.rawMessage;
+  const text = truncateWithEllipsis(body.replace(/\s+/g, " ").trim(), PREVIEW_MAX_CHARS);
+  if (!text) {
+    return null;
+  }
+  const senderName = kind === "group" ? message.nickname.trim() || message.userId : null;
+  return { senderName, text };
 }
 
 /** 群消息里是否 @ 了机器人（at 段的 qq 命中 botQQ）。私聊无 @ 概念，恒为 false。 */

--- a/apps/agent/src/agent/capabilities/messaging/conversation.ts
+++ b/apps/agent/src/agent/capabilities/messaging/conversation.ts
@@ -146,8 +146,18 @@ export class Conversation {
     return this.entered;
   }
 
+  /**
+   * 缓冲里最新的一条**真实未读**（跳过回声）：通知预览用——预览渲染的是「别人最新说了
+   * 什么」，小镜自己的回声不算。缓冲空（如 restoreUnread 恢复的裸计数）时返回 null。
+   */
   public getLatestUnread(): ConversationMessage | null {
-    return this.unread.at(-1)?.message ?? null;
+    for (let i = this.unread.length - 1; i >= 0; i--) {
+      const entry = this.unread[i];
+      if (entry.countsAsUnread) {
+        return entry.message;
+      }
+    }
+    return null;
   }
 
   public setGroupInfo(groupInfo: NapcatGetGroupInfoResult): void {

--- a/apps/agent/static/context/notifications/qq-chat.hbs
+++ b/apps/agent/static/context/notifications/qq-chat.hbs
@@ -1,1 +1,1 @@
-{{displayName}}: {{#if hasTags}}{{#if hasCount}}[{{countLabel}} 条消息]{{/if}}{{#if mentioned}}[有人 @ 你]{{/if}}{{else}}有新消息{{/if}}
+{{displayName}}: {{#if hasCount}}[{{countLabel}} 条消息]{{/if}}{{#if mentioned}}[有人 @ 你]{{/if}}{{#if preview}}{{#if hasTags}} {{/if}}{{#if preview.senderName}}{{preview.senderName}}: {{/if}}{{preview.text}}{{/if}}{{#if showFallback}}有新消息{{/if}}

--- a/apps/agent/test/agent/apps/qq/qq.app.test.ts
+++ b/apps/agent/test/agent/apps/qq/qq.app.test.ts
@@ -168,8 +168,8 @@ describe("QqApp", () => {
     scheduler.fireWindowEnd(); // 空闲来第一条→前沿短窗结束才 flush
 
     expect(onFlush).toHaveBeenCalledTimes(1);
-    // 通知只报信号，不带正文：单条且未 @ 时兜底显示"有新消息"。
-    expect(onFlush.mock.calls[0][0]).toEqual(["QQ:", "产品群: 有新消息"]);
+    // 通知带最新一条预览：群聊附发言人 + 正文。
+    expect(onFlush.mock.calls[0][0]).toEqual(["QQ:", "产品群: 群友: 在吗"]);
   });
 
   it("keeps the unread count climbing across windows, resetting only on open", async () => {
@@ -178,20 +178,20 @@ describe("QqApp", () => {
     const app = createApp(scheduler, onFlush);
     await app.onStartup();
 
-    // 空闲第一条→开前沿短窗，窗结束 flush，count 1（无条数标签，兜底"有新消息"）。
+    // 空闲第一条→开前沿短窗，窗结束 flush，count 1（无条数标签，只带预览）。
     app.handleNapcatEvent({ type: "napcat_group_message", data: groupMessage("1") });
     scheduler.fireWindowEnd();
-    expect(onFlush.mock.calls[0][0]).toEqual(["QQ:", "产品群: 有新消息"]);
+    expect(onFlush.mock.calls[0][0]).toEqual(["QQ:", "产品群: 群友: 1"]);
 
-    // 再来一条→窗内攒着，窗结束 flush，count 2。
+    // 再来一条→窗内攒着，窗结束 flush，count 2，预览取最新一条。
     app.handleNapcatEvent({ type: "napcat_group_message", data: groupMessage("2") });
     scheduler.fireWindowEnd();
-    expect(onFlush.mock.calls[1][0]).toEqual(["QQ:", "产品群: [2 条消息]"]);
+    expect(onFlush.mock.calls[1][0]).toEqual(["QQ:", "产品群: [2 条消息] 群友: 2"]);
 
     // 又一条→没有 open，计数继续涨到 3，而不是按窗口重新计数。
     app.handleNapcatEvent({ type: "napcat_group_message", data: groupMessage("3") });
     scheduler.fireWindowEnd();
-    expect(onFlush.mock.calls[2][0]).toEqual(["QQ:", "产品群: [3 条消息]"]);
+    expect(onFlush.mock.calls[2][0]).toEqual(["QQ:", "产品群: [3 条消息] 群友: 3"]);
 
     // 小镜终于来看→未读清零；窗口排空回到空闲。open 成功后会话成为前台当前
     // （focused 自愈），先 blur 让后续消息回到通知路径。
@@ -202,7 +202,7 @@ describe("QqApp", () => {
     // 之后的新消息从 count 1 重新开始（又走前沿短窗）。
     app.handleNapcatEvent({ type: "napcat_group_message", data: groupMessage("4") });
     scheduler.fireWindowEnd();
-    expect(onFlush.mock.calls[3][0]).toEqual(["QQ:", "产品群: 有新消息"]);
+    expect(onFlush.mock.calls[3][0]).toEqual(["QQ:", "产品群: 群友: 4"]);
   });
 
   it("marks [有人@你] when the bot is mentioned", async () => {
@@ -435,7 +435,8 @@ describe("QqApp", () => {
     });
     scheduler.fireWindowEnd(); // 空闲来第一条→前沿短窗结束才 flush
 
-    expect(onFlush.mock.calls[0][0]).toEqual(["QQ:", "老王: 有新消息"]);
+    // 私聊预览不重复标发送人（会话名就是对方），直接跟正文。
+    expect(onFlush.mock.calls[0][0]).toEqual(["QQ:", "老王: 在不在"]);
     // 会话被建出来，能打开
     expect((await app.openConversation("qq_private:888")).ok).toBe(true);
     expect(app.getCurrentChatTarget()).toEqual({ chatType: "private", userId: "888" });

--- a/apps/agent/test/agent/chat-notification-draft.test.ts
+++ b/apps/agent/test/agent/chat-notification-draft.test.ts
@@ -1,16 +1,30 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildChatNotificationPreview,
   ChatNotificationDraft,
   detectBotMentioned,
 } from "../../src/agent/capabilities/messaging/chat-notification-draft.js";
+import type { ConversationMessage } from "../../src/agent/capabilities/messaging/conversation.js";
 import type { NapcatReceiveMessageSegment } from "../../src/napcat/application/napcat-gateway/shared.js";
+
+function groupMessage(text: string, nickname = "群友"): ConversationMessage {
+  return {
+    groupId: "1",
+    userId: "654321",
+    nickname,
+    rawMessage: text,
+    messageSegments: [{ type: "text", data: { text } } as NapcatReceiveMessageSegment],
+    messageId: 1,
+    time: 1,
+  };
+}
 
 describe("ChatNotificationDraft", () => {
   it("belongs to the QQ group", () => {
     expect(new ChatNotificationDraft("qq_group:1", "产品群", false, 1).group).toBe("QQ");
   });
 
-  it("falls back to 有新消息 for a single non-@ message (no body preview)", () => {
+  it("falls back to 有新消息 without tags and without preview", () => {
     expect(new ChatNotificationDraft("qq_group:1", "产品群", false, 1).render()).toBe(
       "产品群: 有新消息",
     );
@@ -35,11 +49,78 @@ describe("ChatNotificationDraft", () => {
     );
   });
 
+  it("renders the latest-message preview with sender for group chats", () => {
+    const draft = new ChatNotificationDraft("qq_group:1", "产品群", false, 3, {
+      senderName: "群友",
+      text: "今晚开黑吗",
+    });
+    expect(draft.render()).toBe("产品群: [3 条消息] 群友: 今晚开黑吗");
+  });
+
+  it("renders the preview without sender for private chats", () => {
+    const draft = new ChatNotificationDraft("qq_private:654321", "老王", false, 1, {
+      senderName: null,
+      text: "在吗",
+    });
+    expect(draft.render()).toBe("老王: 在吗");
+  });
+
+  it("keeps tags and preview together, tags first", () => {
+    const draft = new ChatNotificationDraft("qq_group:1", "产品群", true, 5, {
+      senderName: "群友",
+      text: "小镜快来",
+    });
+    expect(draft.render()).toBe("产品群: [5 条消息][有人 @ 你] 群友: 小镜快来");
+  });
+
   it("merge(prev) takes the latest snapshot (count is authoritative, not accumulated)", () => {
-    // 未读计数 / @ 标记的权威来源是 Conversation，新 draft 已带全量快照；过期 prev 被丢弃。
+    // 未读计数 / @ 标记 / 预览的权威来源是 Conversation，新 draft 已带全量快照；过期 prev 被丢弃。
     const older = new ChatNotificationDraft("qq_group:1", "群", true, 1); // 旧快照：@ 过、count 1
     const newer = new ChatNotificationDraft("qq_group:1", "群", false, 5); // 新快照：count 5、未 @
     expect(newer.merge(older).render()).toBe("群: [5 条消息]");
+  });
+});
+
+describe("buildChatNotificationPreview", () => {
+  it("uses the sender nickname for group messages and none for private ones", () => {
+    expect(buildChatNotificationPreview(groupMessage("在吗"), "group")).toEqual({
+      senderName: "群友",
+      text: "在吗",
+    });
+    expect(buildChatNotificationPreview(groupMessage("在吗"), "private")).toEqual({
+      senderName: null,
+      text: "在吗",
+    });
+  });
+
+  it("falls back to userId when the group nickname is blank", () => {
+    expect(buildChatNotificationPreview(groupMessage("在吗", "  "), "group")).toEqual({
+      senderName: "654321",
+      text: "在吗",
+    });
+  });
+
+  it("collapses whitespace and truncates long bodies", () => {
+    const preview = buildChatNotificationPreview(groupMessage("第一行\n  第二行"), "group");
+    expect(preview?.text).toBe("第一行 第二行");
+
+    const long = buildChatNotificationPreview(groupMessage("啊".repeat(60)), "group");
+    expect(long?.text).toBe("啊".repeat(50) + "…");
+  });
+
+  it("renders non-text segments as placeholders", () => {
+    const message: ConversationMessage = {
+      ...groupMessage(""),
+      messageSegments: [
+        { type: "image", data: { summary: "" } } as unknown as NapcatReceiveMessageSegment,
+      ],
+    };
+    expect(buildChatNotificationPreview(message, "group")?.text).toBe("[图片]");
+  });
+
+  it("returns null when the body renders empty", () => {
+    const message: ConversationMessage = { ...groupMessage("   "), messageSegments: [] };
+    expect(buildChatNotificationPreview(message, "group")).toBeNull();
   });
 });
 

--- a/apps/agent/test/agent/conversation.test.ts
+++ b/apps/agent/test/agent/conversation.test.ts
@@ -201,14 +201,16 @@ describe("Conversation", () => {
       expect(group.hasUnreadMention()).toBe(false);
     });
 
-    it("pushEcho 入缓冲但不计未读、不动 @", () => {
+    it("pushEcho 入缓冲但不计未读、不动 @、不当最新未读", () => {
       const group = Conversation.group("1", 5);
       group.pushEcho(groupMsg("我自己说的", 21));
       expect(group.getUnreadCount()).toBe(0);
       expect(group.hasUnreadMention()).toBe(false);
-      expect(group.getLatestUnread()?.rawMessage).toBe("我自己说的");
+      // 回声不是「别人最新说的」：通知预览不能把小镜自己的发言当最新消息。
+      expect(group.getLatestUnread()).toBeNull();
       // 回声随全量消费一起被带出展示。
       group.pushUnread(groupMsg("别人说的", 22), false);
+      expect(group.getLatestUnread()?.rawMessage).toBe("别人说的");
       const tail = group.consumeUnreadTail();
       expect(tail.map(m => m.rawMessage)).toEqual(["我自己说的", "别人说的"]);
     });

--- a/config.yaml
+++ b/config.yaml
@@ -22,7 +22,7 @@ server:
     llmRetryBackoffMs: 30000
     waitToolMaxWaitMs: 600000
     notificationLeadingWindowMs: 1000 # 空闲来第一条通知时先开这么长的前沿短窗聚合首批，窗结束才 flush（不再前沿立即发）
-    notificationBatchWindowMs: 5000
+    notificationBatchWindowMs: 30000
     messaging:
       aiTone:
         enabled: true # 发言 AI 味门控；置 false 完全退化为原发送行为


### PR DESCRIPTION
## 改动内容

两件事：

### 1. 通知节流窗口 5s → 30s

`config.yaml` 的 `server.agent.notificationBatchWindowMs` 从 5000 改为 30000，与 `config.loader.ts` 的默认值（30_000）对齐。前沿短窗（`notificationLeadingWindowMs: 1000`）不变。

### 2. QQ 通知附带最新一条消息预览

通知行格式从纯信号升级为「信号 + 预览」：

- 群聊：`产品群: [3 条消息][有人 @ 你] 群友: 今晚开黑吗`
- 私聊：`老王: [2 条消息] 在吗`（会话名即对方，不重复标发送人）
- 缓冲无真实未读（如重启 restore 的裸计数）时退回纯标签格式；标签与预览都没有时仍兜底「有新消息」

实现要点：

- `ChatNotificationDraft` 加可选 `preview` 参数；新增 `buildChatNotificationPreview()`：段渲染（@/图片/表情转占位文本）→ 折叠空白成单行 → 按码点截断 50 字符（`truncateWithEllipsis`，免疫劈代理对）
- `Conversation.getLatestUnread()` 收紧为跳过回声——预览渲染「别人最新说了什么」，不能把小镜自己的发言当最新消息（此前无调用方，无副作用）
- 文案落在 `static/context/notifications/qq-chat.hbs`，TS 只算 view-model（符合模板铁律）

## KV 缓存自检

- 通知仍走 NotificationCenter → `notification` 事件 → 尾部追加路径，只改易变尾部内容，不碰稳定前缀
- QQ help 模板无「通知不带正文」承诺，未改动（避免无谓的前缀失效）
- 进上下文的散文全部在 `.hbs` 模板

## 测试

- draft 单测重写：预览渲染（群/私/标签组合）、发送人回退、空白折叠、截断、占位段、空正文返 null、回声排除
- `qq.app.test.ts` 五处 flush 断言更新；`conversation.test.ts` 回声语义断言更新
- `pnpm build / typecheck / lint / format` 四门禁全过；全仓 `pnpm test` 全绿（agent 包 115 文件 751 用例）

## 文档

document-release 审计：docs/configuration.md 只列字段名不列值，ARCHITECTURE.md 通知叙述行为未变，无漂移、零改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)