### PR TITLE
fix(metric): drain 响应体避免 undici 连接滞留

### DIFF
--- a/apps/agent/src/metric/application/metric.impl.service.ts
+++ b/apps/agent/src/metric/application/metric.impl.service.ts
@@ -51,6 +51,11 @@ export class HttpMetricService implements MetricService {
         signal: AbortSignal.timeout(2000),
       });
 
+      // 不解析响应体，但必须把它 drain 掉（cancel）：undici 下未消费的 body 会拖住底层
+      // 连接的复用/释放，metric 是高频打点路径，long-lived socket/stream 会累积。cancel
+      // 自身的 rejection 同样咽下，维持 fire-and-forget 契约。
+      await response.body?.cancel().catch(() => {});
+
       if (!response.ok) {
         logger.warn("Metric record endpoint returned non-2xx", {
           event: "metric.record.http_failed",


### PR DESCRIPTION
## 背景

`apps/agent/src/metric/application/metric.impl.service.ts` 的 `HttpMetricService.record()` 是 fire-and-forget 打点：发出 fetch 后只检查 `response.ok`，从不读取或 cancel 响应体。undici 下未消费的 body 会拖住底层连接的复用/释放，metric 是高频路径，long-lived socket/stream 会累积。

issue #279 契约重构 review（Codex 对抗审查）发现的**既有问题**——非该重构引入（origin/master 上已存在），当时按「不在纯重构 PR 内扩散」原则未修，单开处理。

## 改动

拿到 response 后（无论 ok 与否）无条件 drain 掉 body：

```ts
await response.body?.cancel().catch(() => {});
```

- 放在 `!response.ok` 判断之前；cancel 丢弃流不影响 `response.status`。
- `.catch(() => {})` 吞掉 cancel 自身可能的 rejection，外层 `try` 兜底同步抛。
- 完整保留「不解析语义、分级记日志、绝不抛」的 fire-and-forget 契约。

收益：让高频打点路径的连接及时归还池，避免 socket/stream 累积。

## 验证

- `pnpm build` / `typecheck` / `lint` / `format` 全绿
- 806 个 agent 测试通过；新增这行在 200 与 400 两条 mock 响应路径上均被实际执行，未破坏任何一条