### PR TITLE
feat(spire): 真菌兽 + 亡语钩子 + 孢子云（阶段2 M3c-1）

### DIFF
--- a/apps/agent/src/agent/capabilities/spire/render/spire-screen.ts
+++ b/apps/agent/src/agent/capabilities/spire/render/spire-screen.ts
@@ -27,6 +27,8 @@ const POWER_LABELS: Record<string, string> = {
   sharp_hide: "反甲",
   enrage: "激怒",
   artifact: "神器",
+  angry: "狂怒",
+  spore_cloud: "孢子云",
   mode_shift: "模式",
 };
 

--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -85,6 +85,10 @@ function createEnemyState(state: GameState, defId: string, hpOverride?: number):
     // 哨卫开局各带 1 层神器（抵消你首个减益）。
     powers.push({ id: "artifact", amount: 1 });
   }
+  if (defId === "fungi_beast") {
+    // 真菌兽开局自带孢子云（显示用；死亡给玩家 2 易伤由 deathEffects 结算）。
+    powers.push({ id: "spore_cloud", amount: 2 });
+  }
   const hp = hpOverride ?? nextRange(state.rng, def.hpMin, def.hpMax);
   return {
     defId,
@@ -411,7 +415,15 @@ function dealDamageToEnemy(
   }
   const afterBlock = Math.max(0, dmg - enemy.block);
   enemy.block = Math.max(0, enemy.block - dmg);
+  const wasAlive = enemy.hp > 0;
   enemy.hp = Math.max(0, enemy.hp - afterBlock);
+  // 亡语：此击致死则结算敌人的死亡效果（真菌兽孢子云给玩家易伤）。
+  if (wasAlive && enemy.hp === 0) {
+    const dyingDef = getEnemyDef(enemy.defId);
+    if (dyingDef.deathEffects) {
+      applyEffects(state, dyingDef.deathEffects, { side: "enemy", index: enemyIndex }, null);
+    }
+  }
   // 拉加维林：睡眠中受到穿透格挡的伤害立即苏醒，去掉金属化。
   if (enemy.asleep && afterBlock > 0 && enemy.hp > 0) {
     enemy.asleep = false;

--- a/apps/spire/src/engine/enemies/enemies.ts
+++ b/apps/spire/src/engine/enemies/enemies.ts
@@ -247,6 +247,36 @@ const ENEMY_LIST: EnemyDef[] = [
     },
   },
 
+  {
+    id: "fungi_beast",
+    name: "真菌兽",
+    hpMin: 22,
+    hpMax: 28,
+    deathEffects: [{ kind: "apply_power", power: "vulnerable", amount: 2, on: "target" }],
+    moves: [
+      {
+        id: "fungi_bite",
+        name: "撕咬",
+        effects: [{ kind: "deal_damage", amount: 6 }],
+        intent: "attack",
+      },
+      {
+        id: "fungi_grow",
+        name: "成长",
+        effects: [{ kind: "apply_power", power: "strength", amount: 3, on: "self" }],
+        intent: "buff",
+      },
+    ],
+    // 连两次撕咬后强制成长；刚成长完回撕咬；否则随机（近似权重）。
+    intentRule: {
+      scripted: [],
+      weighted: [
+        { move: "fungi_bite", weight: 60, maxInARow: 2 },
+        { move: "fungi_grow", weight: 40, maxInARow: 1 },
+      ],
+    },
+  },
+
   // —— 精英：地精头目（Enrage = 玩家出技能牌它加力量）——
   {
     id: "gremlin_nob",
@@ -607,6 +637,11 @@ const ENCOUNTERS: Record<string, EncounterDef> = {
   three_sentries: { id: "three_sentries", enemies: ["sentry", "sentry", "sentry"], isBoss: false },
   large_slime_acid: { id: "large_slime_acid", enemies: ["acid_slime_l"], isBoss: false },
   large_slime_spike: { id: "large_slime_spike", enemies: ["spike_slime_l"], isBoss: false },
+  two_fungi_beasts: {
+    id: "two_fungi_beasts",
+    enemies: ["fungi_beast", "fungi_beast"],
+    isBoss: false,
+  },
   guardian: { id: "guardian", enemies: ["the_guardian"], isBoss: true },
   hexaghost: { id: "hexaghost", enemies: ["hexaghost"], isBoss: true },
   slime_boss: { id: "slime_boss", enemies: ["slime_boss"], isBoss: true },
@@ -642,6 +677,7 @@ const STRONG_ENCOUNTER_POOL: readonly WeightedEncounter[] = [
   { id: "blue_slaver", weight: 2 },
   { id: "three_louse", weight: 2 },
   { id: "large_slime", weight: 2 }, // 选中后 50/50 展开为 酸液大 / 尖刺大
+  { id: "two_fungi_beasts", weight: 2 },
   { id: "lots_of_slimes", weight: 1 },
 ];
 

--- a/apps/spire/src/engine/glossary.ts
+++ b/apps/spire/src/engine/glossary.ts
@@ -58,6 +58,11 @@ export const GLOSSARY: readonly GlossaryEntry[] = [
     definition: "敌人专属：你每打出一张技能牌，它就获得等于层数的力量。地精头目开局自带。",
   },
   {
+    term: "孢子云",
+    aliases: ["spore cloud", "sporecloud"],
+    definition: "敌人专属：它死亡时对你施加 2 层易伤。真菌兽自带——秒杀它反而会吃到易伤。",
+  },
+  {
     term: "反甲",
     aliases: ["sharp hide", "sharphide", "thorns"],
     definition:

--- a/apps/spire/src/engine/types.ts
+++ b/apps/spire/src/engine/types.ts
@@ -22,6 +22,8 @@ export type PowerId =
   | "sharp_hide" // 反甲：被攻击时对攻击者（玩家）反弹 N 点无视格挡的伤害（守卫者防御姿态）
   | "enrage" // 激怒：玩家每打出一张技能牌，此敌人获得 = 层数的力量（地精头目）
   | "artifact" // 神器：抵消下一个施加到自己身上的减益（每抵消一个消耗一层）
+  | "angry" // 狂怒：每次受到攻击伤害，获得 = 层数的力量（狂暴地精）
+  | "spore_cloud" // 孢子云：死亡时给玩家施加易伤（真菌兽，显示用；实际死亡效果在 deathEffects）
   | "mode_shift"; // 模式切换累计（守卫者，内部计数用）
 
 /** 玩家出牌 / 敌人出招共用的效果原语。target 相对「行动者」解析。 */
@@ -99,6 +101,8 @@ export type EnemyDef = {
   stanceMoves?: { offensive: string[]; defensive: string[] };
   /** 半血分裂：降到 ≤maxHp/2 时分裂成这些敌人（各自 HP = 分裂瞬间当前 HP）。 */
   splitInto?: string[];
+  /** 亡语：此敌人死亡时结算的效果（真菌兽孢子云给玩家易伤）。 */
+  deathEffects?: Effect[];
 };
 
 export type EnemyState = {

--- a/apps/spire/test/enemies-act1.test.ts
+++ b/apps/spire/test/enemies-act1.test.ts
@@ -55,6 +55,7 @@ describe("Act1 战斗池节奏：前 3 场 weak、其余 strong", () => {
     "lots_of_slimes",
     "large_slime_acid",
     "large_slime_spike",
+    "two_fungi_beasts",
   ]);
 
   it("combatsEntered < 3 只抽 weak 池", () => {

--- a/apps/spire/test/fungi.test.ts
+++ b/apps/spire/test/fungi.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat, playCard } from "../src/engine/combat/combat.js";
+import { getPower } from "../src/engine/powers/powers.js";
+import { getEncounterDef } from "../src/engine/enemies/enemies.js";
+import type { CardInstance, GameState } from "../src/engine/types.js";
+
+// M3c-1：真菌兽 + 亡语（孢子云死亡给玩家易伤）+ on-death 钩子。asc0。
+
+function fungiFight(): GameState {
+  const s = newRun({ runId: "fungi", seed: 1 });
+  startCombat(s, "two_fungi_beasts");
+  s.hp = 500;
+  s.maxHp = 500;
+  return s;
+}
+
+function play(s: GameState, defId: string, target: number | null): void {
+  const card: CardInstance = { uid: s.nextUid++, defId, upgraded: false };
+  s.combat!.hand = [card];
+  s.combat!.energy = 3;
+  expect(playCard(s, 0, target).ok).toBe(true);
+}
+
+describe("真菌兽：孢子云亡语", () => {
+  it("HP 22-28，开局自带孢子云 2", () => {
+    const s = fungiFight();
+    for (const e of s.combat!.enemies) {
+      expect(e.hp).toBeGreaterThanOrEqual(22);
+      expect(e.hp).toBeLessThanOrEqual(28);
+      expect(getPower(e.powers, "spore_cloud")).toBe(2);
+    }
+  });
+
+  it("杀死真菌兽 → 玩家被施加 2 层易伤", () => {
+    const s = fungiFight();
+    s.combat!.enemies[0]!.hp = 5;
+    play(s, "bludgeon", 0); // 32 伤，杀死 0 号
+    expect(s.combat!.enemies[0]!.hp).toBe(0);
+    expect(getPower(s.combat!.playerPowers, "vulnerable")).toBe(2);
+  });
+
+  it("亡语只在致死时触发一次（多段攻击不叠加）", () => {
+    const s = fungiFight();
+    s.combat!.enemies[0]!.hp = 3;
+    play(s, "pummel", 0); // 2×4 多段，第 2 段致死，后续段不再触发亡语
+    expect(s.combat!.enemies[0]!.hp).toBe(0);
+    expect(getPower(s.combat!.playerPowers, "vulnerable")).toBe(2); // 仍是 2，不是 4/6/8
+  });
+
+  it("未致死不触发亡语", () => {
+    const s = fungiFight();
+    play(s, "strike", 0); // 6 伤，真菌兽 22+ 不死
+    expect(getPower(s.combat!.playerPowers, "vulnerable")).toBe(0);
+  });
+});
+
+describe("真菌兽组进 strong 池", () => {
+  it("双真菌兽 encounter 组成正确", () => {
+    expect(getEncounterDef("two_fungi_beasts").enemies).toEqual(["fungi_beast", "fungi_beast"]);
+  });
+});


### PR DESCRIPTION
治「图里怪太少」：strong 池加真菌兽，引入**亡语(on-death)机制**。数值对齐 sts_lightspeed asc0。Refs #234。

## 改动
- **亡语机制**：`EnemyDef.deathEffects`，敌人被此击致死时结算一次（`dealDamageToEnemy` 里 wasAlive→hp0 判定，多段攻击只触发一次）。可复用的 on-death 钩子。
- **真菌兽** 22-28：撕咬6 / 成长(+3力量)；开局自带**孢子云2**（显示），死亡时给玩家 **2 易伤**——秒杀它反被上易伤的经典博弈。
- 双真菌兽组进 strong 池（权重2）；术语「孢子云」+ agent POWER_LABELS 同步。

## 验证
门禁全绿：build/typecheck/lint(0)/format + **spire 105/105**（新增 `fungi.test.ts` 5 例：HP/孢子云、杀死上2易伤、多段只触发一次、未致死不触发、encounter 组成）· **agent 702**。sim stuck=0、胜场 25。

## 部署
spire + agent（孢子云 label）。合并后 `app:deploy spire` + `app:deploy agent`。