### PR TITLE
chore(spire): 移除 vitest 配置中已退役的 @kagami/shared 死 alias

### DIFF
--- a/apps/spire/vitest.config.ts
+++ b/apps/spire/vitest.config.ts
@@ -1,15 +1,6 @@
-import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
-const rootDir = path.dirname(fileURLToPath(import.meta.url));
-
 export default defineConfig({
-  resolve: {
-    alias: {
-      "@kagami/shared/": path.resolve(rootDir, "../../packages/shared/src/"),
-    },
-  },
   test: {
     environment: "node",
     include: ["test/**/*.test.ts"],


### PR DESCRIPTION
## 背景

#279（PR #300）删除了 `@kagami/shared` 包，但 `apps/spire/vitest.config.ts` 仍保留一条 `resolve.alias`：

```ts
"@kagami/shared/": path.resolve(rootDir, "../../packages/shared/src/"),
```

它指向已不存在的目录。spire 无测试经它解析，故不报错，但属于陈旧噪音配置——来源是 #279 合并 master 时取 master 版 spire 生态连带带回的死配置。

## 改动

- 删除该死 alias。
- 由于它是 `resolve.alias` 的唯一条目，连带精简掉整个 `resolve` 块，以及随之失效的 `path` / `fileURLToPath` / `rootDir` 三处未使用导入。
- 结果与 `apps/agent`、`apps/llm` 的 `vitest.config.ts` 一致（无 `resolve` 块形态）。

## 验证

- `pnpm --filter @kagami/spire-service test` → 20 文件 / 144 用例全绿。
- `pnpm build` / `typecheck` / `lint` / `format` 四项提交前检查全部通过（lint 的 7 条 warning 均在 `packages/rpc-client`，与本改动无关的既存告警）。