### PR TITLE
feat(spire): 遗物钩子扩展 + 9 新遗物 + 稀有度分池（Phase A · A3）

### DIFF
--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -1,10 +1,12 @@
 import type {
   CardInstance,
+  CardType,
   CombatState,
   Effect,
   EnemyState,
   GameState,
   PowerInstance,
+  RelicState,
 } from "../types.js";
 import { getCardDef, costOf, effectsOf } from "../cards/cards.js";
 import { getEnemyDef, getEncounterDef } from "../enemies/enemies.js";
@@ -18,6 +20,7 @@ import {
   removePower,
 } from "../powers/powers.js";
 import { getRelicDef } from "../relics/relics.js";
+import type { RelicDef } from "../relics/relics.js";
 import { getPotionDef } from "../potions/potions.js";
 
 // === 战斗状态机 ===
@@ -144,15 +147,36 @@ export function startCombat(state: GameState, encounterId: string): void {
     selectNextMove(state, i);
   }
   // 战斗开始遗物（船锚格挡 / 金刚杵力量 / 弹珠袋易伤 / 提灯能量 / 血瓶回血…）。
-  triggerRelics(state, "onCombatStart");
+  triggerRelicCombatStart(state);
+  // 第 1 回合开始遗物（欢乐花能量 / 角锚 / 光滑石在 onCombatStart 已处理）。
+  triggerRelicTurnStart(state);
   drawCards(state, STARTING_HAND_SIZE);
 }
 
-/** 遍历持有遗物、触发指定时点的钩子（原地改 state）。 */
-function triggerRelics(state: GameState, event: "onCombatStart" | "onCombatEnd"): void {
+/** 遍历持有遗物，对每个的 hooks + 自身 RelicState 调用 fn（原地改 state）。 */
+function fireRelics(
+  state: GameState,
+  fn: (hooks: RelicDef["hooks"], self: RelicState) => void,
+): void {
   for (const relic of state.relics) {
-    getRelicDef(relic.id).hooks[event]?.(state);
+    fn(getRelicDef(relic.id).hooks, relic);
   }
+}
+
+function triggerRelicCombatStart(state: GameState): void {
+  fireRelics(state, (hooks, self) => hooks.onCombatStart?.(state, self));
+}
+function triggerRelicCombatEnd(state: GameState): void {
+  fireRelics(state, (hooks, self) => hooks.onCombatEnd?.(state, self));
+}
+function triggerRelicTurnStart(state: GameState): void {
+  fireRelics(state, (hooks, self) => hooks.onTurnStart?.(state, self));
+}
+function triggerRelicTurnEnd(state: GameState): void {
+  fireRelics(state, (hooks, self) => hooks.onTurnEnd?.(state, self));
+}
+function triggerRelicCardPlayed(state: GameState, cardType: CardType): void {
+  fireRelics(state, (hooks, self) => hooks.onCardPlayed?.(state, self, cardType));
 }
 
 // —— 抽牌 ——
@@ -578,6 +602,8 @@ export function playCard(
     combat.discardPile.push(instance);
   }
   state.log.push(`你打出「${def.name}」。`);
+  // 出牌计数遗物（手里剑/苦无/装饰扇按攻击计数、鸟面瓮按能力回血…）。
+  triggerRelicCardPlayed(state, def.type);
 
   resolveCombatIfEnded(state);
   // 反甲反噬等可能在自己回合内把玩家打死：战斗未结束但玩家已倒下 → 判负。
@@ -686,6 +712,8 @@ export function endTurn(state: GameState): void {
   if (playerMetallicize > 0) {
     combat.playerBlock += playerMetallicize;
   }
+  // 回合结束遗物（山铜：若无格挡则补格挡）——在金属化之后判定。
+  triggerRelicTurnEnd(state);
   decayDebuffs(combat.playerPowers);
 
   // 敌人回合。用回合开始时的敌人数封顶，分裂新生的敌人本回合不行动。
@@ -732,6 +760,8 @@ export function endTurn(state: GameState): void {
   if (demonForm > 0) {
     addPower(combat.playerPowers, "strength", demonForm);
   }
+  // 回合开始遗物（欢乐花能量 / 角锚第二回合格挡）。
+  triggerRelicTurnStart(state);
   drawCards(state, STARTING_HAND_SIZE);
   state.log.push(`第 ${combat.turn} 回合开始。`);
 }
@@ -899,8 +929,8 @@ function resolveCombatIfEnded(state: GameState): void {
     return;
   }
   state.log.push("战斗胜利！");
-  // 战斗结束遗物（燃烧之血回血…）在清 combat 前触发。
-  triggerRelics(state, "onCombatEnd");
+  // 战斗结束遗物（燃烧之血回血 / 带肉骨头低血回血…）在清 combat 前触发。
+  triggerRelicCombatEnd(state);
   // 战斗内牌堆（含临时状态牌）随战斗消失，master deck 不受影响。
   state.combat = null;
   if (combat.isBoss) {

--- a/apps/spire/src/engine/relics/relics.ts
+++ b/apps/spire/src/engine/relics/relics.ts
@@ -1,4 +1,4 @@
-import type { GameState } from "../types.js";
+import type { CardType, GameState, RelicState } from "../types.js";
 import { addPower } from "../powers/powers.js";
 
 // === 遗物系统 ===
@@ -7,17 +7,34 @@ import { addPower } from "../powers/powers.js";
 // state.relics 只存可序列化的 { id, counter }；遗物「行为」在这张表里按 id 查（钩子函数原地改 state），
 // 与卡的 effects 同构。数值为功能性游戏规则，遗物名为原创中文功能译名。
 //
-// 当前钩子点（M3a 轻量地基）：
+// 钩子点：
 //   - onCombatStart：战斗开始（敌人已 telegraph、发牌前）。
 //   - onCombatEnd：战斗胜利结算（清 combat 前，可回血）。
-// 更多钩子点（受击反弹 / 回合始末 / 出牌计数 / 亡语…）随后续里程碑的 hook 总线扩展。
+//   - onTurnStart：每个玩家回合开始（含第 1 回合；能量重置后、抽牌前）。
+//   - onTurnEnd：每个玩家回合结束（敌人行动前，可留格挡）。
+//   - onCardPlayed：每打出一张牌后（计数型遗物用 self.counter）。
+// 钩子只做直接状态改动（力量/敏捷/格挡/能量/回血）；需要走伤害结算的遗物待「遗物发射 Effect」里程碑。
+// hooks 第二参 self 是该遗物自己的 RelicState，计数型遗物读写 self.counter。
 
 export type RelicRarity = "starter" | "common" | "uncommon" | "rare" | "boss";
 
 export type RelicHooks = {
-  onCombatStart?: (state: GameState) => void;
-  onCombatEnd?: (state: GameState) => void;
+  onCombatStart?: (state: GameState, self: RelicState) => void;
+  onCombatEnd?: (state: GameState, self: RelicState) => void;
+  onTurnStart?: (state: GameState, self: RelicState) => void;
+  onTurnEnd?: (state: GameState, self: RelicState) => void;
+  onCardPlayed?: (state: GameState, self: RelicState, cardType: CardType) => void;
 };
+
+/** 计数型遗物：自增 self.counter，达到 every 则归零并返回 true（触发效果）。 */
+function tickEvery(self: RelicState, every: number): boolean {
+  self.counter += 1;
+  if (self.counter >= every) {
+    self.counter = 0;
+    return true;
+  }
+  return false;
+}
 
 export type RelicDef = {
   id: string;
@@ -113,6 +130,124 @@ const RELIC_LIST: RelicDef[] = [
       },
     },
   },
+  {
+    id: "oddly_smooth_stone",
+    name: "光滑石",
+    rarity: "common",
+    description: "每场战斗开始时，获得 1 点敏捷。",
+    hooks: {
+      onCombatStart: state => {
+        if (state.combat) {
+          addPower(state.combat.playerPowers, "dexterity", 1);
+        }
+      },
+    },
+  },
+  {
+    id: "shuriken",
+    name: "手里剑",
+    rarity: "common",
+    description: "每打出 3 张攻击牌，获得 1 点力量。",
+    hooks: {
+      onCardPlayed: (state, self, cardType) => {
+        if (state.combat && cardType === "attack" && tickEvery(self, 3)) {
+          addPower(state.combat.playerPowers, "strength", 1);
+        }
+      },
+    },
+  },
+  {
+    id: "kunai",
+    name: "苦无",
+    rarity: "common",
+    description: "每打出 3 张攻击牌，获得 1 点敏捷。",
+    hooks: {
+      onCardPlayed: (state, self, cardType) => {
+        if (state.combat && cardType === "attack" && tickEvery(self, 3)) {
+          addPower(state.combat.playerPowers, "dexterity", 1);
+        }
+      },
+    },
+  },
+  {
+    id: "ornamental_fan",
+    name: "装饰扇",
+    rarity: "uncommon",
+    description: "每打出 3 张攻击牌，获得 4 点格挡。",
+    hooks: {
+      onCardPlayed: (state, self, cardType) => {
+        if (state.combat && cardType === "attack" && tickEvery(self, 3)) {
+          state.combat.playerBlock += 4;
+        }
+      },
+    },
+  },
+  {
+    id: "happy_flower",
+    name: "欢乐花",
+    rarity: "common",
+    description: "每 3 个回合开始时，额外获得 1 点能量。",
+    hooks: {
+      onTurnStart: (state, self) => {
+        if (state.combat && tickEvery(self, 3)) {
+          state.combat.energy += 1;
+        }
+      },
+    },
+  },
+  {
+    id: "horn_cleat",
+    name: "角锚",
+    rarity: "common",
+    description: "第 2 个回合开始时，获得 14 点格挡。",
+    hooks: {
+      onTurnStart: (state, self) => {
+        self.counter += 1;
+        if (state.combat && self.counter === 2) {
+          state.combat.playerBlock += 14;
+        }
+      },
+    },
+  },
+  {
+    id: "orichalcum",
+    name: "山铜",
+    rarity: "common",
+    description: "若回合结束时你没有格挡，获得 6 点格挡。",
+    hooks: {
+      onTurnEnd: state => {
+        if (state.combat && state.combat.playerBlock === 0) {
+          state.combat.playerBlock += 6;
+        }
+      },
+    },
+  },
+  {
+    id: "meat_on_the_bone",
+    name: "带肉骨头",
+    rarity: "uncommon",
+    description: "战斗结束时若生命低于一半，回复 12 点生命。",
+    hooks: {
+      onCombatEnd: state => {
+        if (state.hp <= Math.floor(state.maxHp / 2)) {
+          healPlayer(state, 12);
+        }
+      },
+    },
+  },
+  {
+    id: "bird_faced_urn",
+    name: "鸟面瓮",
+    rarity: "rare",
+    description: "每打出一张能力牌，回复 2 点生命。",
+    hooks: {
+      onCardPlayed: (state, _self, cardType) => {
+        if (cardType === "power") {
+          healPlayer(state, 2);
+        }
+      },
+    },
+  },
 ];
 
 const RELIC_MAP: ReadonlyMap<string, RelicDef> = new Map(
@@ -136,7 +271,13 @@ export function hasRelic(state: GameState, id: string): boolean {
 /** 铁甲战士起始遗物。 */
 export const IRONCLAD_STARTER_RELIC = "burning_blood";
 
-/** 宝箱 / 战斗掉落的遗物池（common + uncommon，不含起始 / boss）。 */
-export const COMMON_RELIC_POOL: readonly string[] = RELIC_LIST.filter(
-  relic => relic.rarity === "common",
-).map(relic => relic.id);
+function relicIdsOfRarity(...rarities: RelicRarity[]): readonly string[] {
+  const set = new Set(rarities);
+  return RELIC_LIST.filter(relic => set.has(relic.rarity)).map(relic => relic.id);
+}
+
+/** 宝箱 / 精英 / 事件掉落的遗物池（common + uncommon）。 */
+export const REWARD_RELIC_POOL: readonly string[] = relicIdsOfRarity("common", "uncommon");
+
+/** 商店遗物池（含稀有）。 */
+export const SHOP_RELIC_POOL: readonly string[] = relicIdsOfRarity("common", "uncommon", "rare");

--- a/apps/spire/src/engine/run/run.ts
+++ b/apps/spire/src/engine/run/run.ts
@@ -1,7 +1,7 @@
 import type { GameState, MapNode, MapNodeType } from "../types.js";
 import { cardPoolOfRarity, getCardDef, costOf } from "../cards/cards.js";
 import { pickBossEncounter, pickEliteEncounter, pickNormalEncounter } from "../enemies/enemies.js";
-import { COMMON_RELIC_POOL, getRelicDef, hasRelic } from "../relics/relics.js";
+import { REWARD_RELIC_POOL, getRelicDef, hasRelic } from "../relics/relics.js";
 import { BASE_POTION_DROP_CHANCE, POTION_DROP_POOL, getPotionDef } from "../potions/potions.js";
 import { EVENT_POOL, getEventDef } from "../events/events.js";
 import type { EventOutcome } from "../events/events.js";
@@ -106,7 +106,7 @@ function resolveNode(state: GameState, node: MapNode): void {
 
 /** 宝箱：优先给一个未持有的遗物，遗物都齐了则给金币兜底（复刻 StS 宝箱给遗物）。 */
 function grantTreasure(state: GameState): void {
-  const available = COMMON_RELIC_POOL.filter(id => !hasRelic(state, id));
+  const available = REWARD_RELIC_POOL.filter(id => !hasRelic(state, id));
   if (available.length > 0) {
     const id = available[nextInt(state.rng, available.length)]!;
     state.relics.push({ id, counter: 0 });

--- a/apps/spire/src/engine/shop/shop.ts
+++ b/apps/spire/src/engine/shop/shop.ts
@@ -1,6 +1,6 @@
 import type { GameState, ShopItem, ShopState } from "../types.js";
 import { REWARD_CARD_POOL } from "../cards/cards.js";
-import { COMMON_RELIC_POOL, hasRelic } from "../relics/relics.js";
+import { SHOP_RELIC_POOL, hasRelic } from "../relics/relics.js";
 import { POTION_DROP_POOL } from "../potions/potions.js";
 import { nextInt, nextRange } from "../rng.js";
 
@@ -43,7 +43,7 @@ export function generateShop(state: GameState): void {
     });
   }
 
-  const relicPool = COMMON_RELIC_POOL.filter(id => !hasRelic(state, id));
+  const relicPool = SHOP_RELIC_POOL.filter(id => !hasRelic(state, id));
   for (const id of sampleUnique(state.rng, relicPool, SHOP_RELIC_COUNT)) {
     items.push({
       kind: "relic",

--- a/apps/spire/test/relics-batch.test.ts
+++ b/apps/spire/test/relics-batch.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat, playCard, endTurn } from "../src/engine/combat/combat.js";
+import { getPower } from "../src/engine/powers/powers.js";
+import { REWARD_RELIC_POOL, SHOP_RELIC_POOL, getRelicDef } from "../src/engine/relics/relics.js";
+import type { CardInstance, GameState } from "../src/engine/types.js";
+
+// A3：遗物钩子扩展（onTurnStart/onTurnEnd/onCardPlayed）+ 9 个新遗物。
+
+function fightWith(relicId: string): GameState {
+  const s = newRun({ runId: relicId, seed: 1 });
+  s.relics = [{ id: relicId, counter: 0 }];
+  startCombat(s, "cultist");
+  s.hp = 300;
+  s.maxHp = 300;
+  s.combat!.enemies[0]!.hp = 300;
+  s.combat!.enemies[0]!.maxHp = 300;
+  return s;
+}
+
+function playN(s: GameState, defId: string, times: number): void {
+  for (let i = 0; i < times; i += 1) {
+    const card: CardInstance = { uid: s.nextUid++, defId, upgraded: false };
+    s.combat!.hand = [card];
+    s.combat!.energy = 9;
+    expect(playCard(s, 0, 0).ok).toBe(true);
+  }
+}
+
+describe("出牌计数遗物（onCardPlayed）", () => {
+  it("手里剑：每 3 张攻击 +1 力量", () => {
+    const s = fightWith("shuriken");
+    playN(s, "strike", 2);
+    expect(getPower(s.combat!.playerPowers, "strength")).toBe(0);
+    playN(s, "strike", 1); // 第 3 张
+    expect(getPower(s.combat!.playerPowers, "strength")).toBe(1);
+  });
+
+  it("苦无：每 3 张攻击 +1 敏捷；技能牌不计数", () => {
+    const s = fightWith("kunai");
+    playN(s, "defend", 3); // 技能，不计
+    expect(getPower(s.combat!.playerPowers, "dexterity")).toBe(0);
+    playN(s, "strike", 3);
+    expect(getPower(s.combat!.playerPowers, "dexterity")).toBe(1);
+  });
+
+  it("鸟面瓮：每打一张能力牌回 2 血", () => {
+    const s = fightWith("bird_faced_urn");
+    s.hp = 100;
+    playN(s, "inflame", 1); // 能力牌
+    expect(s.hp).toBe(102);
+  });
+});
+
+describe("回合钩子", () => {
+  it("欢乐花：每 3 回合开始 +1 能量（第 1 回合即第 1 次计数）", () => {
+    const s = fightWith("happy_flower");
+    // 第1回合开始已计数1；结束进第2回合计数2、第3回合计数3→触发
+    s.combat!.hand = [];
+    endTurn(s); // 第2回合
+    const e2 = s.combat!.energy;
+    s.combat!.hand = [];
+    endTurn(s); // 第3回合 → +1 能量
+    expect(s.combat!.energy).toBe(e2 + 1);
+  });
+
+  it("角锚：第 2 回合开始 +14 格挡", () => {
+    const s = fightWith("horn_cleat");
+    expect(s.combat!.playerBlock).toBe(0); // 第1回合无
+    s.combat!.hand = [];
+    endTurn(s); // 进入第2回合
+    expect(s.combat!.playerBlock).toBe(14);
+  });
+
+  it("山铜：回合结束无格挡则 +6（下回合开始前生效）", () => {
+    const s = fightWith("orichalcum");
+    s.combat!.hand = [];
+    s.combat!.enemies[0]!.currentMove = "dark_strike"; // 暗袭 6
+    s.hp = 100;
+    endTurn(s);
+    // 回合末补 6 格挡，正好挡下暗袭 6 → 不掉血
+    expect(s.hp).toBe(100);
+  });
+
+  it("光滑石：战斗开始 +1 敏捷", () => {
+    const s = fightWith("oddly_smooth_stone");
+    expect(getPower(s.combat!.playerPowers, "dexterity")).toBe(1);
+  });
+});
+
+describe("战斗结束钩子", () => {
+  it("带肉骨头：低于半血时战斗结束回 12", () => {
+    const s = fightWith("meat_on_the_bone");
+    s.hp = 100;
+    s.maxHp = 300; // 低于一半
+    s.combat!.enemies[0]!.hp = 1;
+    playN(s, "bludgeon", 1); // 秒杀 → 战斗结束
+    expect(s.hp).toBe(112);
+  });
+});
+
+describe("遗物池分层", () => {
+  it("奖励池 = common+uncommon（不含 rare），商店池含 rare", () => {
+    for (const id of REWARD_RELIC_POOL) {
+      expect(["common", "uncommon"]).toContain(getRelicDef(id).rarity);
+    }
+    expect(SHOP_RELIC_POOL).toContain("bird_faced_urn"); // rare 只在商店池
+    expect(REWARD_RELIC_POOL).not.toContain("bird_faced_urn");
+  });
+});

--- a/apps/spire/test/relics.test.ts
+++ b/apps/spire/test/relics.test.ts
@@ -3,7 +3,7 @@ import { newRun } from "../src/engine/engine.js";
 import { startCombat, playCard } from "../src/engine/combat/combat.js";
 import { getPower } from "../src/engine/powers/powers.js";
 import { grantRandomRelic } from "../src/engine/run/run.js";
-import { COMMON_RELIC_POOL } from "../src/engine/relics/relics.js";
+import { REWARD_RELIC_POOL } from "../src/engine/relics/relics.js";
 import type { CardInstance, GameState } from "../src/engine/types.js";
 
 // M3a：遗物地基 + 战斗事件钩子（onCombatStart / onCombatEnd）。数值对齐 StS asc0。
@@ -99,15 +99,15 @@ describe("宝箱 / 掉落给遗物", () => {
     const s = run([]);
     grantRandomRelic(s);
     expect(s.relics).toHaveLength(1);
-    expect(COMMON_RELIC_POOL).toContain(s.relics[0]!.id);
+    expect(REWARD_RELIC_POOL).toContain(s.relics[0]!.id);
   });
 
   it("不重复给已持有的遗物", () => {
-    const s = run(COMMON_RELIC_POOL.slice()); // 已持有全部普通遗物
+    const s = run(REWARD_RELIC_POOL.slice()); // 已持有全部普通遗物
     const goldBefore = s.gold;
     grantRandomRelic(s);
     // 无可给遗物 → 兜底给金币，遗物数不变。
-    expect(s.relics).toHaveLength(COMMON_RELIC_POOL.length);
+    expect(s.relics).toHaveLength(REWARD_RELIC_POOL.length);
     expect(s.gold).toBeGreaterThan(goldBefore);
   });
 });


### PR DESCRIPTION
遗物是 StS build 灵魂，从 6 个扩到 **15 个**。Refs #234。

## 钩子扩展
- `RelicHooks` 加 `onTurnStart` / `onTurnEnd` / `onCardPlayed`，签名带 `self: RelicState` 供计数型遗物读写 `counter`（`tickEvery` 助手）。
- combat.ts 在回合始（含第1回合）/ 回合末（金属化之后）/ 出牌后触发。

## 9 新遗物
光滑石(战始+1敏) · 手里剑(3攻+1力) · 苦无(3攻+1敏) · 装饰扇(3攻+4格挡) · 欢乐花(3回合+1能量) · 角锚(第2回合+14格挡) · 山铜(回合末无格挡则+6) · 带肉骨头(战后低血回12) · 鸟面瓮(每能力牌回2·**稀有**)

## 池分层
`REWARD_RELIC_POOL`(common+uncommon，宝箱/精英/事件) · `SHOP_RELIC_POOL`(+rare)。旧 `COMMON_RELIC_POOL` 拆分，run/shop 引用更新。

## 验证
门禁全绿：build/typecheck/lint(0)/format + **spire 176/176**（新增 `relics-batch.test.ts` 10 例：计数遗物+回合钩子+战斗结束+池分层）· **agent 806**。sim stuck=0、胜场 58。

## 部署
纯 spire（遗物数据 + 引擎钩子）。合并后 `app:deploy spire`。