### PR TITLE
build(test): 根级 vitest projects 单进程跑全部包测试

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,7 +130,7 @@ pnpm format
 ```bash
 pnpm build        # 按 workspace 依赖拓扑构建所有包
 pnpm typecheck    # 全部包类型检查
-pnpm test         # 运行所有声明了 test 脚本的包（后端各服务/包 + apps/web 纯函数层）
+pnpm test         # 根级 vitest projects 单进程跑全部包的测试（新包只需自带 vitest.config.ts 即被纳入）
 pnpm lint         # ESLint 检查（lint:fix 自动修复）
 pnpm format       # Prettier 检查（format:write 自动格式化）
 

--- a/apps/console/vitest.config.ts
+++ b/apps/console/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+    clearMocks: true,
+    restoreMocks: true,
+  },
+});

--- a/apps/metric/vitest.config.ts
+++ b/apps/metric/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+    clearMocks: true,
+    restoreMocks: true,
+  },
+});

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "db:migrate:reset": "bash ./scripts/prisma.sh migrate reset",
     "db:migrate:resolve": "bash ./scripts/prisma.sh migrate resolve",
     "typecheck": "pnpm -r typecheck",
-    "test": "pnpm -r --workspace-concurrency=1 --if-present test",
+    "test": "NODE_OPTIONS=--max-old-space-size=2048 vitest run",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier . --check",
@@ -31,6 +31,7 @@
     "prettier": "^3.6.2",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.48.0",
+    "vitest": "^3.2.4",
     "yaml": "^2.8.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       typescript-eslint:
         specifier: ^8.48.0
         version: 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@24.11.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
       yaml:
         specifier: ^2.8.2
         version: 2.8.2

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+// 根级 projects：单个 vitest 进程跑全部包的测试。
+// 不走 pnpm -r 串行调度，省掉每个包各冷启动一次 vitest 的开销（CI 上约占 test 步骤 80% 时间）。
+export default defineConfig({
+  test: {
+    projects: ["apps/*/vitest.config.ts", "packages/*/vitest.config.ts"],
+  },
+});


### PR DESCRIPTION
## 问题

CI 一遍 ~4.5 分钟，其中 Test 步骤 142s 占一半。根因不是测试本身慢（全部用例实际执行仅 ~26s），而是 `pnpm -r --workspace-concurrency=1` 串行跑 17 个包，每个包各自冷启动一次 vitest，~115s 全是启动开销。

## 方案

根级 `vitest.config.ts` 用 vitest 3.2 的 `test.projects` 把 `apps/*` / `packages/*` 全部聚成一个 vitest 进程，17 次冷启动变 1 次：

- 根 `test` 脚本改为直接 `vitest run`（保留原 agent 包的 2GB 堆上限，对所有 worker 生效），根 devDependencies 加 `vitest ^3.2.4`
- 补齐 `apps/console`、`apps/metric` 缺失的 `vitest.config.ts`（配置与其他包对齐，也使其被 projects glob 纳入）
- 各包自己的 `test` / `test:watch` 脚本原样保留，`pnpm --filter <包> test` 不受影响
- `ci.yml` 无需改动，入口仍是 `pnpm test`
- AGENTS.md 同步：新包只需自带 `vitest.config.ts` 即被纳入

## 效果

- 本地 `pnpm test`：87.8s → ~10s
- 用例数与串行方案完全一致（合并 master 后 173 文件 / 1109 用例，全绿），零 vitest 告警
- CI Test 步骤预计 142s → ~30s，整个 run 预计进 2 分半以内

## 验证

- 合并最新 master 后连续 8 轮 `pnpm test` 全绿（master 新合入的 spire / llm-client 测试被 glob 自动纳入）
- build / typecheck / lint / format 四件套全过（lint 7 个 warning 为 chart.tsx / rpc-client 存量问题）