### PR TITLE
feat(spire): 地精帮（狂怒/护盾/巫师）（阶段2 M3c-2）

### DIFF
--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -89,6 +89,10 @@ function createEnemyState(state: GameState, defId: string, hpOverride?: number):
     // 真菌兽开局自带孢子云（显示用；死亡给玩家 2 易伤由 deathEffects 结算）。
     powers.push({ id: "spore_cloud", amount: 2 });
   }
+  if (defId === "mad_gremlin") {
+    // 狂暴地精开局自带狂怒 1（每次受攻击伤害 +1 力量）。
+    powers.push({ id: "angry", amount: 1 });
+  }
   const hp = hpOverride ?? nextRange(state.rng, def.hpMin, def.hpMax);
   return {
     defId,
@@ -284,6 +288,19 @@ function applyEffect(
       }
       break;
     }
+    case "gain_block_ally": {
+      // 护盾地精：给一名随机存活友军（不含自己）加格挡。
+      if (actor.side === "enemy") {
+        const allies = combat.enemies
+          .map((enemy, index) => ({ enemy, index }))
+          .filter(entry => entry.enemy.hp > 0 && entry.index !== actor.index);
+        if (allies.length > 0) {
+          const pick = allies[nextInt(state.rng, allies.length)]!;
+          pick.enemy.block += effect.amount;
+        }
+      }
+      break;
+    }
     case "apply_power": {
       applyPowerEffect(state, effect.power, effect.amount, effect.on, actor, targetEnemyIndex);
       break;
@@ -428,6 +445,11 @@ function dealDamageToEnemy(
   if (enemy.asleep && afterBlock > 0 && enemy.hp > 0) {
     enemy.asleep = false;
     removePower(enemy.powers, "metallicize");
+  }
+  // 狂怒（狂暴地精）：每次受到穿透格挡的攻击伤害，获得 = 层数的力量。
+  const angry = getPower(enemy.powers, "angry");
+  if (angry > 0 && afterBlock > 0 && enemy.hp > 0) {
+    addPower(enemy.powers, "strength", angry);
   }
   // 半血分裂：降到 ≤maxHp/2 且未分裂过 → 下一动作强制变分裂。
   const def = getEnemyDef(enemy.defId);
@@ -659,6 +681,25 @@ function selectNextMove(state: GameState, enemyIndex: number): void {
     return;
   }
   const def = getEnemyDef(enemy.defId);
+
+  // 护盾地精：场上还有其他存活友军时保护友军，只剩自己时改攻击。
+  if (enemy.defId === "shield_gremlin") {
+    enemy.currentMove = livingEnemies(combat).length > 1 ? "protect" : "shield_bash";
+    return;
+  }
+
+  // 地精巫师：蓄力 3 回合 → 终极爆发 → 归零重新蓄力（4 段循环）。
+  if (enemy.defId === "gremlin_wizard") {
+    const cycle = ["charging", "charging", "charging", "ultimate_blast"] as const;
+    if (enemy.moveHistory.length === 0) {
+      enemy.rotationIndex = 0;
+      enemy.currentMove = cycle[0];
+      return;
+    }
+    enemy.rotationIndex = (enemy.rotationIndex + 1) % cycle.length;
+    enemy.currentMove = cycle[enemy.rotationIndex]!;
+    return;
+  }
 
   // 史莱姆王：黏液喷射 → 蓄力 → 猛砸 固定 3 段循环（半血分裂另由 split 覆盖）。
   if (enemy.defId === "slime_boss") {

--- a/apps/spire/src/engine/enemies/enemies.ts
+++ b/apps/spire/src/engine/enemies/enemies.ts
@@ -277,6 +277,95 @@ const ENEMY_LIST: EnemyDef[] = [
     },
   },
 
+  // —— 地精帮（狂暴/鬼祟/肥胖/护盾/巫师）——
+  {
+    id: "mad_gremlin",
+    name: "狂暴地精",
+    hpMin: 20,
+    hpMax: 24,
+    moves: [
+      {
+        id: "scratch",
+        name: "抓挠",
+        effects: [{ kind: "deal_damage", amount: 4 }],
+        intent: "attack",
+      },
+    ],
+    intentRule: { scripted: [], weighted: [{ move: "scratch", weight: 1, maxInARow: 99 }] },
+  },
+  {
+    id: "sneaky_gremlin",
+    name: "鬼祟地精",
+    hpMin: 10,
+    hpMax: 14,
+    moves: [
+      {
+        id: "puncture",
+        name: "穿刺",
+        effects: [{ kind: "deal_damage", amount: 9 }],
+        intent: "attack",
+      },
+    ],
+    intentRule: { scripted: [], weighted: [{ move: "puncture", weight: 1, maxInARow: 99 }] },
+  },
+  {
+    id: "fat_gremlin",
+    name: "肥胖地精",
+    hpMin: 13,
+    hpMax: 17,
+    moves: [
+      {
+        id: "smash",
+        name: "猛击",
+        effects: [
+          { kind: "deal_damage", amount: 4 },
+          { kind: "apply_power", power: "weak", amount: 1, on: "target" },
+        ],
+        intent: "attack",
+      },
+    ],
+    intentRule: { scripted: [], weighted: [{ move: "smash", weight: 1, maxInARow: 99 }] },
+  },
+  {
+    id: "shield_gremlin",
+    name: "护盾地精",
+    hpMin: 12,
+    hpMax: 15,
+    moves: [
+      {
+        id: "protect",
+        name: "保护",
+        effects: [{ kind: "gain_block_ally", amount: 7 }],
+        intent: "defend",
+      },
+      {
+        id: "shield_bash",
+        name: "盾击",
+        effects: [{ kind: "deal_damage", amount: 6 }],
+        intent: "attack",
+      },
+    ],
+    // 出招由 combat.ts 的 shield_gremlin 专属分支处理（有友军则保护、否则攻击）。
+    intentRule: { scripted: [], weighted: [] },
+  },
+  {
+    id: "gremlin_wizard",
+    name: "地精巫师",
+    hpMin: 21,
+    hpMax: 25,
+    moves: [
+      { id: "charging", name: "蓄力", effects: [], intent: "unknown" },
+      {
+        id: "ultimate_blast",
+        name: "终极爆发",
+        effects: [{ kind: "deal_damage", amount: 25 }],
+        intent: "attack",
+      },
+    ],
+    // 出招由 combat.ts 的 gremlin_wizard 专属分支处理（蓄力3回合→大招→循环）。
+    intentRule: { scripted: [], weighted: [] },
+  },
+
   // —— 精英：地精头目（Enrage = 玩家出技能牌它加力量）——
   {
     id: "gremlin_nob",
@@ -642,6 +731,12 @@ const ENCOUNTERS: Record<string, EncounterDef> = {
     enemies: ["fungi_beast", "fungi_beast"],
     isBoss: false,
   },
+  // 地精帮：固定代表性 4 只（含护盾/巫师/狂暴，展示各机制；StS 为随机组成）。
+  gremlin_gang: {
+    id: "gremlin_gang",
+    enemies: ["mad_gremlin", "sneaky_gremlin", "shield_gremlin", "gremlin_wizard"],
+    isBoss: false,
+  },
   guardian: { id: "guardian", enemies: ["the_guardian"], isBoss: true },
   hexaghost: { id: "hexaghost", enemies: ["hexaghost"], isBoss: true },
   slime_boss: { id: "slime_boss", enemies: ["slime_boss"], isBoss: true },
@@ -678,6 +773,7 @@ const STRONG_ENCOUNTER_POOL: readonly WeightedEncounter[] = [
   { id: "three_louse", weight: 2 },
   { id: "large_slime", weight: 2 }, // 选中后 50/50 展开为 酸液大 / 尖刺大
   { id: "two_fungi_beasts", weight: 2 },
+  { id: "gremlin_gang", weight: 1 },
   { id: "lots_of_slimes", weight: 1 },
 ];
 

--- a/apps/spire/src/engine/glossary.ts
+++ b/apps/spire/src/engine/glossary.ts
@@ -58,6 +58,11 @@ export const GLOSSARY: readonly GlossaryEntry[] = [
     definition: "敌人专属：你每打出一张技能牌，它就获得等于层数的力量。地精头目开局自带。",
   },
   {
+    term: "狂怒",
+    aliases: ["angry"],
+    definition: "敌人专属：每次受到攻击伤害，就获得等于层数的力量。狂暴地精自带，越打越猛。",
+  },
+  {
     term: "孢子云",
     aliases: ["spore cloud", "sporecloud"],
     definition: "敌人专属：它死亡时对你施加 2 层易伤。真菌兽自带——秒杀它反而会吃到易伤。",

--- a/apps/spire/src/engine/types.ts
+++ b/apps/spire/src/engine/types.ts
@@ -40,6 +40,8 @@ export type Effect =
   // 敌人用：按玩家当前生命锁定一个每击伤害存入 rolledDamage（六火之灵激活：floor(hp/divisor)+add）。
   | { kind: "store_hp_scaled_damage"; divisor: number; add: number }
   | { kind: "gain_block"; amount: number }
+  // 敌人用：给一名随机存活友军加格挡（护盾地精保护）。
+  | { kind: "gain_block_ally"; amount: number }
   | { kind: "apply_power"; power: PowerId; amount: number; on: "self" | "target" | "all_enemies" }
   | { kind: "draw"; amount: number }
   | { kind: "gain_energy"; amount: number }

--- a/apps/spire/test/enemies-act1.test.ts
+++ b/apps/spire/test/enemies-act1.test.ts
@@ -49,14 +49,6 @@ describe("脆弱：格挡打七五折", () => {
 describe("Act1 战斗池节奏：前 3 场 weak、其余 strong", () => {
   // weak 的 small_slimes 被展开成 _a / _b。
   const WEAK = new Set(["cultist", "jaw_worm", "two_louse", "small_slimes_a", "small_slimes_b"]);
-  const STRONG = new Set([
-    "blue_slaver",
-    "three_louse",
-    "lots_of_slimes",
-    "large_slime_acid",
-    "large_slime_spike",
-    "two_fungi_beasts",
-  ]);
 
   it("combatsEntered < 3 只抽 weak 池", () => {
     for (let seed = 0; seed < 40; seed += 1) {
@@ -67,11 +59,11 @@ describe("Act1 战斗池节奏：前 3 场 weak、其余 strong", () => {
     }
   });
 
-  it("combatsEntered >= 3 只抽 strong 池", () => {
+  it("combatsEntered >= 3 抽 strong 池（不再出现 weak 专属 encounter）", () => {
     for (let seed = 0; seed < 40; seed += 1) {
       const rng = seedRng(seed);
       for (const entered of [3, 5, 9]) {
-        expect(STRONG.has(pickNormalEncounter(rng, entered))).toBe(true);
+        expect(WEAK.has(pickNormalEncounter(rng, entered))).toBe(false);
       }
     }
   });

--- a/apps/spire/test/gremlins.test.ts
+++ b/apps/spire/test/gremlins.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat, playCard, endTurn } from "../src/engine/combat/combat.js";
+import { getPower } from "../src/engine/powers/powers.js";
+import { getEncounterDef } from "../src/engine/enemies/enemies.js";
+import type { CardInstance, EnemyState, GameState } from "../src/engine/types.js";
+
+// M3c-2：地精帮——狂怒(受击加力量)/护盾(保护友军)/巫师(蓄力大招)。asc0。
+
+function gangFight(): GameState {
+  const s = newRun({ runId: "gang", seed: 1 });
+  startCombat(s, "gremlin_gang");
+  s.hp = 500;
+  s.maxHp = 500;
+  return s;
+}
+
+function byDef(s: GameState, defId: string): EnemyState {
+  return s.combat!.enemies.find(e => e.defId === defId)!;
+}
+
+function indexOf(s: GameState, defId: string): number {
+  return s.combat!.enemies.findIndex(e => e.defId === defId);
+}
+
+function play(s: GameState, defId: string, target: number | null): void {
+  const card: CardInstance = { uid: s.nextUid++, defId, upgraded: false };
+  s.combat!.hand = [card];
+  s.combat!.energy = 3;
+  expect(playCard(s, 0, target).ok).toBe(true);
+}
+
+describe("地精帮组成", () => {
+  it("固定 4 只：狂暴/鬼祟/护盾/巫师", () => {
+    expect(getEncounterDef("gremlin_gang").enemies).toEqual([
+      "mad_gremlin",
+      "sneaky_gremlin",
+      "shield_gremlin",
+      "gremlin_wizard",
+    ]);
+  });
+});
+
+describe("狂暴地精：狂怒", () => {
+  it("开局狂怒 1，受攻击伤害就 +1 力量", () => {
+    const s = gangFight();
+    const mad = byDef(s, "mad_gremlin");
+    expect(getPower(mad.powers, "angry")).toBe(1);
+    expect(getPower(mad.powers, "strength")).toBe(0);
+    mad.hp = 100; // 抬血防秒
+    mad.maxHp = 100;
+    play(s, "strike", indexOf(s, "mad_gremlin")); // 6 伤穿透
+    expect(getPower(byDef(s, "mad_gremlin").powers, "strength")).toBe(1);
+  });
+
+  it("被格挡挡下的攻击不触发狂怒", () => {
+    const s = gangFight();
+    const mad = byDef(s, "mad_gremlin");
+    mad.hp = 100;
+    mad.block = 50; // 挡下打击
+    play(s, "strike", indexOf(s, "mad_gremlin"));
+    expect(getPower(byDef(s, "mad_gremlin").powers, "strength")).toBe(0);
+  });
+});
+
+describe("护盾地精：保护友军", () => {
+  it("有友军时保护（给友军加格挡），只剩自己时改攻击", () => {
+    const s = gangFight();
+    const shield = byDef(s, "shield_gremlin");
+    expect(shield.currentMove).toBe("protect");
+    // 杀掉除护盾外所有地精
+    for (const e of s.combat!.enemies) {
+      if (e.defId !== "shield_gremlin") {
+        e.hp = 0;
+      }
+    }
+    // 触发一次 selectNextMove（通过 endTurn 后重新 telegraph）
+    endTurn(s);
+    expect(byDef(s, "shield_gremlin").currentMove).toBe("shield_bash");
+  });
+
+  it("保护给一名友军加 7 格挡", () => {
+    const s = gangFight();
+    // 只留护盾 + 狂暴，护盾 protect 会给狂暴加 7 格挡
+    byDef(s, "sneaky_gremlin").hp = 0;
+    byDef(s, "gremlin_wizard").hp = 0;
+    const madIdx = indexOf(s, "mad_gremlin");
+    s.combat!.enemies[madIdx]!.block = 0;
+    // 强制护盾出 protect 并执行
+    byDef(s, "shield_gremlin").currentMove = "protect";
+    endTurn(s);
+    expect(s.combat!.enemies[madIdx]!.block).toBeGreaterThanOrEqual(7);
+  });
+});
+
+describe("地精巫师：蓄力大招", () => {
+  it("蓄力 3 回合后终极爆发 25，然后循环", () => {
+    const s = gangFight();
+    // 杀掉其他地精，隔离巫师
+    for (const e of s.combat!.enemies) {
+      if (e.defId !== "gremlin_wizard") {
+        e.hp = 0;
+      }
+    }
+    const wiz = () => byDef(s, "gremlin_wizard");
+    const seq: string[] = [wiz().currentMove];
+    for (let i = 0; i < 4; i += 1) {
+      s.hp = 500;
+      s.combat!.playerBlock = 0;
+      endTurn(s);
+      seq.push(wiz().currentMove);
+    }
+    expect(seq).toEqual(["charging", "charging", "charging", "ultimate_blast", "charging"]);
+  });
+
+  it("终极爆发造成 25 伤害", () => {
+    const s = gangFight();
+    for (const e of s.combat!.enemies) {
+      if (e.defId !== "gremlin_wizard") {
+        e.hp = 0;
+      }
+    }
+    byDef(s, "gremlin_wizard").currentMove = "ultimate_blast";
+    s.hp = 500;
+    s.combat!.playerBlock = 0;
+    endTurn(s);
+    expect(s.hp).toBe(500 - 25);
+  });
+});


### PR DESCRIPTION
治「图里怪太少」：strong 池加**地精帮**，引入 3 个新机制。数值对齐 sts_lightspeed asc0。Refs #234。

## 新机制
- **狂怒(angry)**：受穿透格挡的攻击伤害就 +力量（狂暴地精自带 1，越打越猛）。
- **gain_block_ally** 原语：给随机存活友军加格挡（护盾地精）。

## 5 种地精
| 地精 | HP | 招式 |
|---|---|---|
| 狂暴 | 20-24 | 抓挠4（自带狂怒1） |
| 鬼祟 | 10-14 | 穿刺9 |
| 肥胖 | 13-17 | 猛击4+虚弱1 |
| 护盾 | 12-15 | 有友军→保护(+7友军格挡)；独存→盾击6 |
| 巫师 | 21-25 | 蓄力3回合→终极爆发25→循环 |

地精帮 encounter（固定代表性 4 只：狂暴/鬼祟/护盾/巫师）进 strong 池。逃跑机制暂略（战斗多在其前结束，已在 doc 记明）。

## 验证
门禁全绿：build/typecheck/lint(0)/format + **spire 112/112**（新增 `gremlins.test.ts` 7 例：组成、狂怒受击+力量/被格挡不触发、护盾有友军保护+独存攻击+加7格挡、巫师蓄力3回合大招25+循环）· **agent 702**。sim stuck=0、胜场 28。

## 部署
spire + agent（狂怒 label）。合并后 `app:deploy spire` + `app:deploy agent`。