### PR TITLE
feat(spire): 技能卡批次 8 张 + double_block/upgradedCost（Phase A · A2 续）

### DIFF
--- a/apps/spire/src/engine/cards/cards.ts
+++ b/apps/spire/src/engine/cards/cards.ts
@@ -181,6 +181,7 @@ const CARD_LIST: CardDef[] = [
     type: "attack",
     rarity: "common",
     cost: 1,
+    upgradedCost: 0,
     targeted: true,
     exhausts: false,
     effects: [{ kind: "deal_damage_equal_to_block" }],
@@ -421,6 +422,133 @@ const CARD_LIST: CardDef[] = [
     upgradedDescription: "失去 6 点生命。获得 2 点能量。抽 5 张牌。消耗。",
   },
 
+  // —— 技能/工具类扩充（A2 批次，全用既有原语）——
+  {
+    id: "ghostly_armor",
+    name: "虚魂护甲",
+    type: "skill",
+    rarity: "uncommon",
+    cost: 1,
+    targeted: false,
+    exhausts: false,
+    ethereal: true,
+    effects: [{ kind: "gain_block", amount: 10 }],
+    upgradedEffects: [{ kind: "gain_block", amount: 13 }],
+    description: "虚无。获得 10 点格挡。",
+    upgradedDescription: "虚无。获得 13 点格挡。",
+  },
+  {
+    id: "intimidate",
+    name: "恫吓",
+    type: "skill",
+    rarity: "uncommon",
+    cost: 0,
+    targeted: false,
+    exhausts: true,
+    effects: [{ kind: "apply_power", power: "weak", amount: 1, on: "all_enemies" }],
+    upgradedEffects: [{ kind: "apply_power", power: "weak", amount: 2, on: "all_enemies" }],
+    description: "对所有敌人施加 1 层虚弱。消耗。",
+    upgradedDescription: "对所有敌人施加 2 层虚弱。消耗。",
+  },
+  {
+    id: "shockwave",
+    name: "震荡波",
+    type: "skill",
+    rarity: "uncommon",
+    cost: 2,
+    targeted: false,
+    exhausts: true,
+    effects: [
+      { kind: "apply_power", power: "weak", amount: 3, on: "all_enemies" },
+      { kind: "apply_power", power: "vulnerable", amount: 3, on: "all_enemies" },
+    ],
+    upgradedEffects: [
+      { kind: "apply_power", power: "weak", amount: 5, on: "all_enemies" },
+      { kind: "apply_power", power: "vulnerable", amount: 5, on: "all_enemies" },
+    ],
+    description: "对所有敌人施加 3 层虚弱、3 层易伤。消耗。",
+    upgradedDescription: "对所有敌人施加 5 层虚弱、5 层易伤。消耗。",
+  },
+  {
+    id: "disarm",
+    name: "缴械",
+    type: "skill",
+    rarity: "uncommon",
+    cost: 1,
+    targeted: true,
+    exhausts: true,
+    effects: [{ kind: "apply_power", power: "strength", amount: -2, on: "target" }],
+    upgradedEffects: [{ kind: "apply_power", power: "strength", amount: -3, on: "target" }],
+    description: "使一个敌人失去 2 点力量。消耗。",
+    upgradedDescription: "使一个敌人失去 3 点力量。消耗。",
+  },
+  {
+    id: "bloodletting",
+    name: "放血",
+    type: "skill",
+    rarity: "uncommon",
+    cost: 0,
+    targeted: false,
+    exhausts: false,
+    effects: [
+      { kind: "lose_hp", amount: 3 },
+      { kind: "gain_energy", amount: 2 },
+    ],
+    upgradedEffects: [
+      { kind: "lose_hp", amount: 3 },
+      { kind: "gain_energy", amount: 3 },
+    ],
+    description: "失去 3 点生命。获得 2 点能量。",
+    upgradedDescription: "失去 3 点生命。获得 3 点能量。",
+  },
+  {
+    id: "seeing_red",
+    name: "见红",
+    type: "skill",
+    rarity: "uncommon",
+    cost: 1,
+    upgradedCost: 0,
+    targeted: false,
+    exhausts: true,
+    effects: [{ kind: "gain_energy", amount: 2 }],
+    upgradedEffects: [{ kind: "gain_energy", amount: 2 }],
+    description: "获得 2 点能量。消耗。",
+    upgradedDescription: "费用降为 0。获得 2 点能量。消耗。",
+  },
+  {
+    id: "power_through",
+    name: "强渡",
+    type: "skill",
+    rarity: "uncommon",
+    cost: 1,
+    targeted: false,
+    exhausts: false,
+    effects: [
+      { kind: "gain_block", amount: 15 },
+      { kind: "add_card", cardId: "wound", pile: "hand", count: 2 },
+    ],
+    upgradedEffects: [
+      { kind: "gain_block", amount: 20 },
+      { kind: "add_card", cardId: "wound", pile: "hand", count: 2 },
+    ],
+    description: "获得 15 点格挡。将两张「伤口」加入手牌。",
+    upgradedDescription: "获得 20 点格挡。将两张「伤口」加入手牌。",
+  },
+  {
+    id: "entrench",
+    name: "坚守",
+    type: "skill",
+    rarity: "uncommon",
+    cost: 2,
+    upgradedCost: 1,
+    targeted: false,
+    exhausts: false,
+    effects: [{ kind: "double_block" }],
+    upgradedEffects: [{ kind: "double_block" }],
+    description: "使当前格挡翻倍。",
+    upgradedDescription: "费用降为 1。使当前格挡翻倍。",
+  },
+
   // —— 敌人塞进牌组的废牌 / 伤口（不可打出）——
   {
     id: "wound",
@@ -536,13 +664,13 @@ export function effectsOf(def: CardDef, upgraded: boolean): CardDef["effects"] {
   return upgraded ? def.upgradedEffects : def.effects;
 }
 
-/** 取一张牌当前生效的费用（力压升级后降为 0）。 */
+/** 取一张牌当前生效的费用（升级降费卡用 upgradedCost）。 */
 export function costOf(def: CardDef, upgraded: boolean): number | null {
   if (def.cost === null) {
     return null;
   }
-  if (def.id === "body_slam" && upgraded) {
-    return 0;
+  if (upgraded && def.upgradedCost !== undefined) {
+    return def.upgradedCost;
   }
   return def.cost;
 }

--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -289,6 +289,13 @@ function applyEffect(
       }
       break;
     }
+    case "double_block": {
+      // 玩家当前格挡翻倍（坚守）。
+      if (actor.side === "player") {
+        combat.playerBlock *= 2;
+      }
+      break;
+    }
     case "gain_block_ally": {
       // 护盾地精：给一名随机存活友军（不含自己）加格挡。
       if (actor.side === "enemy") {

--- a/apps/spire/src/engine/types.ts
+++ b/apps/spire/src/engine/types.ts
@@ -44,6 +44,8 @@ export type Effect =
   // 敌人用：按玩家当前生命锁定一个每击伤害存入 rolledDamage（六火之灵激活：floor(hp/divisor)+add）。
   | { kind: "store_hp_scaled_damage"; divisor: number; add: number }
   | { kind: "gain_block"; amount: number }
+  // 玩家用：当前格挡翻倍（坚守）。
+  | { kind: "double_block" }
   // 敌人用：给一名随机存活友军加格挡（护盾地精保护）。
   | { kind: "gain_block_ally"; amount: number }
   | { kind: "apply_power"; power: PowerId; amount: number; on: "self" | "target" | "all_enemies" }
@@ -61,6 +63,8 @@ export type CardDef = {
   type: CardType;
   rarity: CardRarity;
   cost: number | null;
+  /** 升级后的费用（省略=不变）；用于力压/见红等升级降费卡。 */
+  upgradedCost?: number;
   /** 需要选择一个敌人目标（攻击类多为 true；AoE / 自身增益为 false）。 */
   targeted: boolean;
   /** 打出后进入消耗堆而非弃牌堆。 */

--- a/apps/spire/test/cards-batch.test.ts
+++ b/apps/spire/test/cards-batch.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat, playCard, endTurn } from "../src/engine/combat/combat.js";
+import { getPower } from "../src/engine/powers/powers.js";
+import { costOf, getCardDef } from "../src/engine/cards/cards.js";
+import type { CardInstance, GameState } from "../src/engine/types.js";
+
+// A2 批次：技能/工具卡（全用既有原语）+ double_block + upgradedCost + 负力量 + 虚无。
+
+function combat(encounter = "gremlin_gang"): GameState {
+  const s = newRun({ runId: "batch", seed: 1 });
+  startCombat(s, encounter);
+  s.hp = 300;
+  s.maxHp = 300;
+  for (const e of s.combat!.enemies) {
+    e.hp = 100;
+    e.maxHp = 100;
+    e.block = 0;
+    e.powers = [];
+  }
+  return s;
+}
+
+function play(s: GameState, defId: string, upgraded = false, target: number | null = null): void {
+  const card: CardInstance = { uid: s.nextUid++, defId, upgraded };
+  s.combat!.hand = [card];
+  s.combat!.energy = 3;
+  expect(playCard(s, 0, target).ok).toBe(true);
+}
+
+describe("升级降费（upgradedCost 泛化）", () => {
+  it("见红/力压/坚守 升级后费用", () => {
+    expect(costOf(getCardDef("seeing_red"), false)).toBe(1);
+    expect(costOf(getCardDef("seeing_red"), true)).toBe(0);
+    expect(costOf(getCardDef("body_slam"), true)).toBe(0);
+    expect(costOf(getCardDef("entrench"), true)).toBe(1);
+  });
+});
+
+describe("坚守：格挡翻倍", () => {
+  it("当前格挡 8 → 16", () => {
+    const s = combat();
+    s.combat!.playerBlock = 8;
+    play(s, "entrench");
+    expect(s.combat!.playerBlock).toBe(16);
+  });
+});
+
+describe("AoE 减益", () => {
+  it("恫吓给所有敌人虚弱并消耗", () => {
+    const s = combat();
+    play(s, "intimidate");
+    for (const e of s.combat!.enemies) {
+      expect(getPower(e.powers, "weak")).toBe(1);
+    }
+    expect(s.combat!.exhaustPile.some(c => c.defId === "intimidate")).toBe(true);
+  });
+
+  it("震荡波给所有敌人虚弱+易伤", () => {
+    const s = combat();
+    play(s, "shockwave");
+    for (const e of s.combat!.enemies) {
+      expect(getPower(e.powers, "weak")).toBe(3);
+      expect(getPower(e.powers, "vulnerable")).toBe(3);
+    }
+  });
+});
+
+describe("缴械：削力量（可为负）", () => {
+  it("敌人力量 -2", () => {
+    const s = combat();
+    play(s, "disarm", false, 0);
+    expect(getPower(s.combat!.enemies[0]!.powers, "strength")).toBe(-2);
+    expect(s.combat!.exhaustPile.some(c => c.defId === "disarm")).toBe(true);
+  });
+});
+
+describe("资源类", () => {
+  it("放血：失 3 血 + 2 能量", () => {
+    const s = combat();
+    s.hp = 100;
+    s.combat!.energy = 3;
+    play(s, "bloodletting");
+    expect(s.hp).toBe(97);
+    expect(s.combat!.energy).toBe(5); // 0费，3-0+2
+  });
+
+  it("见红：+2 能量并消耗", () => {
+    const s = combat();
+    s.combat!.energy = 3;
+    play(s, "seeing_red");
+    expect(s.combat!.energy).toBe(4); // 1费，3-1+2
+    expect(s.combat!.exhaustPile.some(c => c.defId === "seeing_red")).toBe(true);
+  });
+
+  it("强渡：+15 格挡 + 手牌两张伤口", () => {
+    const s = combat();
+    play(s, "power_through");
+    expect(s.combat!.playerBlock).toBe(15);
+    expect(s.combat!.hand.filter(c => c.defId === "wound")).toHaveLength(2);
+  });
+});
+
+describe("虚魂护甲：虚无", () => {
+  it("打出给 10 格挡", () => {
+    const s = combat();
+    play(s, "ghostly_armor");
+    expect(s.combat!.playerBlock).toBe(10);
+  });
+
+  it("回合结束仍在手 → 被消耗（虚无）", () => {
+    const s = combat();
+    const card: CardInstance = { uid: s.nextUid++, defId: "ghostly_armor", upgraded: false };
+    s.combat!.hand = [card];
+    endTurn(s);
+    expect(s.combat!.exhaustPile.some(c => c.defId === "ghostly_armor")).toBe(true);
+    expect(s.combat!.discardPile.some(c => c.defId === "ghostly_armor")).toBe(false);
+  });
+});


### PR DESCRIPTION
铺开利用稀有度系统的第一批新卡，充实技能/工具侧（此前偏攻击）。**全用既有原语**。Refs #234。

## 原语
- `CardDef.upgradedCost` 泛化升级降费（替掉 body_slam 的 id 特判；力压/见红/坚守共用）。
- 新 `double_block`（当前格挡翻倍，坚守用）。

## 8 张罕见卡（自动入 UNCOMMON 池 + 奖励）
虚魂护甲(虚无+10/13格挡) · 恫吓(全体虚弱·消耗) · 震荡波(全体虚弱+易伤·消耗) · 缴械(敌 -2/3 力量·消耗) · 放血(自伤3+2/3能量) · 见红(+2能量·消耗·升级0费) · 强渡(+15/20格挡+2伤口入手) · 坚守(格挡翻倍·升级1费)

## 验证
门禁全绿：build/typecheck/lint(0)/format + **spire 167/167**（新增 `cards-batch.test.ts` 10 例：升级降费泛化/格挡翻倍/AoE减益/负力量/资源/虚无消耗）· **agent 806**。sim stuck=0。（贪心胜率波动=AI不会用工具牌，非游戏问题。）

## 部署
纯 spire（卡牌数据驱动）。合并后 `app:deploy spire`。