### PR TITLE
feat(spire): 卡牌稀有度系统 + 奖励加权 + 献焰/献祭（Phase A · A2）

### DIFF
--- a/apps/spire/src/engine/cards/cards.ts
+++ b/apps/spire/src/engine/cards/cards.ts
@@ -11,6 +11,7 @@ const CARD_LIST: CardDef[] = [
     id: "strike",
     name: "打击",
     type: "attack",
+    rarity: "starter",
     cost: 1,
     targeted: true,
     exhausts: false,
@@ -23,6 +24,7 @@ const CARD_LIST: CardDef[] = [
     id: "defend",
     name: "防御",
     type: "skill",
+    rarity: "starter",
     cost: 1,
     targeted: false,
     exhausts: false,
@@ -35,6 +37,7 @@ const CARD_LIST: CardDef[] = [
     id: "bash",
     name: "痛击",
     type: "attack",
+    rarity: "starter",
     cost: 2,
     targeted: true,
     exhausts: false,
@@ -55,6 +58,7 @@ const CARD_LIST: CardDef[] = [
     id: "anger",
     name: "愤怒",
     type: "attack",
+    rarity: "common",
     cost: 0,
     targeted: true,
     exhausts: false,
@@ -73,6 +77,7 @@ const CARD_LIST: CardDef[] = [
     id: "cleave",
     name: "横扫",
     type: "attack",
+    rarity: "common",
     cost: 1,
     targeted: false,
     exhausts: false,
@@ -85,6 +90,7 @@ const CARD_LIST: CardDef[] = [
     id: "clothesline",
     name: "铁臂勾拳",
     type: "attack",
+    rarity: "common",
     cost: 2,
     targeted: true,
     exhausts: false,
@@ -103,6 +109,7 @@ const CARD_LIST: CardDef[] = [
     id: "iron_wave",
     name: "铁浪",
     type: "attack",
+    rarity: "common",
     cost: 1,
     targeted: true,
     exhausts: false,
@@ -121,6 +128,7 @@ const CARD_LIST: CardDef[] = [
     id: "pommel_strike",
     name: "剑柄打击",
     type: "attack",
+    rarity: "common",
     cost: 1,
     targeted: true,
     exhausts: false,
@@ -139,6 +147,7 @@ const CARD_LIST: CardDef[] = [
     id: "twin_strike",
     name: "双重打击",
     type: "attack",
+    rarity: "common",
     cost: 1,
     targeted: true,
     exhausts: false,
@@ -151,6 +160,7 @@ const CARD_LIST: CardDef[] = [
     id: "shrug_it_off",
     name: "泰然自若",
     type: "skill",
+    rarity: "common",
     cost: 1,
     targeted: false,
     exhausts: false,
@@ -169,6 +179,7 @@ const CARD_LIST: CardDef[] = [
     id: "body_slam",
     name: "力压",
     type: "attack",
+    rarity: "common",
     cost: 1,
     targeted: true,
     exhausts: false,
@@ -181,6 +192,7 @@ const CARD_LIST: CardDef[] = [
     id: "thunderclap",
     name: "疾雷",
     type: "attack",
+    rarity: "common",
     cost: 1,
     targeted: false,
     exhausts: false,
@@ -201,6 +213,7 @@ const CARD_LIST: CardDef[] = [
     id: "heavy_blade",
     name: "重刃",
     type: "attack",
+    rarity: "common",
     cost: 2,
     targeted: true,
     exhausts: false,
@@ -213,6 +226,7 @@ const CARD_LIST: CardDef[] = [
     id: "uppercut",
     name: "上勾拳",
     type: "attack",
+    rarity: "uncommon",
     cost: 1,
     targeted: true,
     exhausts: false,
@@ -233,6 +247,7 @@ const CARD_LIST: CardDef[] = [
     id: "hemokinesis",
     name: "血魔法",
     type: "attack",
+    rarity: "uncommon",
     cost: 1,
     targeted: true,
     exhausts: false,
@@ -251,6 +266,7 @@ const CARD_LIST: CardDef[] = [
     id: "pummel",
     name: "乱拳",
     type: "attack",
+    rarity: "uncommon",
     cost: 1,
     targeted: true,
     exhausts: true,
@@ -263,6 +279,7 @@ const CARD_LIST: CardDef[] = [
     id: "bludgeon",
     name: "重锤",
     type: "attack",
+    rarity: "rare",
     cost: 3,
     targeted: true,
     exhausts: false,
@@ -275,6 +292,7 @@ const CARD_LIST: CardDef[] = [
     id: "wild_strike",
     name: "狂野劈砍",
     type: "attack",
+    rarity: "common",
     cost: 1,
     targeted: true,
     exhausts: false,
@@ -293,6 +311,7 @@ const CARD_LIST: CardDef[] = [
     id: "sword_boomerang",
     name: "剑刃回旋镖",
     type: "attack",
+    rarity: "common",
     cost: 1,
     targeted: false,
     exhausts: false,
@@ -305,6 +324,7 @@ const CARD_LIST: CardDef[] = [
     id: "inflame",
     name: "燃怒",
     type: "power",
+    rarity: "uncommon",
     cost: 1,
     targeted: false,
     exhausts: false,
@@ -318,6 +338,7 @@ const CARD_LIST: CardDef[] = [
     id: "metallicize",
     name: "金属化",
     type: "power",
+    rarity: "uncommon",
     cost: 1,
     targeted: false,
     exhausts: false,
@@ -330,6 +351,7 @@ const CARD_LIST: CardDef[] = [
     id: "demon_form",
     name: "恶魔形态",
     type: "power",
+    rarity: "rare",
     cost: 3,
     targeted: false,
     exhausts: false,
@@ -342,6 +364,7 @@ const CARD_LIST: CardDef[] = [
     id: "reckless_charge",
     name: "鲁莽冲锋",
     type: "attack",
+    rarity: "common",
     cost: 0,
     targeted: true,
     exhausts: false,
@@ -357,11 +380,53 @@ const CARD_LIST: CardDef[] = [
     upgradedDescription: "造成 10 点伤害。将一张「眩晕」洗入抽牌堆。",
   },
 
+  {
+    id: "immolate",
+    name: "献焰",
+    type: "attack",
+    rarity: "rare",
+    cost: 2,
+    targeted: false,
+    exhausts: false,
+    effects: [
+      { kind: "deal_damage_all", amount: 21 },
+      { kind: "add_card", cardId: "burn", pile: "discard", count: 1 },
+    ],
+    upgradedEffects: [
+      { kind: "deal_damage_all", amount: 28 },
+      { kind: "add_card", cardId: "burn", pile: "discard", count: 1 },
+    ],
+    description: "对所有敌人造成 21 点伤害。将一张「灼烧」置入弃牌堆。",
+    upgradedDescription: "对所有敌人造成 28 点伤害。将一张「灼烧」置入弃牌堆。",
+  },
+  {
+    id: "offering",
+    name: "献祭",
+    type: "skill",
+    rarity: "rare",
+    cost: 0,
+    targeted: false,
+    exhausts: true,
+    effects: [
+      { kind: "lose_hp", amount: 6 },
+      { kind: "gain_energy", amount: 2 },
+      { kind: "draw", amount: 3 },
+    ],
+    upgradedEffects: [
+      { kind: "lose_hp", amount: 6 },
+      { kind: "gain_energy", amount: 2 },
+      { kind: "draw", amount: 5 },
+    ],
+    description: "失去 6 点生命。获得 2 点能量。抽 3 张牌。消耗。",
+    upgradedDescription: "失去 6 点生命。获得 2 点能量。抽 5 张牌。消耗。",
+  },
+
   // —— 敌人塞进牌组的废牌 / 伤口（不可打出）——
   {
     id: "wound",
     name: "伤口",
     type: "status",
+    rarity: "special",
     cost: null,
     targeted: false,
     exhausts: false,
@@ -374,6 +439,7 @@ const CARD_LIST: CardDef[] = [
     id: "burn",
     name: "灼烧",
     type: "status",
+    rarity: "special",
     cost: null,
     targeted: false,
     exhausts: false,
@@ -386,6 +452,7 @@ const CARD_LIST: CardDef[] = [
     id: "dazed",
     name: "眩晕",
     type: "status",
+    rarity: "special",
     cost: null,
     targeted: false,
     exhausts: false,
@@ -399,6 +466,7 @@ const CARD_LIST: CardDef[] = [
     id: "slimed",
     name: "泥泞",
     type: "status",
+    rarity: "special",
     cost: null,
     targeted: false,
     exhausts: true,
@@ -436,29 +504,32 @@ export const IRONCLAD_STARTER_DECK: readonly string[] = [
   "bash",
 ];
 
-/** 卡奖励池（不含起始专属与废牌）：三选一从这里抽。 */
+function idsByRarity(rarity: CardDef["rarity"]): readonly string[] {
+  return CARD_LIST.filter(card => card.rarity === rarity).map(card => card.id);
+}
+
+/** 按稀有度分档的卡池（自动从 CARD_LIST 派生，加卡即入池）。 */
+export const COMMON_CARD_POOL: readonly string[] = idsByRarity("common");
+export const UNCOMMON_CARD_POOL: readonly string[] = idsByRarity("uncommon");
+export const RARE_CARD_POOL: readonly string[] = idsByRarity("rare");
+
+/** 全部可获得卡（普通+罕见+稀有；不含起始专属与废牌）：商店与「无视稀有度」场景用。 */
 export const REWARD_CARD_POOL: readonly string[] = [
-  "anger",
-  "cleave",
-  "clothesline",
-  "iron_wave",
-  "pommel_strike",
-  "twin_strike",
-  "shrug_it_off",
-  "body_slam",
-  "thunderclap",
-  "heavy_blade",
-  "uppercut",
-  "hemokinesis",
-  "pummel",
-  "bludgeon",
-  "wild_strike",
-  "sword_boomerang",
-  "inflame",
-  "metallicize",
-  "demon_form",
-  "reckless_charge",
+  ...COMMON_CARD_POOL,
+  ...UNCOMMON_CARD_POOL,
+  ...RARE_CARD_POOL,
 ];
+
+/** 取某稀有度的卡池。 */
+export function cardPoolOfRarity(rarity: "common" | "uncommon" | "rare"): readonly string[] {
+  if (rarity === "rare") {
+    return RARE_CARD_POOL;
+  }
+  if (rarity === "uncommon") {
+    return UNCOMMON_CARD_POOL;
+  }
+  return COMMON_CARD_POOL;
+}
 
 /** 取一张牌当前生效的效果（升级则用升级效果）。 */
 export function effectsOf(def: CardDef, upgraded: boolean): CardDef["effects"] {

--- a/apps/spire/src/engine/run/run.ts
+++ b/apps/spire/src/engine/run/run.ts
@@ -1,5 +1,5 @@
 import type { GameState, MapNode, MapNodeType } from "../types.js";
-import { REWARD_CARD_POOL, getCardDef, costOf } from "../cards/cards.js";
+import { cardPoolOfRarity, getCardDef, costOf } from "../cards/cards.js";
 import { pickBossEncounter, pickEliteEncounter, pickNormalEncounter } from "../enemies/enemies.js";
 import { COMMON_RELIC_POOL, getRelicDef, hasRelic } from "../relics/relics.js";
 import { BASE_POTION_DROP_CHANCE, POTION_DROP_POOL, getPotionDef } from "../potions/potions.js";
@@ -29,6 +29,14 @@ const ENABLED_MAP_TYPES: readonly MapNodeType[] = [
   "rest",
   "treasure",
 ];
+
+const RARITY_LABELS: Record<string, string> = {
+  common: "普通",
+  uncommon: "罕见",
+  rare: "稀有",
+  starter: "起始",
+  special: "特殊",
+};
 
 const NODE_TYPE_LABELS: Record<MapNodeType, string> = {
   combat: "战斗",
@@ -144,15 +152,32 @@ export function generateReward(state: GameState): void {
     state.pendingRelicReward = false;
   }
   rollPotionDrop(state);
-  const pool = [...REWARD_CARD_POOL];
   const choices: { defId: string; upgraded: boolean }[] = [];
-  for (let i = 0; i < REWARD_CARD_COUNT && pool.length > 0; i += 1) {
-    const idx = nextInt(state.rng, pool.length);
-    choices.push({ defId: pool[idx]!, upgraded: false });
-    pool.splice(idx, 1);
+  const picked = new Set<string>();
+  for (let i = 0; i < REWARD_CARD_COUNT; i += 1) {
+    const defId = rollRewardCard(state, picked);
+    if (defId === null) {
+      break;
+    }
+    picked.add(defId);
+    choices.push({ defId, upgraded: false });
   }
   state.reward = { cardChoices: choices };
   state.screen = "reward";
+}
+
+/** 掷一张奖励卡：先掷稀有度（稀有 4% / 罕见 36% / 普通 60%），再从该档池里挑未重复的。 */
+function rollRewardCard(state: GameState, exclude: ReadonlySet<string>): string | null {
+  const roll = nextInt(state.rng, 100);
+  const rarity = roll < 4 ? "rare" : roll < 40 ? "uncommon" : "common";
+  // 依次尝试目标档 → 降级兜底，保证总能给出一张不重复的卡。
+  for (const tier of [rarity, "uncommon", "common"] as const) {
+    const candidates = cardPoolOfRarity(tier).filter(id => !exclude.has(id));
+    if (candidates.length > 0) {
+      return candidates[nextInt(state.rng, candidates.length)]!;
+    }
+  }
+  return null;
 }
 
 /** 当前屏幕可选项（渲染 + 校验 choose 用）。 */
@@ -168,7 +193,8 @@ export function currentOptions(state: GameState): string[] {
       const def = getCardDef(choice.defId);
       const cost = costOf(def, choice.upgraded);
       const desc = choice.upgraded ? def.upgradedDescription : def.description;
-      return `${def.name}${choice.upgraded ? "+" : ""} 费${cost ?? "-"} · ${desc}`;
+      const rarity = RARITY_LABELS[def.rarity] ?? "";
+      return `[${rarity}] ${def.name}${choice.upgraded ? "+" : ""} 费${cost ?? "-"} · ${desc}`;
     });
     return [...cards, "跳过（不拿卡）"];
   }

--- a/apps/spire/src/engine/types.ts
+++ b/apps/spire/src/engine/types.ts
@@ -9,6 +9,9 @@ export type CharacterId = "ironclad";
 
 export type CardType = "attack" | "skill" | "power" | "status";
 
+/** 卡稀有度：奖励按稀有度加权抽取；starter/special 不进普通奖励池。 */
+export type CardRarity = "starter" | "common" | "uncommon" | "rare" | "special";
+
 /** 状态效果标识。切片集合：被动修正器 + 时机触发机制（见 powers/）。 */
 export type PowerId =
   | "strength" // 力量：攻击伤害 +N（被动，可负、持续）
@@ -56,6 +59,7 @@ export type CardDef = {
   id: string;
   name: string;
   type: CardType;
+  rarity: CardRarity;
   cost: number | null;
   /** 需要选择一个敌人目标（攻击类多为 true；AoE / 自身增益为 false）。 */
   targeted: boolean;

--- a/apps/spire/test/card-rarity.test.ts
+++ b/apps/spire/test/card-rarity.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { generateReward } from "../src/engine/run/run.js";
+import {
+  COMMON_CARD_POOL,
+  UNCOMMON_CARD_POOL,
+  RARE_CARD_POOL,
+  getCardDef,
+} from "../src/engine/cards/cards.js";
+
+// A2：卡稀有度系统 + 奖励按稀有度加权。
+
+describe("稀有度分池", () => {
+  it("三档池非空、互不相交、不含起始/特殊", () => {
+    const all = [...COMMON_CARD_POOL, ...UNCOMMON_CARD_POOL, ...RARE_CARD_POOL];
+    expect(COMMON_CARD_POOL.length).toBeGreaterThan(0);
+    expect(UNCOMMON_CARD_POOL.length).toBeGreaterThan(0);
+    expect(RARE_CARD_POOL.length).toBeGreaterThan(0);
+    expect(new Set(all).size).toBe(all.length); // 无重复
+    for (const id of all) {
+      const r = getCardDef(id).rarity;
+      expect(["common", "uncommon", "rare"]).toContain(r);
+    }
+  });
+
+  it("新稀有卡 献焰/献祭 归入稀有池", () => {
+    expect(RARE_CARD_POOL).toContain("immolate");
+    expect(RARE_CARD_POOL).toContain("offering");
+  });
+
+  it("每档池里的卡稀有度自洽", () => {
+    for (const id of COMMON_CARD_POOL) expect(getCardDef(id).rarity).toBe("common");
+    for (const id of UNCOMMON_CARD_POOL) expect(getCardDef(id).rarity).toBe("uncommon");
+    for (const id of RARE_CARD_POOL) expect(getCardDef(id).rarity).toBe("rare");
+  });
+});
+
+describe("奖励按稀有度加权", () => {
+  it("永远给 3 张不重复、不含起始/特殊的卡", () => {
+    for (let seed = 0; seed < 60; seed += 1) {
+      const s = newRun({ runId: `r${seed}`, seed });
+      generateReward(s);
+      const choices = s.reward!.cardChoices;
+      expect(choices).toHaveLength(3);
+      expect(new Set(choices.map(c => c.defId)).size).toBe(3);
+      for (const c of choices) {
+        const r = getCardDef(c.defId).rarity;
+        expect(["common", "uncommon", "rare"]).toContain(r);
+      }
+    }
+  });
+
+  it("分布偏向普通：普通 > 罕见 > 稀有，且稀有确实会出现", () => {
+    const counts = { common: 0, uncommon: 0, rare: 0 };
+    for (let seed = 0; seed < 800; seed += 1) {
+      const s = newRun({ runId: `d${seed}`, seed });
+      generateReward(s);
+      for (const c of s.reward!.cardChoices) {
+        const r = getCardDef(c.defId).rarity as "common" | "uncommon" | "rare";
+        counts[r] += 1;
+      }
+    }
+    expect(counts.common).toBeGreaterThan(counts.uncommon);
+    expect(counts.uncommon).toBeGreaterThan(counts.rare);
+    expect(counts.rare).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
给卡牌分档，奖励掷稀有度让稀有卡有分量——全量卡池扩充的地基。Refs #234。

## 系统
- `CardDef.rarity`（starter/common/uncommon/rare/special）；**27 张现有卡全部标注**。
- 卡池按稀有度**自动派生**（`COMMON/UNCOMMON/RARE_CARD_POOL`，加卡即入池，不再手维护清单）。
- **奖励掷稀有度**：每张先掷（稀有 4% / 罕见 36% / 普通 60%）→ 从该档挑不重复卡 → 空档降级兜底；奖励行加 `[稀有度]` 标签。
- 2 张稀有纯数据卡：**献焰**(全体 21/28 + 灼烧)、**献祭**(0 费·自伤6+能量2+抽3/5·消耗)。

## 验证
门禁全绿：build/typecheck/lint(0)/format + **spire 157/157**（新增 `card-rarity.test.ts` 5 例：三档池非空互斥不含起始/特殊、新卡入稀有池、**800 局分布断言 普通>罕见>稀有 且稀有必现**、奖励恒 3 张不重复）· **agent 806**。sim stuck=0、胜场 97。

## 部署
纯 spire（奖励文案数据驱动，agent 无需改）。合并后 `app:deploy spire`。