### PR TITLE
feat(spire): 商店节点 + 金币经济闭环（Phase A · A1）

### DIFF
--- a/apps/agent/src/agent/capabilities/spire/render/spire-screen.ts
+++ b/apps/agent/src/agent/capabilities/spire/render/spire-screen.ts
@@ -79,6 +79,7 @@ export function renderSpireScreen(screen: SpireScreen): string {
     isRest: screen.screen === "rest",
     isEvent: screen.screen === "event",
     eventDescription: screen.event?.description ?? "",
+    isShop: screen.screen === "shop",
     isGameover: screen.screen === "gameover",
     isVictory: screen.screen === "victory",
     hp: screen.player.hp,

--- a/apps/agent/static/context/spire-screen.hbs
+++ b/apps/agent/static/context/spire-screen.hbs
@@ -53,6 +53,13 @@
 [{{n}}] {{text}}
 {{/each}}
 用 invoke(tool="choose", option_index=编号) 做出选择。
+{{else if isShop}}
+商店。你有 {{gold}} 金币　生命 {{hp}}/{{maxHp}}　牌组 {{deckCount}} 张。
+在售（买完可继续逛，逛够了就离开）：
+{{#each options}}
+[{{n}}] {{text}}
+{{/each}}
+用 invoke(tool="choose", option_index=编号) 购买或离开。
 {{else if isGameover}}
 你倒下了，这一局到此为止。生命 0/{{maxHp}}。
 想再来一局就调用 start_run。

--- a/apps/spire/src/engine/engine.ts
+++ b/apps/spire/src/engine/engine.ts
@@ -53,6 +53,7 @@ export function newRun(input: {
     combat: null,
     reward: null,
     event: null,
+    shop: null,
     combatsEntered: 0,
     pendingRelicReward: false,
     rng,
@@ -97,7 +98,8 @@ export function applyAction(state: GameState, action: GameAction): ActionResult 
         state.screen !== "reward" &&
         state.screen !== "rest" &&
         state.screen !== "map" &&
-        state.screen !== "event"
+        state.screen !== "event" &&
+        state.screen !== "shop"
       ) {
         return { ok: false, reason: "当前屏幕没有可选项。" };
       }

--- a/apps/spire/src/engine/run/run.ts
+++ b/apps/spire/src/engine/run/run.ts
@@ -5,6 +5,7 @@ import { COMMON_RELIC_POOL, getRelicDef, hasRelic } from "../relics/relics.js";
 import { BASE_POTION_DROP_CHANCE, POTION_DROP_POOL, getPotionDef } from "../potions/potions.js";
 import { EVENT_POOL, getEventDef } from "../events/events.js";
 import type { EventOutcome } from "../events/events.js";
+import { generateShop } from "../shop/shop.js";
 import { nextInt, nextRange } from "../rng.js";
 import { startCombat } from "../combat/combat.js";
 import { generateMap, availableNext } from "../map/map.js";
@@ -19,8 +20,15 @@ const REWARD_CARD_COUNT = 3;
 const TREASURE_GOLD_MIN = 25;
 const TREASURE_GOLD_MAX = 35;
 
-/** 本里程碑启用的地图节点类型（商店随后续里程碑加入）。 */
-const ENABLED_MAP_TYPES: readonly MapNodeType[] = ["combat", "elite", "event", "rest", "treasure"];
+/** 启用的地图节点类型（全类型齐备）。 */
+const ENABLED_MAP_TYPES: readonly MapNodeType[] = [
+  "combat",
+  "elite",
+  "event",
+  "shop",
+  "rest",
+  "treasure",
+];
 
 const NODE_TYPE_LABELS: Record<MapNodeType, string> = {
   combat: "战斗",
@@ -71,13 +79,18 @@ function resolveNode(state: GameState, node: MapNode): void {
       state.log.push("你来到一处篝火。");
       return;
     }
+    case "shop": {
+      generateShop(state);
+      state.log.push("你走进一间商店。");
+      return;
+    }
     case "treasure": {
       grantTreasure(state);
       backToMap(state);
       return;
     }
     default: {
-      // shop 尚未启用（未来里程碑）；保守回地图。
+      // 所有节点类型已启用；保守回地图兜底。
       backToMap(state);
     }
   }
@@ -170,7 +183,30 @@ export function currentOptions(state: GameState): string[] {
   if (state.screen === "event" && state.event) {
     return getEventDef(state.event.id).choices.map(choice => choice.label);
   }
+  if (state.screen === "shop" && state.shop) {
+    const options = state.shop.items.map(item => {
+      const name = shopItemName(item);
+      if (item.sold) {
+        return `${name}（已售罄）`;
+      }
+      const affordable = state.gold >= item.cost ? "" : "（金币不足）";
+      return `${name} — ${item.cost} 金${affordable}`;
+    });
+    options.push("离开商店");
+    return options;
+  }
   return [];
+}
+
+/** 商店商品的展示名（卡/遗物/药水）。 */
+function shopItemName(item: NonNullable<GameState["shop"]>["items"][number]): string {
+  if (item.kind === "card") {
+    return `牌·${getCardDef(item.defId).name}`;
+  }
+  if (item.kind === "relic") {
+    return `遗物·${getRelicDef(item.id).name}`;
+  }
+  return `药水·${getPotionDef(item.id).name}`;
 }
 
 /** 结算一个事件结果（原地改 state）。金币/生命/牌组/遗物/药水复用既有系统。 */
@@ -221,6 +257,36 @@ function upgradableCards(state: GameState): GameState["deck"] {
 
 export type ChooseResult = { ok: true } | { ok: false; reason: string };
 
+/** 购买一件商店商品：校验售罄/金币/药水槽 → 扣金币、入库、标记售罄，留在商店屏。 */
+function buyShopItem(
+  state: GameState,
+  item: NonNullable<GameState["shop"]>["items"][number],
+): ChooseResult {
+  if (item.sold) {
+    return { ok: false, reason: "这件商品已经卖掉了。" };
+  }
+  if (state.gold < item.cost) {
+    return { ok: false, reason: `金币不足：需 ${item.cost}，你只有 ${state.gold}。` };
+  }
+  if (item.kind === "potion" && state.potions.indexOf(null) < 0) {
+    return { ok: false, reason: "药水槽已满，先用掉一瓶再买。" };
+  }
+
+  state.gold -= item.cost;
+  item.sold = true;
+  if (item.kind === "card") {
+    state.deck.push({ uid: state.nextUid++, defId: item.defId, upgraded: false });
+    state.log.push(`你买下了牌「${getCardDef(item.defId).name}」。`);
+  } else if (item.kind === "relic") {
+    state.relics.push({ id: item.id, counter: 0 });
+    state.log.push(`你买下了遗物「${getRelicDef(item.id).name}」。`);
+  } else {
+    state.potions[state.potions.indexOf(null)] = item.id;
+    state.log.push(`你买下了药水「${getPotionDef(item.id).name}」。`);
+  }
+  return { ok: true };
+}
+
 export function applyChoose(state: GameState, optionIndex: number): ChooseResult {
   if (state.screen === "map") {
     const options = availableNext(state.map, state.currentNodeId);
@@ -246,6 +312,20 @@ export function applyChoose(state: GameState, optionIndex: number): ChooseResult
     state.reward = null;
     backToMap(state);
     return { ok: true };
+  }
+
+  if (state.screen === "shop" && state.shop) {
+    const items = state.shop.items;
+    if (optionIndex === items.length) {
+      state.shop = null;
+      backToMap(state);
+      return { ok: true };
+    }
+    const item = items[optionIndex];
+    if (!item) {
+      return { ok: false, reason: `选项 ${optionIndex} 无效。` };
+    }
+    return buyShopItem(state, item);
   }
 
   if (state.screen === "event" && state.event) {

--- a/apps/spire/src/engine/shop/shop.ts
+++ b/apps/spire/src/engine/shop/shop.ts
@@ -1,0 +1,67 @@
+import type { GameState, ShopItem, ShopState } from "../types.js";
+import { REWARD_CARD_POOL } from "../cards/cards.js";
+import { COMMON_RELIC_POOL, hasRelic } from "../relics/relics.js";
+import { POTION_DROP_POOL } from "../potions/potions.js";
+import { nextInt, nextRange } from "../rng.js";
+
+// === 商店库存生成 ===
+//
+// 进店时一次性生成库存并定价（此后价格固定）。定价区间近似 StS（功能性数值）：
+// 卡 ~45-65、遗物 ~140-180、药水 ~50-70。稀有度分档待卡池/遗物全量里程碑细化。
+
+const SHOP_CARD_COUNT = 5;
+const SHOP_RELIC_COUNT = 2;
+const SHOP_POTION_COUNT = 3;
+
+const CARD_PRICE_MIN = 45;
+const CARD_PRICE_MAX = 65;
+const RELIC_PRICE_MIN = 140;
+const RELIC_PRICE_MAX = 180;
+const POTION_PRICE_MIN = 50;
+const POTION_PRICE_MAX = 70;
+
+/** 从池里不重复抽 count 个 id。 */
+function sampleUnique(rng: GameState["rng"], pool: readonly string[], count: number): string[] {
+  const remaining = [...pool];
+  const out: string[] = [];
+  for (let i = 0; i < count && remaining.length > 0; i += 1) {
+    out.push(remaining.splice(nextInt(rng, remaining.length), 1)[0]!);
+  }
+  return out;
+}
+
+/** 生成一间商店的库存（原地写入 state.shop，切到 shop 屏）。 */
+export function generateShop(state: GameState): void {
+  const items: ShopItem[] = [];
+
+  for (const defId of sampleUnique(state.rng, REWARD_CARD_POOL, SHOP_CARD_COUNT)) {
+    items.push({
+      kind: "card",
+      defId,
+      cost: nextRange(state.rng, CARD_PRICE_MIN, CARD_PRICE_MAX),
+      sold: false,
+    });
+  }
+
+  const relicPool = COMMON_RELIC_POOL.filter(id => !hasRelic(state, id));
+  for (const id of sampleUnique(state.rng, relicPool, SHOP_RELIC_COUNT)) {
+    items.push({
+      kind: "relic",
+      id,
+      cost: nextRange(state.rng, RELIC_PRICE_MIN, RELIC_PRICE_MAX),
+      sold: false,
+    });
+  }
+
+  for (const id of sampleUnique(state.rng, POTION_DROP_POOL, SHOP_POTION_COUNT)) {
+    items.push({
+      kind: "potion",
+      id,
+      cost: nextRange(state.rng, POTION_PRICE_MIN, POTION_PRICE_MAX),
+      sold: false,
+    });
+  }
+
+  state.shop = { items } satisfies ShopState;
+  state.screen = "shop";
+}

--- a/apps/spire/src/engine/types.ts
+++ b/apps/spire/src/engine/types.ts
@@ -180,10 +180,27 @@ export type MapGraph = {
   bossNodeId: string;
 };
 
-export type Screen = "map" | "combat" | "reward" | "rest" | "event" | "gameover" | "victory";
+export type Screen =
+  | "map"
+  | "combat"
+  | "reward"
+  | "rest"
+  | "event"
+  | "shop"
+  | "gameover"
+  | "victory";
 
 /** 当前进行中的事件（? 节点）。 */
 export type EventState = { id: string };
+
+/** 商店一件在售商品。sold 后不可再买。 */
+export type ShopItem =
+  | { kind: "card"; defId: string; cost: number; sold: boolean }
+  | { kind: "relic"; id: string; cost: number; sold: boolean }
+  | { kind: "potion"; id: string; cost: number; sold: boolean };
+
+/** 商店库存（进店时一次性生成，定价固定）。 */
+export type ShopState = { items: ShopItem[] };
 
 /** RNG 内部状态：必须完整可序列化并从存档精确复原（issue #234 C11）。 */
 export type RngState = { s0: number; s1: number; s2: number; s3: number };
@@ -214,6 +231,8 @@ export type GameState = {
   reward: RewardState | null;
   /** 当前进行中的事件（? 节点）；null = 不在事件屏。 */
   event: EventState | null;
+  /** 当前商店库存；null = 不在商店屏。 */
+  shop: ShopState | null;
   /** 已进入过的普通战斗数（决定抽 weak / strong encounter 池，复刻 StS Act1 节奏）。 */
   combatsEntered: number;
   /** 本场战斗胜利后是否发一个遗物（精英战为 true；下次 generateReward 消费后清零）。 */

--- a/apps/spire/src/sim/policy.ts
+++ b/apps/spire/src/sim/policy.ts
@@ -45,6 +45,18 @@ export function legalActions(state: GameState): GameAction[] {
       optionIndex,
     }));
   }
+  if (state.screen === "shop" && state.shop) {
+    // 只列「买得起且未售」的商品 + 离开，避免策略卡在非法购买上。
+    const actions: GameAction[] = [];
+    state.shop.items.forEach((item, optionIndex) => {
+      const roomForPotion = item.kind !== "potion" || state.potions.indexOf(null) >= 0;
+      if (!item.sold && state.gold >= item.cost && roomForPotion) {
+        actions.push({ type: "choose", optionIndex });
+      }
+    });
+    actions.push({ type: "choose", optionIndex: state.shop.items.length }); // 离开
+    return actions;
+  }
   if (state.screen === "reward" || state.screen === "rest") {
     // 选项数量 = currentOptions().length；这里不引 run 层，直接按已知结构估算上界后再交给引擎校验。
     // reward: cardChoices + 跳过；rest: 1(休息) + 可升级卡数。用一个安全上界枚举，引擎会拒绝越界。
@@ -78,6 +90,10 @@ export class RandomPolicy implements Policy {
 /** 贪心：能打的攻击往最低血敌人砸、否则出防御，最后 end_turn；非战斗屏永远选第一项。 */
 export class GreedyPolicy implements Policy {
   public decide(state: GameState): GameAction {
+    // 商店：贪心不购物，直接离开（离开是最后一个选项），避免卡在售罄/买不起上。
+    if (state.screen === "shop" && state.shop) {
+      return { type: "choose", optionIndex: state.shop.items.length };
+    }
     if (state.screen !== "combat" || !state.combat) {
       return { type: "choose", optionIndex: 0 };
     }

--- a/apps/spire/test/shop.test.ts
+++ b/apps/spire/test/shop.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { generateShop } from "../src/engine/shop/shop.js";
+import { applyChoose, currentOptions } from "../src/engine/run/run.js";
+import type { GameState } from "../src/engine/types.js";
+
+// A1：商店节点——买卡/遗物/药水，闭合金币经济。
+
+function shop(): GameState {
+  const s = newRun({ runId: "shop", seed: 1 });
+  generateShop(s);
+  return s;
+}
+
+describe("商店库存", () => {
+  it("进店切到 shop 屏、生成 5 卡 + 2 遗物 + 3 药水", () => {
+    const s = shop();
+    expect(s.screen).toBe("shop");
+    const items = s.shop!.items;
+    expect(items.filter(i => i.kind === "card")).toHaveLength(5);
+    expect(items.filter(i => i.kind === "relic").length).toBeLessThanOrEqual(2);
+    expect(items.filter(i => i.kind === "potion")).toHaveLength(3);
+    for (const item of items) {
+      expect(item.cost).toBeGreaterThan(0);
+      expect(item.sold).toBe(false);
+    }
+  });
+
+  it("选项 = 各商品 + 离开", () => {
+    const s = shop();
+    const options = currentOptions(s);
+    expect(options).toHaveLength(s.shop!.items.length + 1);
+    expect(options[options.length - 1]).toBe("离开商店");
+  });
+});
+
+describe("购买", () => {
+  it("买一张牌：扣金币、进牌组、标记售罄、留在店里", () => {
+    const s = shop();
+    const cardIdx = s.shop!.items.findIndex(i => i.kind === "card");
+    const item = s.shop!.items[cardIdx]!;
+    s.gold = item.cost + 100;
+    const deckBefore = s.deck.length;
+    expect(applyChoose(s, cardIdx).ok).toBe(true);
+    expect(s.gold).toBe(100);
+    expect(s.deck.length).toBe(deckBefore + 1);
+    expect(s.shop!.items[cardIdx]!.sold).toBe(true);
+    expect(s.screen).toBe("shop"); // 留在店里
+  });
+
+  it("金币不足被拒", () => {
+    const s = shop();
+    const idx = 0;
+    s.gold = 0;
+    const r = applyChoose(s, idx);
+    expect(r.ok).toBe(false);
+    expect(s.shop!.items[idx]!.sold).toBe(false);
+  });
+
+  it("已售商品不能再买", () => {
+    const s = shop();
+    s.gold = 9999;
+    expect(applyChoose(s, 0).ok).toBe(true);
+    expect(applyChoose(s, 0).ok).toBe(false); // 第二次已售罄
+  });
+
+  it("买遗物进遗物栏、买药水进空槽", () => {
+    const s = shop();
+    s.gold = 9999;
+    const relicIdx = s.shop!.items.findIndex(i => i.kind === "relic");
+    if (relicIdx >= 0) {
+      const relicsBefore = s.relics.length;
+      expect(applyChoose(s, relicIdx).ok).toBe(true);
+      expect(s.relics.length).toBe(relicsBefore + 1);
+    }
+    const potionIdx = s.shop!.items.findIndex(i => i.kind === "potion");
+    expect(applyChoose(s, potionIdx).ok).toBe(true);
+    expect(s.potions.filter(p => p !== null).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("药水槽满时买药水被拒", () => {
+    const s = shop();
+    s.gold = 9999;
+    s.potions = ["fire_potion", "fire_potion", "fire_potion"];
+    const potionIdx = s.shop!.items.findIndex(i => i.kind === "potion");
+    expect(applyChoose(s, potionIdx).ok).toBe(false);
+  });
+});
+
+describe("离开", () => {
+  it("选最后一项离开 → 回地图、清空 shop", () => {
+    const s = shop();
+    const leaveIdx = s.shop!.items.length;
+    expect(applyChoose(s, leaveIdx).ok).toBe(true);
+    expect(s.screen).toBe("map");
+    expect(s.shop).toBeNull();
+  });
+});

--- a/packages/spire-api/src/contract.ts
+++ b/packages/spire-api/src/contract.ts
@@ -79,7 +79,7 @@ export const SpireEventViewSchema = z.object({
 
 export const SpireScreenSchema = z.object({
   version: z.number().int(),
-  screen: z.enum(["map", "combat", "reward", "rest", "event", "gameover", "victory"]),
+  screen: z.enum(["map", "combat", "reward", "rest", "event", "shop", "gameover", "victory"]),
   player: z.object({
     hp: z.number().int(),
     maxHp: z.number().int(),


### PR DESCRIPTION
补齐地图**最后一类节点**——商店，让金币有处可花（此前 gold 是死变量，产出却无消费）。Refs #234。

## 系统
- 地图启用 `shop` 节点；新 `shop` 屏 + `state.shop`；`engine/shop/shop.ts` 进店一次性生成库存并定价（**5 卡 + 2 未持有遗物 + 3 药水**；定价近似 StS：卡 45-65 / 遗物 140-180 / 药水 50-70）。
- **购买**（复用 `choose` 流）：校验售罄 / 金币 / 药水槽 → 扣金币、入牌组/遗物栏/药水槽、标记售罄，留在店里可继续逛；最后一项「离开商店」回地图。
- 契约包 screen enum += `shop`（options 驱动，无需额外视图字段）；agent 渲染 + hbs 商店屏。
- sim：贪心进店即离开、`legalActions` 只列买得起且未售的商品 + 离开。

## 验证
门禁全绿：build/typecheck/lint(0)/format + **spire 152/152**（新增 `shop.test.ts` 8 例：库存构成、选项、买卡扣钱进组留店、金币不足/已售/槽满被拒、买遗物药水、离开清空）· **agent 806**。sim 贪心+随机双策略 **stuck=0**。

去牌服务(purge，二步选择)留作 A7 跟进。

## 部署
spire + agent（商店屏）。合并后 `app:deploy spire` + `app:deploy agent`。