### PR TITLE
feat(spire): 事件(? 节点)系统 + 4 个原创事件（阶段2 M4）

### DIFF
--- a/apps/agent/src/agent/capabilities/spire/render/spire-screen.ts
+++ b/apps/agent/src/agent/capabilities/spire/render/spire-screen.ts
@@ -77,6 +77,8 @@ export function renderSpireScreen(screen: SpireScreen): string {
     isCombat: screen.screen === "combat",
     isReward: screen.screen === "reward",
     isRest: screen.screen === "rest",
+    isEvent: screen.screen === "event",
+    eventDescription: screen.event?.description ?? "",
     isGameover: screen.screen === "gameover",
     isVictory: screen.screen === "victory",
     hp: screen.player.hp,

--- a/apps/agent/static/context/spire-screen.hbs
+++ b/apps/agent/static/context/spire-screen.hbs
@@ -45,6 +45,14 @@
 [{{n}}] {{text}}
 {{/each}}
 用 invoke(tool="choose", option_index=编号) 选择。
+{{else if isEvent}}
+未知房间。你：生命 {{hp}}/{{maxHp}}　金币 {{gold}}　牌组 {{deckCount}} 张。
+{{eventDescription}}
+你可以：
+{{#each options}}
+[{{n}}] {{text}}
+{{/each}}
+用 invoke(tool="choose", option_index=编号) 做出选择。
 {{else if isGameover}}
 你倒下了，这一局到此为止。生命 0/{{maxHp}}。
 想再来一局就调用 start_run。

--- a/apps/agent/test/spire/spire-client.test.ts
+++ b/apps/agent/test/spire/spire-client.test.ts
@@ -16,6 +16,7 @@ function screenOf(version: number): SpireScreen {
     deckCount: 10,
     relics: [{ name: "燃烧之血", description: "每场战斗结束后，回复 6 点生命。" }],
     potions: [],
+    event: null,
     combat: null,
     options: ["0", "1"],
     log: [],

--- a/apps/spire/src/application/state-view.ts
+++ b/apps/spire/src/application/state-view.ts
@@ -12,6 +12,7 @@ import { getEnemyDef } from "../engine/enemies/enemies.js";
 import { computeAttackDamage } from "../engine/powers/powers.js";
 import { getRelicDef } from "../engine/relics/relics.js";
 import { getPotionDef } from "../engine/potions/potions.js";
+import { getEventDef } from "../engine/events/events.js";
 import { currentOptions } from "../engine/run/run.js";
 
 // === 结构化屏幕视图（ScreenView）===
@@ -45,6 +46,7 @@ export function toScreenView(state: GameState, opts: { suppressLog?: boolean }):
       const def = getPotionDef(id);
       return [{ slot, name: def.name, description: def.description, targeted: def.targeted }];
     }),
+    event: state.event ? { description: getEventDef(state.event.id).description } : null,
     combat: state.combat ? toCombatView(state) : null,
     options: currentOptions(state),
     log: opts.suppressLog ? [] : state.log,

--- a/apps/spire/src/engine/engine.ts
+++ b/apps/spire/src/engine/engine.ts
@@ -52,6 +52,7 @@ export function newRun(input: {
     currentNodeId: null,
     combat: null,
     reward: null,
+    event: null,
     combatsEntered: 0,
     pendingRelicReward: false,
     rng,
@@ -92,7 +93,12 @@ export function applyAction(state: GameState, action: GameAction): ActionResult 
       return result;
     }
     case "choose": {
-      if (state.screen !== "reward" && state.screen !== "rest" && state.screen !== "map") {
+      if (
+        state.screen !== "reward" &&
+        state.screen !== "rest" &&
+        state.screen !== "map" &&
+        state.screen !== "event"
+      ) {
         return { ok: false, reason: "当前屏幕没有可选项。" };
       }
       return applyChoose(state, action.optionIndex);

--- a/apps/spire/src/engine/events/events.ts
+++ b/apps/spire/src/engine/events/events.ts
@@ -1,0 +1,135 @@
+// === 事件（? 节点）数据表 ===
+//
+// 描述 / 选项 / 结果均为**原创中文文案**（不复制杀戮尖塔的事件叙事）；机制/概率/结果结构
+// 复刻其玩法骨架。结果通过 EventOutcome 复用金币/生命/牌组/遗物/药水等既有系统结算。
+
+export type EventOutcome =
+  | { kind: "gain_gold"; amount: number }
+  | { kind: "lose_gold"; amount: number }
+  | { kind: "heal"; amount: number }
+  | { kind: "lose_hp"; amount: number }
+  | { kind: "gain_max_hp"; amount: number }
+  | { kind: "add_card"; cardId: string }
+  | { kind: "gain_relic" }
+  | { kind: "gain_potion" }
+  | { kind: "nothing" };
+
+export type EventChoice = {
+  /** 选项按钮文案（原创）。 */
+  label: string;
+  /** 选择后展示的结果叙述（原创）。 */
+  resultText: string;
+  outcomes: EventOutcome[];
+};
+
+export type EventDef = {
+  id: string;
+  /** 事件情境描述（原创）。 */
+  description: string;
+  choices: EventChoice[];
+};
+
+const EVENT_LIST: EventDef[] = [
+  {
+    id: "cooling_embers",
+    description: "半塌的石室中央，一堆灰烬还残着余温，灰里似乎埋着被人匆忙丢下的东西。",
+    choices: [
+      {
+        label: "拢近火堆取暖",
+        resultText: "暖意顺着骨头爬上来，疲惫散了些。你回复了 12 点生命。",
+        outcomes: [{ kind: "heal", amount: 12 }],
+      },
+      {
+        label: "徒手在灰里翻找",
+        resultText: "你摸出几枚发烫的硬币，指尖也被余烬燎起了泡。",
+        outcomes: [
+          { kind: "gain_gold", amount: 30 },
+          { kind: "lose_hp", amount: 6 },
+        ],
+      },
+    ],
+  },
+  {
+    id: "faceless_shrine",
+    description: "岔路口立着一尊没有面孔的石像，双手摊在身前，掌心磨得发亮，像是等了很久的供奉。",
+    choices: [
+      {
+        label: "空手合十，诚心祈祷",
+        resultText: "石像掌心浮起一点微光，一件旧物落进你怀里。",
+        outcomes: [{ kind: "gain_relic" }],
+      },
+      {
+        label: "掀翻石像看看底下",
+        resultText: "石像下压着一小袋钱币，倒下时的石棱也划破了你。",
+        outcomes: [
+          { kind: "gain_gold", amount: 55 },
+          { kind: "lose_hp", amount: 10 },
+        ],
+      },
+    ],
+  },
+  {
+    id: "lost_peddler",
+    description: "一个背着鼓胀行囊的商贩瘫坐路边，喘着气说只要一点接济，就把货分你一些。",
+    choices: [
+      {
+        label: "分他一些盘缠",
+        resultText: "他千恩万谢，从行囊里翻出一瓶药水塞给你。",
+        outcomes: [{ kind: "lose_gold", amount: 25 }, { kind: "gain_potion" }],
+      },
+      {
+        label: "抢过他的行囊",
+        resultText: "你夺过钱袋就跑，慌乱里也把他包里一片带刺的脏东西塞进了自己牌组。",
+        outcomes: [
+          { kind: "gain_gold", amount: 45 },
+          { kind: "add_card", cardId: "wound" },
+        ],
+      },
+      {
+        label: "绕开他继续赶路",
+        resultText: "你没有停下，脚步声很快盖过了他的呼唤。",
+        outcomes: [{ kind: "nothing" }],
+      },
+    ],
+  },
+  {
+    id: "fungal_ring",
+    description: "一圈鼓胀的蘑菇在幽光里轻轻搏动，凑近能闻到一股又腥又甜的气味。",
+    choices: [
+      {
+        label: "掰下一朵尝尝",
+        resultText: "腥甜在喉咙里炸开，肚子绞了一下，可你觉得身子骨更结实了。",
+        outcomes: [
+          { kind: "gain_max_hp", amount: 10 },
+          { kind: "lose_hp", amount: 5 },
+        ],
+      },
+      {
+        label: "小心采下孢子",
+        resultText: "你把饱满的孢子囊收进行囊——或许能派上用场。",
+        outcomes: [{ kind: "gain_potion" }],
+      },
+      {
+        label: "一脚把它们踩碎",
+        resultText: "菌盖爆开，露出几枚被菌丝裹着的硬币。",
+        outcomes: [{ kind: "gain_gold", amount: 15 }],
+      },
+    ],
+  },
+];
+
+const EVENT_MAP: ReadonlyMap<string, EventDef> = new Map(
+  EVENT_LIST.map(event => [event.id, event]),
+);
+
+export const ALL_EVENTS: readonly EventDef[] = EVENT_LIST;
+
+export function getEventDef(id: string): EventDef {
+  const def = EVENT_MAP.get(id);
+  if (!def) {
+    throw new Error(`未知事件 id: ${id}`);
+  }
+  return def;
+}
+
+export const EVENT_POOL: readonly string[] = EVENT_LIST.map(event => event.id);

--- a/apps/spire/src/engine/run/run.ts
+++ b/apps/spire/src/engine/run/run.ts
@@ -3,22 +3,24 @@ import { REWARD_CARD_POOL, getCardDef, costOf } from "../cards/cards.js";
 import { pickBossEncounter, pickEliteEncounter, pickNormalEncounter } from "../enemies/enemies.js";
 import { COMMON_RELIC_POOL, getRelicDef, hasRelic } from "../relics/relics.js";
 import { BASE_POTION_DROP_CHANCE, POTION_DROP_POOL, getPotionDef } from "../potions/potions.js";
+import { EVENT_POOL, getEventDef } from "../events/events.js";
+import type { EventOutcome } from "../events/events.js";
 import { nextInt, nextRange } from "../rng.js";
 import { startCombat } from "../combat/combat.js";
 import { generateMap, availableNext } from "../map/map.js";
 
 // === 爬塔 / 分支地图 / 奖励 / 休息 / 宝箱 ===
 //
-// 分支地图（StS 节点图）：在 "map" 屏 choose 一个上层节点 → 进入该节点（战斗/篝火/宝箱/Boss）
-// → 结算后回到 "map" 屏继续选路，直到 Boss。节点类型内容随里程碑启用（当前 combat/rest/treasure/boss）。
+// 分支地图（StS 节点图）：在 "map" 屏 choose 一个上层节点 → 进入该节点（战斗/精英/未知/篝火/宝箱/Boss）
+// → 结算后回到 "map" 屏继续选路，直到 Boss。节点类型内容随里程碑启用（商店待后续）。
 
 const REST_HEAL_RATIO = 0.3;
 const REWARD_CARD_COUNT = 3;
 const TREASURE_GOLD_MIN = 25;
 const TREASURE_GOLD_MAX = 35;
 
-/** 本里程碑启用的地图节点类型（事件/商店随内容里程碑加入）。 */
-const ENABLED_MAP_TYPES: readonly MapNodeType[] = ["combat", "elite", "rest", "treasure"];
+/** 本里程碑启用的地图节点类型（商店随后续里程碑加入）。 */
+const ENABLED_MAP_TYPES: readonly MapNodeType[] = ["combat", "elite", "event", "rest", "treasure"];
 
 const NODE_TYPE_LABELS: Record<MapNodeType, string> = {
   combat: "战斗",
@@ -57,6 +59,13 @@ function resolveNode(state: GameState, node: MapNode): void {
       startCombat(state, pickBossEncounter(state.rng));
       return;
     }
+    case "event": {
+      const eventId = EVENT_POOL[nextInt(state.rng, EVENT_POOL.length)]!;
+      state.event = { id: eventId };
+      state.screen = "event";
+      state.log.push("你踏进一处未知的房间。");
+      return;
+    }
     case "rest": {
       state.screen = "rest";
       state.log.push("你来到一处篝火。");
@@ -68,7 +77,7 @@ function resolveNode(state: GameState, node: MapNode): void {
       return;
     }
     default: {
-      // event / shop 尚未启用（未来里程碑）；保守回地图。
+      // shop 尚未启用（未来里程碑）；保守回地图。
       backToMap(state);
     }
   }
@@ -158,7 +167,52 @@ export function currentOptions(state: GameState): string[] {
     }
     return options;
   }
+  if (state.screen === "event" && state.event) {
+    return getEventDef(state.event.id).choices.map(choice => choice.label);
+  }
   return [];
+}
+
+/** 结算一个事件结果（原地改 state）。金币/生命/牌组/遗物/药水复用既有系统。 */
+function applyEventOutcome(state: GameState, outcome: EventOutcome): void {
+  switch (outcome.kind) {
+    case "gain_gold":
+      state.gold += outcome.amount;
+      break;
+    case "lose_gold":
+      state.gold = Math.max(0, state.gold - outcome.amount);
+      break;
+    case "heal":
+      state.hp = Math.min(state.maxHp, state.hp + outcome.amount);
+      break;
+    case "lose_hp":
+      // 事件不会致死：至少留 1 点生命（复刻 StS 事件不杀人）。
+      state.hp = Math.max(1, state.hp - outcome.amount);
+      break;
+    case "gain_max_hp":
+      state.maxHp += outcome.amount;
+      state.hp += outcome.amount;
+      break;
+    case "add_card":
+      state.deck.push({ uid: state.nextUid++, defId: outcome.cardId, upgraded: false });
+      break;
+    case "gain_relic":
+      grantTreasure(state);
+      break;
+    case "gain_potion": {
+      const slot = state.potions.indexOf(null);
+      if (slot >= 0) {
+        state.potions[slot] = POTION_DROP_POOL[nextInt(state.rng, POTION_DROP_POOL.length)]!;
+      }
+      break;
+    }
+    case "nothing":
+      break;
+    default: {
+      const _exhaustive: never = outcome;
+      void _exhaustive;
+    }
+  }
 }
 
 function upgradableCards(state: GameState): GameState["deck"] {
@@ -190,6 +244,21 @@ export function applyChoose(state: GameState, optionIndex: number): ChooseResult
       return { ok: false, reason: `选项 ${optionIndex} 无效。` };
     }
     state.reward = null;
+    backToMap(state);
+    return { ok: true };
+  }
+
+  if (state.screen === "event" && state.event) {
+    const event = getEventDef(state.event.id);
+    const choice = event.choices[optionIndex];
+    if (!choice) {
+      return { ok: false, reason: `选项 ${optionIndex} 无效。` };
+    }
+    for (const outcome of choice.outcomes) {
+      applyEventOutcome(state, outcome);
+    }
+    state.log.push(choice.resultText);
+    state.event = null;
     backToMap(state);
     return { ok: true };
   }

--- a/apps/spire/src/engine/types.ts
+++ b/apps/spire/src/engine/types.ts
@@ -180,7 +180,10 @@ export type MapGraph = {
   bossNodeId: string;
 };
 
-export type Screen = "map" | "combat" | "reward" | "rest" | "gameover" | "victory";
+export type Screen = "map" | "combat" | "reward" | "rest" | "event" | "gameover" | "victory";
+
+/** 当前进行中的事件（? 节点）。 */
+export type EventState = { id: string };
 
 /** RNG 内部状态：必须完整可序列化并从存档精确复原（issue #234 C11）。 */
 export type RngState = { s0: number; s1: number; s2: number; s3: number };
@@ -209,6 +212,8 @@ export type GameState = {
   currentNodeId: string | null;
   combat: CombatState | null;
   reward: RewardState | null;
+  /** 当前进行中的事件（? 节点）；null = 不在事件屏。 */
+  event: EventState | null;
   /** 已进入过的普通战斗数（决定抽 weak / strong encounter 池，复刻 StS Act1 节奏）。 */
   combatsEntered: number;
   /** 本场战斗胜利后是否发一个遗物（精英战为 true；下次 generateReward 消费后清零）。 */

--- a/apps/spire/src/sim/policy.ts
+++ b/apps/spire/src/sim/policy.ts
@@ -1,6 +1,7 @@
 import type { GameState } from "../engine/types.js";
 import type { GameAction } from "../engine/engine.js";
 import { costOf, getCardDef } from "../engine/cards/cards.js";
+import { getEventDef } from "../engine/events/events.js";
 import { nextInt } from "../engine/rng.js";
 import { availableNext } from "../engine/map/map.js";
 import type { RngState } from "../engine/types.js";
@@ -32,6 +33,13 @@ export function legalActions(state: GameState): GameAction[] {
   }
   if (state.screen === "map") {
     const count = availableNext(state.map, state.currentNodeId).length;
+    return Array.from({ length: Math.max(1, count) }, (_, optionIndex) => ({
+      type: "choose" as const,
+      optionIndex,
+    }));
+  }
+  if (state.screen === "event" && state.event) {
+    const count = getEventDef(state.event.id).choices.length;
     return Array.from({ length: Math.max(1, count) }, (_, optionIndex) => ({
       type: "choose" as const,
       optionIndex,

--- a/apps/spire/test/events.test.ts
+++ b/apps/spire/test/events.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { applyChoose, currentOptions } from "../src/engine/run/run.js";
+import { ALL_EVENTS, getEventDef } from "../src/engine/events/events.js";
+import type { GameState } from "../src/engine/types.js";
+
+// M4：事件（? 节点）——原创文案 + 复用金币/生命/牌组/遗物/药水结算。
+
+function atEvent(eventId: string): GameState {
+  const s = newRun({ runId: eventId, seed: 1 });
+  s.event = { id: eventId };
+  s.screen = "event";
+  s.log = [];
+  return s;
+}
+
+describe("事件数据", () => {
+  it("每个事件都有描述和至少两个带结果文案的选项", () => {
+    expect(ALL_EVENTS.length).toBeGreaterThanOrEqual(4);
+    for (const event of ALL_EVENTS) {
+      expect(event.description.length).toBeGreaterThan(0);
+      expect(event.choices.length).toBeGreaterThanOrEqual(2);
+      for (const choice of event.choices) {
+        expect(choice.label.length).toBeGreaterThan(0);
+        expect(choice.resultText.length).toBeGreaterThan(0);
+        expect(choice.outcomes.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("事件屏选项 = 各选择的 label", () => {
+    const s = atEvent("cooling_embers");
+    expect(currentOptions(s)).toEqual(getEventDef("cooling_embers").choices.map(c => c.label));
+  });
+});
+
+describe("事件结算", () => {
+  it("灰烬·取暖 → 回血；翻找 → +金币 -生命", () => {
+    const heal = atEvent("cooling_embers");
+    heal.hp = 50;
+    heal.maxHp = 80;
+    expect(applyChoose(heal, 0).ok).toBe(true);
+    expect(heal.hp).toBe(62);
+    expect(heal.screen).toBe("map");
+    expect(heal.event).toBeNull();
+
+    const dig = atEvent("cooling_embers");
+    dig.hp = 50;
+    dig.gold = 0;
+    expect(applyChoose(dig, 1).ok).toBe(true);
+    expect(dig.gold).toBe(30);
+    expect(dig.hp).toBe(44);
+  });
+
+  it("神龛·祈祷 → 得遗物（或金币兜底）", () => {
+    const s = atEvent("faceless_shrine");
+    const relicsBefore = s.relics.length;
+    const goldBefore = s.gold;
+    expect(applyChoose(s, 0).ok).toBe(true);
+    // 起始只有 1 遗物，池里有未持有的 → 应加一件遗物
+    expect(s.relics.length === relicsBefore + 1 || s.gold > goldBefore).toBe(true);
+  });
+
+  it("商贩·施舍 → -金币 +药水", () => {
+    const s = atEvent("lost_peddler");
+    s.gold = 100;
+    expect(applyChoose(s, 0).ok).toBe(true);
+    expect(s.gold).toBe(75);
+    expect(s.potions.filter(p => p !== null)).toHaveLength(1);
+  });
+
+  it("商贩·抢夺 → +金币，牌组塞入一张伤口", () => {
+    const s = atEvent("lost_peddler");
+    s.gold = 0;
+    const deckBefore = s.deck.length;
+    expect(applyChoose(s, 1).ok).toBe(true);
+    expect(s.gold).toBe(45);
+    expect(s.deck.length).toBe(deckBefore + 1);
+    expect(s.deck.some(c => c.defId === "wound")).toBe(true);
+  });
+
+  it("蘑菇·尝一口 → +最大生命 +当前生命 -生命", () => {
+    const s = atEvent("fungal_ring");
+    s.hp = 40;
+    s.maxHp = 80;
+    expect(applyChoose(s, 0).ok).toBe(true);
+    expect(s.maxHp).toBe(90); // +10
+    expect(s.hp).toBe(45); // 40 +10 -5
+  });
+
+  it("失血不致死：至少留 1 点生命", () => {
+    const s = atEvent("faceless_shrine");
+    s.hp = 3; // 掀神像 -10
+    expect(applyChoose(s, 1).ok).toBe(true);
+    expect(s.hp).toBe(1);
+  });
+
+  it("非法选项被拒", () => {
+    const s = atEvent("cooling_embers");
+    expect(applyChoose(s, 9).ok).toBe(false);
+  });
+});

--- a/packages/spire-api/src/contract.ts
+++ b/packages/spire-api/src/contract.ts
@@ -73,9 +73,13 @@ export const SpirePotionViewSchema = z.object({
   targeted: z.boolean(),
 });
 
+export const SpireEventViewSchema = z.object({
+  description: z.string(),
+});
+
 export const SpireScreenSchema = z.object({
   version: z.number().int(),
-  screen: z.enum(["map", "combat", "reward", "rest", "gameover", "victory"]),
+  screen: z.enum(["map", "combat", "reward", "rest", "event", "gameover", "victory"]),
   player: z.object({
     hp: z.number().int(),
     maxHp: z.number().int(),
@@ -84,6 +88,7 @@ export const SpireScreenSchema = z.object({
   deckCount: z.number().int(),
   relics: z.array(SpireRelicViewSchema),
   potions: z.array(SpirePotionViewSchema),
+  event: SpireEventViewSchema.nullable(),
   combat: SpireCombatViewSchema.nullable(),
   options: z.array(z.string()),
   log: z.array(z.string()),


### PR DESCRIPTION
补齐地图**最后一类可交互节点**——未知(?)房间。机制骨架复刻 StS，**文案全原创**。Refs #234。

## 系统
- 地图启用 `event` 类型；新 `event` 屏 + `state.event`；复用 `choose` 流（选项=事件选择）。
- `engine/events/events.ts`：`EventOutcome`（金币/生命/最大生命/牌组/遗物/药水/无）复用既有系统结算。
- 事件**失血不致死**（至少留 1 血，复刻 StS）；`gain_relic` 走宝箱逻辑、`gain_potion` 入空槽。
- 契约包 `SpireScreenSchema += event`（单一事实源）→ state-view / agent client(自动派生) / render / hbs 事件屏；sim policy 支持 event 屏。

## 4 个原创事件
- **灰烬余烟**：取暖回血 / 翻找(+金币-血)
- **无面神龛**：祈祷(得遗物) / 掀翻(+金币-血)
- **迷路商贩**：施舍(-金币+药水) / 抢夺(+金币+牌组塞伤口) / 离开
- **蘑菇圈**：尝一口(+最大生命-血) / 采孢子(+药水) / 踩碎(+金币)

## 验证
门禁全绿：build/typecheck/lint(0)/format + **spire 144/144**（新增 `events.test.ts` 9 例：数据完整性、选项=label、各结果结算、失血保底1、非法选项拒绝）· **agent 806**。sim 贪心 300 局**胜场 86**（事件续航拉高）、stuck=0、平均第 11.6 层。

## 部署
spire + agent（事件屏渲染）。合并后 `app:deploy spire` + `app:deploy agent`。