### PR TITLE
feat(spire): 精英拉加维林 + 睡眠/金属化/敏捷机制（阶段2 M3b-2）

### DIFF
--- a/apps/agent/src/agent/capabilities/spire/render/spire-screen.ts
+++ b/apps/agent/src/agent/capabilities/spire/render/spire-screen.ts
@@ -17,9 +17,11 @@ import type {
 
 const POWER_LABELS: Record<string, string> = {
   strength: "力量",
+  dexterity: "敏捷",
   vulnerable: "易伤",
   weak: "虚弱",
   frail: "脆弱",
+  metallicize: "金属化",
   ritual: "仪式",
   curl_up: "蜷缩",
   sharp_hide: "反甲",

--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -11,8 +11,8 @@ import { getEnemyDef, getEncounterDef } from "../enemies/enemies.js";
 import { nextRange, nextFloat, nextInt, shuffleInPlace } from "../rng.js";
 import {
   addPower,
-  applyFrailToBlock,
   computeAttackDamage,
+  computeBlockGain,
   decayDebuffs,
   getPower,
   removePower,
@@ -33,6 +33,8 @@ const LOUSE_CURL_UP_MIN = 3;
 const LOUSE_CURL_UP_MAX = 7;
 const LOUSE_BITE_MIN = 5;
 const LOUSE_BITE_MAX = 7;
+const LAGAVULIN_METALLICIZE = 8;
+const LAGAVULIN_WAKE_TURN = 3; // 睡满两回合、第 3 回合自然醒（combat.turn 从 1 起）。
 
 type ActorRef = { side: "player" } | { side: "enemy"; index: number };
 
@@ -53,6 +55,8 @@ export function startCombat(state: GameState, encounterId: string): void {
     const def = getEnemyDef(defId);
     const powers: PowerInstance[] = [];
     let rolledDamage = 0;
+    let block = 0;
+    let asleep = false;
     if (defId === "louse") {
       // 红虱开局自带蜷缩（首次被攻击获得格挡），block 值随机。
       const curl = nextRange(state.rng, LOUSE_CURL_UP_MIN, LOUSE_CURL_UP_MAX);
@@ -60,19 +64,26 @@ export function startCombat(state: GameState, encounterId: string): void {
       // 咬击基础伤害出生时掷一次、整场固定（5~7）。
       rolledDamage = nextRange(state.rng, LOUSE_BITE_MIN, LOUSE_BITE_MAX);
     }
+    if (defId === "lagavulin") {
+      // 拉加维林开局沉睡：金属化 8（每回合结束回 8 格挡）+ 立即 8 格挡；受伤或睡满自然醒。
+      asleep = true;
+      block = LAGAVULIN_METALLICIZE;
+      powers.push({ id: "metallicize", amount: LAGAVULIN_METALLICIZE });
+    }
     const hp = nextRange(state.rng, def.hpMin, def.hpMax);
     return {
       defId,
       name: def.name,
       hp,
       maxHp: hp,
-      block: 0,
+      block,
       powers,
       moveHistory: [],
       rotationIndex: 0,
       currentMove: "",
       curlUpConsumed: false,
       rolledDamage,
+      asleep,
       modeShiftAccum: 0,
       modeShiftThreshold: def.modeShiftThreshold ?? null,
       stance: def.stanceMoves ? "offensive" : null,
@@ -228,8 +239,8 @@ function applyEffect(
       break;
     }
     case "gain_block": {
-      // 脆弱使获得的格挡打七五折（按「获得方」自己的 powers 判定）。
-      const gained = applyFrailToBlock(effect.amount, powers);
+      // 获得的格挡按「获得方」的敏捷/脆弱修正。
+      const gained = computeBlockGain(effect.amount, powers);
       if (actor.side === "player") {
         combat.playerBlock += gained;
       } else {
@@ -358,6 +369,11 @@ function dealDamageToEnemy(
   const afterBlock = Math.max(0, dmg - enemy.block);
   enemy.block = Math.max(0, enemy.block - dmg);
   enemy.hp = Math.max(0, enemy.hp - afterBlock);
+  // 拉加维林：睡眠中受到穿透格挡的伤害立即苏醒，去掉金属化。
+  if (enemy.asleep && afterBlock > 0 && enemy.hp > 0) {
+    enemy.asleep = false;
+    removePower(enemy.powers, "metallicize");
+  }
   if (
     enemy.stance === "offensive" &&
     enemy.modeShiftThreshold !== null &&
@@ -497,6 +513,11 @@ export function endTurn(state: GameState): void {
       state.log.push("你倒下了。");
       return;
     }
+    // 金属化：自己回合结束获得格挡（拉加维林睡眠期每回合回 8）。
+    const metallicize = getPower(enemy.powers, "metallicize");
+    if (metallicize > 0) {
+      enemy.block += metallicize;
+    }
     decayDebuffs(enemy.powers);
     // 下一招 telegraph（守卫者的姿态推进与防御→进攻切换在 selectNextMove 内处理）。
     selectNextMove(state, i);
@@ -520,11 +541,34 @@ function triggerOnTurnStart(enemy: EnemyState): void {
 // —— 敌人意图选择 ——
 
 function selectNextMove(state: GameState, enemyIndex: number): void {
-  const enemy = state.combat!.enemies[enemyIndex]!;
+  const combat = state.combat!;
+  const enemy = combat.enemies[enemyIndex]!;
   if (enemy.hp <= 0) {
     return;
   }
   const def = getEnemyDef(enemy.defId);
+
+  // 拉加维林：睡眠 → 苏醒 → 重击/重击/吸取灵魂 循环。
+  if (enemy.defId === "lagavulin") {
+    if (enemy.asleep) {
+      // 睡满（第 3 回合）自然苏醒；否则继续睡。
+      if (combat.turn >= LAGAVULIN_WAKE_TURN) {
+        enemy.asleep = false;
+        removePower(enemy.powers, "metallicize");
+        enemy.currentMove = "lag_attack";
+      } else {
+        enemy.currentMove = "sleep";
+      }
+      return;
+    }
+    const history = enemy.moveHistory;
+    const lastTwoAttack =
+      history.length >= 2 &&
+      history[history.length - 1] === "lag_attack" &&
+      history[history.length - 2] === "lag_attack";
+    enemy.currentMove = lastTwoAttack ? "siphon_soul" : "lag_attack";
+    return;
+  }
 
   // Boss：按姿态循环出招。
   if (def.stanceMoves) {

--- a/apps/spire/src/engine/enemies/enemies.ts
+++ b/apps/spire/src/engine/enemies/enemies.ts
@@ -286,6 +286,39 @@ const ENEMY_LIST: EnemyDef[] = [
     },
   },
 
+  // —— 精英：拉加维林（睡眠状态机 + 金属化 + 吸取灵魂减力量敏捷）——
+  {
+    id: "lagavulin",
+    name: "拉加维林",
+    hpMin: 109,
+    hpMax: 111,
+    moves: [
+      {
+        id: "sleep",
+        name: "沉睡",
+        effects: [],
+        intent: "unknown",
+      },
+      {
+        id: "lag_attack",
+        name: "重击",
+        effects: [{ kind: "deal_damage", amount: 18 }],
+        intent: "attack",
+      },
+      {
+        id: "siphon_soul",
+        name: "吸取灵魂",
+        effects: [
+          { kind: "apply_power", power: "strength", amount: -1, on: "target" },
+          { kind: "apply_power", power: "dexterity", amount: -1, on: "target" },
+        ],
+        intent: "debuff",
+      },
+    ],
+    // 出招由 combat.ts 的 lagavulin 专属分支处理（睡眠/苏醒/攻击循环），intentRule 留空。
+    intentRule: { scripted: [], weighted: [] },
+  },
+
   // —— 切片 Boss：守卫者（模式切换 = 引擎能力验证点，issue #234 C10）——
   {
     id: "the_guardian",
@@ -389,6 +422,7 @@ const ENCOUNTERS: Record<string, EncounterDef> = {
     isBoss: false,
   },
   gremlin_nob: { id: "gremlin_nob", enemies: ["gremlin_nob"], isBoss: false },
+  lagavulin: { id: "lagavulin", enemies: ["lagavulin"], isBoss: false },
   guardian: { id: "guardian", enemies: ["the_guardian"], isBoss: true },
 };
 
@@ -449,7 +483,10 @@ export function pickNormalEncounter(rng: RngState, combatsEntered: number): stri
 
 // Act1 精英池（等权重，不重复限制由 StS 的洗牌保证；此处简化为等权随机）。
 // 拉加维林 / 哨卫在 M3b-2 加入。
-const ELITE_ENCOUNTER_POOL: readonly WeightedEncounter[] = [{ id: "gremlin_nob", weight: 1 }];
+const ELITE_ENCOUNTER_POOL: readonly WeightedEncounter[] = [
+  { id: "gremlin_nob", weight: 1 },
+  { id: "lagavulin", weight: 1 },
+];
 
 /** 精英节点：从精英池挑一个 encounter id。 */
 export function pickEliteEncounter(rng: RngState): string {

--- a/apps/spire/src/engine/glossary.ts
+++ b/apps/spire/src/engine/glossary.ts
@@ -15,7 +15,17 @@ export const GLOSSARY: readonly GlossaryEntry[] = [
   {
     term: "力量",
     aliases: ["strength", "str"],
-    definition: "每有 1 层，攻击牌每次造成的伤害 +1（对多段攻击每段都 +1）。持续整场战斗。",
+    definition: "每有 1 层，攻击牌每次造成的伤害 +1（对多段攻击每段都 +1）。持续整场战斗，可为负。",
+  },
+  {
+    term: "敏捷",
+    aliases: ["dexterity", "dex"],
+    definition: "每有 1 层，获得的格挡 +1。持续整场战斗，可为负。",
+  },
+  {
+    term: "金属化",
+    aliases: ["metallicize"],
+    definition: "敌人专属：每当它的回合结束，获得等量的格挡。拉加维林睡眠期靠它维持护盾。",
   },
   {
     term: "易伤",

--- a/apps/spire/src/engine/powers/powers.ts
+++ b/apps/spire/src/engine/powers/powers.ts
@@ -27,10 +27,10 @@ function pruneEmpty(powers: PowerInstance[], id: PowerId): void {
     return;
   }
   const amount = powers[index]!.amount;
-  // 力量可为负并保留；易伤/虚弱/脆弱降到 0 即移除。
+  // 力量 / 敏捷可为负并保留；易伤/虚弱/脆弱降到 0 即移除。
   if ((id === "vulnerable" || id === "weak" || id === "frail") && amount <= 0) {
     powers.splice(index, 1);
-  } else if (amount === 0 && id !== "strength") {
+  } else if (amount === 0 && id !== "strength" && id !== "dexterity") {
     powers.splice(index, 1);
   }
 }
@@ -56,12 +56,19 @@ export function decayDebuffs(powers: PowerInstance[]): void {
   }
 }
 
-/** 脆弱下获得的格挡打七五折（向下取整）。作用于「获得格挡的一方」的 powers。 */
-export function applyFrailToBlock(amount: number, gainerPowers: readonly PowerInstance[]): number {
-  if (getPower(gainerPowers, "frail") > 0) {
-    return Math.floor(amount * 0.75);
+/**
+ * 计算实际获得的格挡：基础 + 敏捷 → ×脆弱0.75 → 向下取整、不低于 0。
+ * 作用于「获得格挡的一方」的 powers（敏捷可负）。
+ */
+export function computeBlockGain(amount: number, gainerPowers: readonly PowerInstance[]): number {
+  let value = amount + getPower(gainerPowers, "dexterity");
+  if (value < 0) {
+    value = 0;
   }
-  return amount;
+  if (getPower(gainerPowers, "frail") > 0) {
+    value = Math.floor(value * 0.75);
+  }
+  return value;
 }
 
 /**

--- a/apps/spire/src/engine/types.ts
+++ b/apps/spire/src/engine/types.ts
@@ -11,10 +11,12 @@ export type CardType = "attack" | "skill" | "power" | "status";
 
 /** 状态效果标识。切片集合：被动修正器 + 时机触发机制（见 powers/）。 */
 export type PowerId =
-  | "strength" // 力量：攻击伤害 +N（被动）
+  | "strength" // 力量：攻击伤害 +N（被动，可负、持续）
+  | "dexterity" // 敏捷：获得的格挡 +N（被动，可负、持续）
   | "vulnerable" // 易伤：受到攻击伤害 ×1.5（回合末 -1）
   | "weak" // 虚弱：造成攻击伤害 ×0.75（回合末 -1）
   | "frail" // 脆弱：获得的格挡 ×0.75（回合末 -1）
+  | "metallicize" // 金属化：每当自己回合结束，获得 N 点格挡（拉加维林睡眠期）
   | "ritual" // 仪式：回合开始 +N 力量（触发）
   | "curl_up" // 蜷缩：首次被攻击时获得格挡（触发，一次性）
   | "sharp_hide" // 反甲：被攻击时对攻击者（玩家）反弹 N 点无视格挡的伤害（守卫者防御姿态）
@@ -109,6 +111,8 @@ export type EnemyState = {
   curlUpConsumed: boolean;
   /** 出生时掷定、整场固定的攻击基础值（红虱咬击 5~7）。0 表示该敌人不用此机制。 */
   rolledDamage: number;
+  /** 是否沉睡（拉加维林开局睡眠；受伤或睡满自然醒时置 false）。 */
+  asleep: boolean;
   /** 守卫者：进攻姿态下累计受到的伤害（达阈值切姿态后清零，非每回合重置——复刻 StS 累计语义）。 */
   modeShiftAccum: number;
   modeShiftThreshold: number | null;

--- a/apps/spire/test/lagavulin.test.ts
+++ b/apps/spire/test/lagavulin.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat, playCard, endTurn } from "../src/engine/combat/combat.js";
+import { addPower, getPower, removePower } from "../src/engine/powers/powers.js";
+import type { CardInstance, EnemyState, GameState } from "../src/engine/types.js";
+
+// M3b-2：拉加维林——睡眠状态机 + 金属化 + 吸取灵魂（减力量/敏捷）+ 敏捷改格挡。asc0。
+
+function lagFight(seed = 1): GameState {
+  const s = newRun({ runId: `lag${seed}`, seed });
+  startCombat(s, "lagavulin");
+  s.hp = 500;
+  s.maxHp = 500;
+  return s;
+}
+
+function lag(s: GameState): EnemyState {
+  return s.combat!.enemies[0]!;
+}
+
+function play(s: GameState, defId: string, target: number | null = 0): void {
+  const card: CardInstance = { uid: s.nextUid++, defId, upgraded: false };
+  s.combat!.hand = [card];
+  s.combat!.energy = 3;
+  expect(playCard(s, 0, target).ok).toBe(true);
+}
+
+describe("拉加维林：开局睡眠", () => {
+  it("HP 109-111，开局沉睡 + 金属化8 + 8格挡 + 首招沉睡", () => {
+    for (let seed = 1; seed <= 15; seed += 1) {
+      const s = lagFight(seed);
+      expect(lag(s).hp).toBeGreaterThanOrEqual(109);
+      expect(lag(s).hp).toBeLessThanOrEqual(111);
+    }
+    const s = lagFight();
+    expect(lag(s).asleep).toBe(true);
+    expect(getPower(lag(s).powers, "metallicize")).toBe(8);
+    expect(lag(s).block).toBe(8);
+    expect(lag(s).currentMove).toBe("sleep");
+  });
+
+  it("睡眠期每回合结束回满 8 格挡、不攻击玩家", () => {
+    const s = lagFight();
+    endTurn(s);
+    expect(lag(s).block).toBe(8);
+    expect(s.hp).toBe(500); // 睡觉不打人
+  });
+});
+
+describe("拉加维林：苏醒", () => {
+  it("睡满第 3 回合自然苏醒、清金属化、改出重击", () => {
+    const s = lagFight();
+    endTurn(s);
+    endTurn(s);
+    endTurn(s);
+    expect(lag(s).asleep).toBe(false);
+    expect(getPower(lag(s).powers, "metallicize")).toBe(0);
+    expect(lag(s).currentMove).toBe("lag_attack");
+  });
+
+  it("受到穿透格挡的伤害立即苏醒并清金属化", () => {
+    const s = lagFight();
+    play(s, "bludgeon"); // 32 伤，破 8 格挡 → 苏醒
+    expect(lag(s).asleep).toBe(false);
+    expect(getPower(lag(s).powers, "metallicize")).toBe(0);
+  });
+
+  it("苏醒后重击造成 18", () => {
+    const s = lagFight();
+    endTurn(s);
+    endTurn(s);
+    endTurn(s); // 苏醒，telegraph 重击
+    endTurn(s); // 执行重击
+    expect(s.hp).toBe(500 - 18);
+  });
+});
+
+describe("吸取灵魂 + 敏捷", () => {
+  it("吸取灵魂令玩家 -1 力量 -1 敏捷", () => {
+    const s = lagFight();
+    const l = lag(s);
+    l.asleep = false;
+    removePower(l.powers, "metallicize");
+    l.currentMove = "siphon_soul";
+    addPower(s.combat!.playerPowers, "strength", 2);
+    addPower(s.combat!.playerPowers, "dexterity", 2);
+    endTurn(s);
+    expect(getPower(s.combat!.playerPowers, "strength")).toBe(1);
+    expect(getPower(s.combat!.playerPowers, "dexterity")).toBe(1);
+  });
+
+  it("敏捷改变获得的格挡（+2 → 防御5给7；-3 → 给2）", () => {
+    const s = lagFight();
+    addPower(s.combat!.playerPowers, "dexterity", 2);
+    play(s, "defend", null);
+    expect(s.combat!.playerBlock).toBe(7);
+
+    const s2 = lagFight();
+    addPower(s2.combat!.playerPowers, "dexterity", -3);
+    play(s2, "defend", null);
+    expect(s2.combat!.playerBlock).toBe(2);
+  });
+});


### PR DESCRIPTION
第二个第一幕精英，带一整套新机制。状态机 + 数值对齐 sts_lightspeed asc0。Refs #234。

## 新机制
- **敏捷(dexterity)**：改变获得的格挡（可负、持续）。`computeBlockGain` 统一「基础+敏捷 → ×脆弱0.75 → floor ≥0」。
- **金属化(metallicize)**：每当自己回合结束获得等量格挡。
- **睡眠状态机**（combat.ts lagavulin 专属分支，类守卫者姿态机）。

## 拉加维林 109-111
- 开局**沉睡**：金属化 8 + 立即 8 格挡，睡眠期每回合回满 8、不攻击。
- **苏醒**：受到穿透格挡的伤害立即醒 / 睡满第 3 回合自然醒（清金属化）。
- 醒后循环：重击 18 / 重击 / 吸取灵魂（玩家 −1 力量 −1 敏捷）——连两次重击后接吸取灵魂。

## 验证
门禁全绿：build/typecheck/lint(0)/format + **spire 78/78**（新增 `lagavulin.test.ts` 7 例：HP/开局睡眠、睡眠回8不打人、自然醒、受击即醒、醒后重击18、吸取灵魂减力量敏捷、敏捷改格挡±）· **agent 702**。sim stuck=0。

## 部署
spire + agent（敏捷/金属化 label）。合并后 `app:deploy spire` + `app:deploy agent`。哨卫在 M3b-3。