### PR TITLE
feat(spire): 事件池扩到 10 个（+6 原创事件）（Phase A · A5）

### DIFF
--- a/apps/spire/src/engine/events/events.ts
+++ b/apps/spire/src/engine/events/events.ts
@@ -93,6 +93,113 @@ const EVENT_LIST: EventDef[] = [
     ],
   },
   {
+    id: "ragged_beggar",
+    description: "一个裹着破布的乞儿蹲在墙角，见你走近，怯生生地伸出了手。",
+    choices: [
+      {
+        label: "施舍他 30 金币",
+        resultText: "他攥紧铜板，从怀里掏出一件旧物硬塞给你，说是祖上传下的护身符。",
+        outcomes: [{ kind: "lose_gold", amount: 30 }, { kind: "gain_relic" }],
+      },
+      {
+        label: "摇摇头走开",
+        resultText: "你没有停留，身后的呼唤很快被风声盖过。",
+        outcomes: [{ kind: "nothing" }],
+      },
+    ],
+  },
+  {
+    id: "dusty_bookshelf",
+    description: "一排蒙尘的书架斜倚在墙上，大多已被虫蛀，只有一本还算完整。",
+    choices: [
+      {
+        label: "通读那本兵书",
+        resultText: "字句晦涩，可读罢你只觉一股火气在胸腔里烧了起来。",
+        outcomes: [{ kind: "add_card", cardId: "inflame" }],
+      },
+      {
+        label: "撕下书页生火取暖",
+        resultText: "火光跳动，你就着暖意歇了好一会儿。",
+        outcomes: [{ kind: "heal", amount: 15 }],
+      },
+    ],
+  },
+  {
+    id: "blood_altar",
+    description: "一方暗红的石台立在房间中央，凹槽里干涸的痕迹还残着腥气，像在等待新的供奉。",
+    choices: [
+      {
+        label: "割破手掌，献上鲜血",
+        resultText: "血珠落进凹槽的刹那，石台亮起，一件器物凭空落入你手。",
+        outcomes: [{ kind: "lose_hp", amount: 10 }, { kind: "gain_relic" }],
+      },
+      {
+        label: "收回手，退开",
+        resultText: "你压下心底那点悸动，绕过石台离开了。",
+        outcomes: [{ kind: "nothing" }],
+      },
+    ],
+  },
+  {
+    id: "glowing_pool",
+    description: "地面裂缝里积着一汪泛着微光的水潭，光影随你的呼吸轻轻晃动。",
+    choices: [
+      {
+        label: "掬起一捧饮下",
+        resultText: "清冽的凉意一路淌到四肢百骸，你觉得自己比先前更耐得住了。",
+        outcomes: [{ kind: "gain_max_hp", amount: 8 }],
+      },
+      {
+        label: "用潭水冲洗伤口",
+        resultText: "伤处的刺痛迅速退去，血也止住了。",
+        outcomes: [{ kind: "heal", amount: 20 }],
+      },
+      {
+        label: "探手到潭底摸索",
+        resultText: "指尖触到几枚沉底的钱币，也被潭里不知名的东西划了一下。",
+        outcomes: [
+          { kind: "gain_gold", amount: 30 },
+          { kind: "lose_hp", amount: 5 },
+        ],
+      },
+    ],
+  },
+  {
+    id: "weapon_rack",
+    description: "一排废弃的兵器斜插在架上，大半锈成了废铁，只有一柄还透着寒光。",
+    choices: [
+      {
+        label: "取下那柄趁手的重刃",
+        resultText: "你掂了掂分量，正合手——这一路总算多了件像样的家伙。",
+        outcomes: [{ kind: "add_card", cardId: "heavy_blade" }],
+      },
+      {
+        label: "把能拆的金属都拆下变卖",
+        resultText: "锈铁不值钱，可积少成多也换了几枚硬币。",
+        outcomes: [{ kind: "gain_gold", amount: 25 }],
+      },
+    ],
+  },
+  {
+    id: "lone_grave",
+    description: "一座无名孤坟立在路旁，土堆前的粗陶碗里还压着几枚发黑的铜钱。",
+    choices: [
+      {
+        label: "掘开坟冢取走陪葬",
+        resultText: "你搜刮到一小袋钱币，但心口莫名一沉，像是揣上了什么甩不掉的东西。",
+        outcomes: [
+          { kind: "gain_gold", amount: 40 },
+          { kind: "add_card", cardId: "wound" },
+        ],
+      },
+      {
+        label: "添一抔新土，默立片刻",
+        resultText: "你替这无名之人整了整坟头，起身时觉得脚步竟稳了几分。",
+        outcomes: [{ kind: "gain_max_hp", amount: 6 }],
+      },
+    ],
+  },
+  {
     id: "fungal_ring",
     description: "一圈鼓胀的蘑菇在幽光里轻轻搏动，凑近能闻到一股又腥又甜的气味。",
     choices: [

--- a/apps/spire/test/events.test.ts
+++ b/apps/spire/test/events.test.ts
@@ -16,7 +16,7 @@ function atEvent(eventId: string): GameState {
 
 describe("事件数据", () => {
   it("每个事件都有描述和至少两个带结果文案的选项", () => {
-    expect(ALL_EVENTS.length).toBeGreaterThanOrEqual(4);
+    expect(ALL_EVENTS.length).toBeGreaterThanOrEqual(10);
     for (const event of ALL_EVENTS) {
       expect(event.description.length).toBeGreaterThan(0);
       expect(event.choices.length).toBeGreaterThanOrEqual(2);
@@ -98,5 +98,22 @@ describe("事件结算", () => {
   it("非法选项被拒", () => {
     const s = atEvent("cooling_embers");
     expect(applyChoose(s, 9).ok).toBe(false);
+  });
+
+  it("武器架·取重刃 → 牌组加入一张重刃", () => {
+    const s = atEvent("weapon_rack");
+    const before = s.deck.length;
+    expect(applyChoose(s, 0).ok).toBe(true);
+    expect(s.deck.length).toBe(before + 1);
+    expect(s.deck.some(c => c.defId === "heavy_blade")).toBe(true);
+  });
+
+  it("血色祭坛·献血 → 失血得遗物", () => {
+    const s = atEvent("blood_altar");
+    s.hp = 50;
+    const relicsBefore = s.relics.length;
+    expect(applyChoose(s, 0).ok).toBe(true);
+    expect(s.hp).toBe(40);
+    expect(s.relics.length).toBeGreaterThanOrEqual(relicsBefore); // 得遗物或金币兜底
   });
 });


### PR DESCRIPTION
未知(?)房间从 4 个事件扩到 **10 个**，纯数据、**原创文案**、复用现有 EventOutcome。Refs #234。

## 新增 6 事件
褴褛乞儿(施舍换遗物) · 蒙尘书架(读兵书得燃怒 / 撕页回血) · 血色祭坛(献血换遗物) · 发光水潭(饮水+最大生命 / 洗伤回血 / 探底得金-血) · 废弃武器架(取重刃 / 拆铁卖钱) · 无名孤坟(掘墓得金+伤口 / 敬立+最大生命)

## 验证
门禁全绿：build/typecheck/lint(0)/format + **spire 178/178**（events 用例强化到 ≥10 + 武器架取重刃/祭坛献血点检）。sim stuck=0。

## 部署
纯 spire（事件数据）。合并后 `app:deploy spire`。