### PR TITLE
feat(spire): Boss 六火之灵 + 灼烧废牌 + Boss 随机化（阶段2 M3d-1）

### DIFF
--- a/apps/agent/static/context/spire-screen.hbs
+++ b/apps/agent/static/context/spire-screen.hbs
@@ -44,7 +44,7 @@
 你倒下了，这一局到此为止。生命 0/{{maxHp}}。
 想再来一局就调用 start_run。
 {{else if isVictory}}
-你击败了守卫者，登顶成功！生命 {{hp}}/{{maxHp}}。
+你击败了这一层的首领，登顶成功！生命 {{hp}}/{{maxHp}}。
 想再爬一次就调用 start_run。
 {{/if}}
 </spire_screen>

--- a/apps/spire/src/application/state-view.ts
+++ b/apps/spire/src/application/state-view.ts
@@ -141,11 +141,11 @@ function computeIntent(state: GameState, enemy: EnemyState): IntentView {
       };
     }
     if (effect.kind === "deal_damage_rolled") {
-      // 红虱咬击：基础值是本敌人出生时掷定的固定值。
+      // 红虱咬击 / 六火之灵分割：基础值是锁定的固定值，可多段。
       return {
         kind: "attack",
         value: computeAttackDamage(enemy.rolledDamage, enemy.powers, playerPowers),
-        hits: 1,
+        hits: effect.times ?? 1,
       };
     }
   }

--- a/apps/spire/src/engine/cards/cards.ts
+++ b/apps/spire/src/engine/cards/cards.ts
@@ -328,6 +328,18 @@ const CARD_LIST: CardDef[] = [
     upgradedDescription: "状态牌，无法打出。占用手牌，本场战斗结束后消失。",
   },
   {
+    id: "burn",
+    name: "灼烧",
+    type: "status",
+    cost: null,
+    targeted: false,
+    exhausts: false,
+    effects: [],
+    upgradedEffects: [],
+    description: "状态牌，无法打出。回合结束时若在手牌中，对你造成 2 点伤害。",
+    upgradedDescription: "状态牌，无法打出。回合结束时若在手牌中，对你造成 2 点伤害。",
+  },
+  {
     id: "dazed",
     name: "眩晕",
     type: "status",

--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -35,6 +35,18 @@ const LOUSE_BITE_MIN = 5;
 const LOUSE_BITE_MAX = 7;
 const LAGAVULIN_METALLICIZE = 8;
 const LAGAVULIN_WAKE_TURN = 3; // 睡满两回合、第 3 回合自然醒（combat.turn 从 1 起）。
+const BURN_DAMAGE = 2;
+
+// 六火之灵激活后的固定仪轨循环（Divider 之后重复）。
+const HEXAGHOST_RITUAL = [
+  "sear",
+  "tackle",
+  "sear",
+  "inflame",
+  "tackle",
+  "sear",
+  "inferno",
+] as const;
 
 type ActorRef = { side: "player" } | { side: "enemy"; index: number };
 
@@ -208,9 +220,21 @@ function applyEffect(
       break;
     }
     case "deal_damage_rolled": {
-      // 敌人专用：用出生时掷定、整场固定的基础值攻击玩家（红虱咬击）。
+      // 敌人专用：用锁定的固定基础值攻击玩家（红虱咬击 ×1；六火之灵分割 ×times）。
       if (actor.side === "enemy") {
-        dealDamageToPlayer(state, combat.enemies[actor.index]!.rolledDamage, powers);
+        const rolled = combat.enemies[actor.index]!.rolledDamage;
+        const times = effect.times ?? 1;
+        for (let hit = 0; hit < times; hit += 1) {
+          dealDamageToPlayer(state, rolled, powers);
+        }
+      }
+      break;
+    }
+    case "store_hp_scaled_damage": {
+      // 敌人专用：按玩家当前生命锁定每击伤害存入 rolledDamage（六火之灵激活）。
+      if (actor.side === "enemy") {
+        combat.enemies[actor.index]!.rolledDamage =
+          Math.floor(state.hp / effect.divisor) + effect.add;
       }
       break;
     }
@@ -423,6 +447,14 @@ function dealDamageToPlayer(
   state.hp = Math.max(0, state.hp - afterBlock);
 }
 
+/** 无来源的固定伤害（灼烧废牌），经玩家格挡但不受力量/易伤影响。 */
+function applyBurnDamage(state: GameState, amount: number): void {
+  const combat = state.combat!;
+  const afterBlock = Math.max(0, amount - combat.playerBlock);
+  combat.playerBlock = Math.max(0, combat.playerBlock - amount);
+  state.hp = Math.max(0, state.hp - afterBlock);
+}
+
 // —— 玩家出牌 ——
 
 export type PlayCardResult = { ok: true } | { ok: false; reason: string };
@@ -504,6 +536,16 @@ export function endTurn(state: GameState): void {
   if (!combat || state.screen !== "combat") {
     return;
   }
+  // 回合结束：手牌中每张灼烧对玩家造成 2 点伤害（经格挡，六火之灵）。
+  const burnCount = combat.hand.filter(instance => instance.defId === "burn").length;
+  for (let i = 0; i < burnCount; i += 1) {
+    applyBurnDamage(state, BURN_DAMAGE);
+  }
+  if (state.hp <= 0) {
+    state.screen = "gameover";
+    state.log.push("你倒下了。");
+    return;
+  }
   // 玩家回合结束：虚无牌被消耗，其余手牌进弃牌堆；玩家 debuff 衰减。
   for (const instance of combat.hand) {
     if (getCardDef(instance.defId).ethereal) {
@@ -568,6 +610,28 @@ function selectNextMove(state: GameState, enemyIndex: number): void {
     return;
   }
   const def = getEnemyDef(enemy.defId);
+
+  // 六火之灵：激活(锁分割伤害) → 分割(6连击) → 固定 7 段仪轨循环。
+  if (enemy.defId === "hexaghost") {
+    const history = enemy.moveHistory;
+    if (history.length === 0) {
+      enemy.currentMove = "activate";
+      return;
+    }
+    const last = history[history.length - 1]!;
+    if (last === "activate") {
+      enemy.currentMove = "divider";
+      return;
+    }
+    if (last === "divider") {
+      enemy.rotationIndex = 0;
+      enemy.currentMove = HEXAGHOST_RITUAL[0];
+      return;
+    }
+    enemy.rotationIndex = (enemy.rotationIndex + 1) % HEXAGHOST_RITUAL.length;
+    enemy.currentMove = HEXAGHOST_RITUAL[enemy.rotationIndex]!;
+    return;
+  }
 
   // 哨卫：错位开局（两侧先射钉、中间先光束）+ 光束↔射钉 严格交替。
   if (enemy.defId === "sentry") {

--- a/apps/spire/src/engine/enemies/enemies.ts
+++ b/apps/spire/src/engine/enemies/enemies.ts
@@ -406,6 +406,60 @@ const ENEMY_LIST: EnemyDef[] = [
     // Boss 出招走 stanceMoves 循环，不用 intentRule；留空满足类型。
     intentRule: { scripted: [], weighted: [] },
   },
+
+  // —— Boss：六火之灵（激活锁伤 → 分割6连 → 7 段仪轨循环）——
+  {
+    id: "hexaghost",
+    name: "六火之灵",
+    hpMin: 250,
+    hpMax: 250,
+    moves: [
+      {
+        id: "activate",
+        name: "激活",
+        effects: [{ kind: "store_hp_scaled_damage", divisor: 12, add: 1 }],
+        intent: "buff",
+      },
+      {
+        id: "divider",
+        name: "分割",
+        effects: [{ kind: "deal_damage_rolled", times: 6 }],
+        intent: "attack",
+      },
+      {
+        id: "sear",
+        name: "灼烧",
+        effects: [
+          { kind: "deal_damage", amount: 6 },
+          { kind: "add_card", cardId: "burn", pile: "discard", count: 1 },
+        ],
+        intent: "attack",
+      },
+      {
+        id: "tackle",
+        name: "冲撞",
+        effects: [{ kind: "deal_damage_multi", amount: 5, times: 2 }],
+        intent: "attack",
+      },
+      {
+        id: "inflame",
+        name: "燃焰",
+        effects: [
+          { kind: "gain_block", amount: 12 },
+          { kind: "apply_power", power: "strength", amount: 2, on: "self" },
+        ],
+        intent: "buff",
+      },
+      {
+        id: "inferno",
+        name: "地狱火",
+        effects: [{ kind: "deal_damage_multi", amount: 2, times: 6 }],
+        intent: "attack",
+      },
+    ],
+    // 出招由 combat.ts 的 hexaghost 专属分支处理，intentRule 留空。
+    intentRule: { scripted: [], weighted: [] },
+  },
 ];
 
 const ENEMY_MAP: ReadonlyMap<string, EnemyDef> = new Map(
@@ -449,6 +503,7 @@ const ENCOUNTERS: Record<string, EncounterDef> = {
   lagavulin: { id: "lagavulin", enemies: ["lagavulin"], isBoss: false },
   three_sentries: { id: "three_sentries", enemies: ["sentry", "sentry", "sentry"], isBoss: false },
   guardian: { id: "guardian", enemies: ["the_guardian"], isBoss: true },
+  hexaghost: { id: "hexaghost", enemies: ["hexaghost"], isBoss: true },
 };
 
 export function getEncounterDef(id: string): EncounterDef {
@@ -517,4 +572,15 @@ const ELITE_ENCOUNTER_POOL: readonly WeightedEncounter[] = [
 /** 精英节点：从精英池挑一个 encounter id。 */
 export function pickEliteEncounter(rng: RngState): string {
   return weightedPick(rng, ELITE_ENCOUNTER_POOL);
+}
+
+// Act1 Boss 池（等权重随机）。史莱姆王待分裂机制里程碑加入。
+const BOSS_ENCOUNTER_POOL: readonly WeightedEncounter[] = [
+  { id: "guardian", weight: 1 },
+  { id: "hexaghost", weight: 1 },
+];
+
+/** Boss 节点：随机挑一个 Boss encounter id。 */
+export function pickBossEncounter(rng: RngState): string {
+  return weightedPick(rng, BOSS_ENCOUNTER_POOL);
 }

--- a/apps/spire/src/engine/run/run.ts
+++ b/apps/spire/src/engine/run/run.ts
@@ -1,6 +1,6 @@
 import type { GameState, MapNode, MapNodeType } from "../types.js";
 import { REWARD_CARD_POOL, getCardDef, costOf } from "../cards/cards.js";
-import { pickEliteEncounter, pickNormalEncounter } from "../enemies/enemies.js";
+import { pickBossEncounter, pickEliteEncounter, pickNormalEncounter } from "../enemies/enemies.js";
 import { COMMON_RELIC_POOL, getRelicDef, hasRelic } from "../relics/relics.js";
 import { nextInt, nextRange } from "../rng.js";
 import { startCombat } from "../combat/combat.js";
@@ -53,7 +53,7 @@ function resolveNode(state: GameState, node: MapNode): void {
       return;
     }
     case "boss": {
-      startCombat(state, "guardian");
+      startCombat(state, pickBossEncounter(state.rng));
       return;
     }
     case "rest": {

--- a/apps/spire/src/engine/types.ts
+++ b/apps/spire/src/engine/types.ts
@@ -33,8 +33,10 @@ export type Effect =
   // 每次命中随机挑一个存活敌人（剑刃回旋镖：3 点 ×3，逐次随机目标）。
   | { kind: "deal_damage_random"; amount: number; times: number }
   | { kind: "deal_damage_equal_to_block" }
-  // 敌人用：伤害取自本敌人出生时掷定的固定值（红虱咬击：整场用同一个 5~7 基础值）。
-  | { kind: "deal_damage_rolled" }
+  // 敌人用：伤害取自本敌人锁定的固定值（红虱咬击；六火之灵分割 times 连击）。
+  | { kind: "deal_damage_rolled"; times?: number }
+  // 敌人用：按玩家当前生命锁定一个每击伤害存入 rolledDamage（六火之灵激活：floor(hp/divisor)+add）。
+  | { kind: "store_hp_scaled_damage"; divisor: number; add: number }
   | { kind: "gain_block"; amount: number }
   | { kind: "apply_power"; power: PowerId; amount: number; on: "self" | "target" | "all_enemies" }
   | { kind: "draw"; amount: number }

--- a/apps/spire/test/hexaghost.test.ts
+++ b/apps/spire/test/hexaghost.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat, endTurn } from "../src/engine/combat/combat.js";
+import { getPower } from "../src/engine/powers/powers.js";
+import { pickBossEncounter } from "../src/engine/enemies/enemies.js";
+import { seedRng } from "../src/engine/rng.js";
+import type { CardInstance, EnemyState, GameState } from "../src/engine/types.js";
+
+// M3d-1：六火之灵——激活锁伤 → 分割6连 → 7 段仪轨；灼烧废牌。asc0。
+
+function hexFight(hp = 500): GameState {
+  const s = newRun({ runId: "hex", seed: 1 });
+  startCombat(s, "hexaghost");
+  s.hp = hp;
+  s.maxHp = 500;
+  return s;
+}
+
+function hex(s: GameState): EnemyState {
+  return s.combat!.enemies[0]!;
+}
+
+describe("六火之灵：开局与仪轨", () => {
+  it("HP 250，首招激活", () => {
+    const s = hexFight();
+    expect(hex(s).hp).toBe(250);
+    expect(hex(s).currentMove).toBe("activate");
+  });
+
+  it("固定序列：激活→分割→灼烧→冲撞→灼烧→燃焰→冲撞→灼烧→地狱火→灼烧(循环)", () => {
+    const s = hexFight();
+    const seq: string[] = [hex(s).currentMove];
+    for (let i = 0; i < 9; i += 1) {
+      endTurn(s);
+      seq.push(hex(s).currentMove);
+    }
+    expect(seq).toEqual([
+      "activate",
+      "divider",
+      "sear",
+      "tackle",
+      "sear",
+      "inflame",
+      "tackle",
+      "sear",
+      "inferno",
+      "sear",
+    ]);
+  });
+});
+
+describe("分割伤害按玩家生命锁定", () => {
+  it("玩家 120 血 → 每击 floor(120/12)+1=11，×6=66", () => {
+    const s = hexFight(120);
+    endTurn(s); // 激活：锁定每击 11
+    expect(hex(s).rolledDamage).toBe(11);
+    endTurn(s); // 分割：11×6=66
+    expect(s.hp).toBe(120 - 66);
+  });
+
+  it("激活本身不造成伤害", () => {
+    const s = hexFight(120);
+    endTurn(s);
+    expect(s.hp).toBe(120);
+  });
+});
+
+describe("灼烧废牌", () => {
+  it("灼烧塞 1 张灼烧进弃牌堆", () => {
+    const s = hexFight();
+    hex(s).currentMove = "sear";
+    const before = s.combat!.discardPile.filter(c => c.defId === "burn").length;
+    endTurn(s);
+    const after = s.combat!.discardPile.filter(c => c.defId === "burn").length;
+    expect(after - before).toBe(1);
+  });
+
+  it("手牌里的灼烧回合结束造成 2 伤害（经格挡）", () => {
+    const s = hexFight(100);
+    const burn: CardInstance = { uid: s.nextUid++, defId: "burn", upgraded: false };
+    s.combat!.hand = [burn];
+    endTurn(s);
+    expect(s.hp).toBe(98); // 激活无伤，仅灼烧 2
+
+    const s2 = hexFight(100);
+    const burn2: CardInstance = { uid: s2.nextUid++, defId: "burn", upgraded: false };
+    s2.combat!.hand = [burn2];
+    s2.combat!.playerBlock = 5;
+    endTurn(s2);
+    expect(s2.hp).toBe(100); // 格挡吸收 2
+  });
+});
+
+describe("燃焰", () => {
+  it("获得 12 格挡 + 2 力量", () => {
+    const s = hexFight();
+    hex(s).currentMove = "inflame";
+    endTurn(s);
+    expect(hex(s).block).toBe(12);
+    expect(getPower(hex(s).powers, "strength")).toBe(2);
+  });
+});
+
+describe("Boss 随机选择", () => {
+  it("只从 guardian / hexaghost 里选", () => {
+    const seen = new Set<string>();
+    for (let seed = 0; seed < 60; seed += 1) {
+      seen.add(pickBossEncounter(seedRng(seed)));
+    }
+    expect(seen.has("guardian")).toBe(true);
+    expect(seen.has("hexaghost")).toBe(true);
+    for (const id of seen) {
+      expect(["guardian", "hexaghost"]).toContain(id);
+    }
+  });
+});


### PR DESCRIPTION
第一幕**第二个 Boss**，Boss 节点不再固定守卫者。仪轨/数值对齐 sts_lightspeed asc0。Refs #234。

## 六火之灵 250
- **激活**：按玩家当前生命锁定每击伤害 `floor(hp/12)+1`（不造成伤害）。
- **分割**：锁定值 ×6 连击（满血 80 → 7×6=42）。
- **7 段固定仪轨**循环：灼烧(6+塞1灼烧废牌) / 冲撞(5×2) / 灼烧 / 燃焰(格挡12+力量2) / 冲撞 / 灼烧 / 地狱火(2×6)。

## 新机制
- `deal_damage_rolled` 加 `times`（分割 6 连，复用红虱咬击）、`store_hp_scaled_damage`（按生命锁伤）。
- **灼烧(burn)** 状态牌：不可打出；回合结束若在手牌则对玩家造成 2 点（经格挡）伤害。
- **Boss 随机化**：`pickBossEncounter` 从 [守卫者/六火之灵] 等权选（史莱姆王待分裂机制里程碑）。

## 验证
门禁全绿：build/typecheck/lint(0)/format + **spire 93/93**（新增 `hexaghost.test.ts` 8 例：HP/首招、完整 7 段序列、分割按生命锁伤 11×6、激活无伤、灼烧塞废牌+手牌 2 伤经格挡、燃焰格挡12力量2、Boss 随机池）· **agent 702**。sim 贪心 300 局胜场 17、stuck=0。

## 部署
spire + agent（胜利屏文案 + 意图多段）。合并后 `app:deploy spire` + `app:deploy agent`。