### PR TITLE
fix(llm-client): auto 空轮不再误判 INVALID_RESPONSE

### DIFF
--- a/packages/llm-client/src/providers/claude-code-response.ts
+++ b/packages/llm-client/src/providers/claude-code-response.ts
@@ -127,6 +127,8 @@ function parseClaudeStreamResponse(value: string): ClaudeMessageResponse | null 
       }
   > = [];
   let model: string | undefined;
+  let sawMessageStart = false;
+  let sawMessageStop = false;
   let inputTokens: number | undefined;
   let outputTokens: number | undefined;
   let cacheReadInputTokens: number | undefined;
@@ -158,7 +160,13 @@ function parseClaudeStreamResponse(value: string): ClaudeMessageResponse | null 
       continue;
     }
 
+    if (parsed.type === "message_stop") {
+      sawMessageStop = true;
+      continue;
+    }
+
     if (parsed.type === "message_start") {
+      sawMessageStart = true;
       const message = isRecord(parsed.message) ? parsed.message : null;
       if (message && typeof message.model === "string") {
         model = message.model;
@@ -277,7 +285,11 @@ function parseClaudeStreamResponse(value: string): ClaudeMessageResponse | null 
     return [block.block];
   });
 
-  if (content.length === 0) {
+  // toolChoice auto 下模型可以合法地"什么都不说"：流正常走完（message_start →
+  // end_turn → message_stop）但一个 content block 都没有。这是空轮而非坏响应，
+  // 映射成空 content 的 assistant 消息（下游 root 按纯文本轮语义挂起）。只有
+  // 流没有完整走完（缺 start/stop）时，零 block 才视为无法解析。
+  if (content.length === 0 && !(sawMessageStart && sawMessageStop)) {
     return null;
   }
 

--- a/packages/llm-client/test/claude-code-provider.test.ts
+++ b/packages/llm-client/test/claude-code-provider.test.ts
@@ -195,6 +195,116 @@ function createProviderConfig(
 }
 
 describe("createClaudeCodeProvider", () => {
+  it("should map a completed zero-block stream to an empty assistant message (auto 空轮)", async () => {
+    // 生产实况（2026-07-03 部署 #270 后）：toolChoice auto + thinking disabled 下
+    // 模型可以合法地"什么都不说"——流完整走完（message_start → end_turn →
+    // message_stop）但零个 content block。必须映射为空 assistant 消息而非
+    // INVALID_RESPONSE，否则 agent 会陷入退避重试循环。
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            createSseResponse([
+              {
+                type: "message_start",
+                message: {
+                  id: "msg_empty",
+                  type: "message",
+                  role: "assistant",
+                  model: "claude-opus-4-6",
+                  content: [],
+                  usage: { input_tokens: 1, output_tokens: 0, cache_read_input_tokens: 165183 },
+                },
+              },
+              {
+                type: "message_delta",
+                delta: { stop_reason: "end_turn", stop_sequence: null },
+                usage: { input_tokens: 1, output_tokens: 2, cache_read_input_tokens: 165183 },
+              },
+              { type: "message_stop" },
+            ]),
+            { status: 200, headers: { "Content-Type": "text/event-stream" } },
+          ),
+      ),
+    );
+
+    const provider = createClaudeCodeProvider({
+      config: createProviderConfig({ models: ["claude-opus-4-6"] }),
+      authStore: createAuthStore(),
+    });
+
+    await expect(
+      provider.chat({
+        system: "你是一个测试助手。",
+        messages: [{ role: "user", content: "ping" }],
+        tools: [],
+        toolChoice: "auto",
+        model: "claude-opus-4-6",
+      }),
+    ).resolves.toMatchObject({
+      response: {
+        provider: "claude-code",
+        model: "claude-opus-4-6",
+        message: {
+          role: "assistant",
+          content: "",
+          toolCalls: [],
+        },
+        usage: {
+          completionTokens: 2,
+          cacheHitTokens: 165183,
+        },
+      },
+    });
+
+    vi.unstubAllGlobals();
+  });
+
+  it("should still reject a truncated stream with zero blocks (no message_stop)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            createSseResponse([
+              {
+                type: "message_start",
+                message: {
+                  id: "msg_trunc",
+                  type: "message",
+                  role: "assistant",
+                  model: "claude-opus-4-6",
+                  content: [],
+                  usage: { input_tokens: 1, output_tokens: 0 },
+                },
+              },
+            ]),
+            { status: 200, headers: { "Content-Type": "text/event-stream" } },
+          ),
+      ),
+    );
+
+    const provider = createClaudeCodeProvider({
+      config: createProviderConfig({ models: ["claude-opus-4-6"] }),
+      authStore: createAuthStore(),
+    });
+
+    await expect(
+      provider.chat({
+        system: "你是一个测试助手。",
+        messages: [{ role: "user", content: "ping" }],
+        tools: [],
+        toolChoice: "auto",
+        model: "claude-opus-4-6",
+      }),
+    ).rejects.toMatchObject({
+      message: "LLM 上游服务调用失败",
+    });
+
+    vi.unstubAllGlobals();
+  });
+
   it("should map a final assistant message from the Claude stream response", async () => {
     const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
       const body = JSON.parse(String(init?.body)) as Record<string, unknown>;


### PR DESCRIPTION
#270 部署后生产热修。

## 现象

部署 #270（toolChoice auto + thinking disabled）后，`llm_chat_call` 连续出现 `INVALID_RESPONSE`（status 200），agent 陷入 30 秒退避重试循环。

## 根因

`auto` 下 claude 模型可以合法地"什么都不说"：SSE 流完整走完（`message_start` → `end_turn`（`output_tokens: 2`）→ `message_stop`）但**零个 content block**。`parseClaudeStreamResponse` 对零 block 一律返回 `null` → provider 判 `INVALID_RESPONSE` → 可重试 → 循环（下一次多半还是空响应）。

生产证据：id 20366-20414 连续 failed，`cache_read_input_tokens: 165183`（KV 缓存命中正常，非缓存问题）。

## 修复

跟踪 `message_start` / `message_stop`：流完整走完的零 block 映射为空 assistant 消息（`content: ""`、零 toolCalls），下游 root 按 #270 的纯文本轮语义挂起（零写入 + 等事件）；截断流（缺 start/stop）仍判无法解析。

新增两个测试：完整空轮流 → 空消息；截断零 block 流 → 仍拒绝。

## 部署

合并后需 `pnpm app:deploy llm`（解析代码在 kagami-llm 进程）。当前生产在退避循环中持续重试，宜尽快上线。