### PR TITLE
feat(spire): 商店去牌服务 purge（Phase A · A7）

### DIFF
--- a/apps/spire/src/engine/run/run.ts
+++ b/apps/spire/src/engine/run/run.ts
@@ -210,6 +210,15 @@ export function currentOptions(state: GameState): string[] {
     return getEventDef(state.event.id).choices.map(choice => choice.label);
   }
   if (state.screen === "shop" && state.shop) {
+    // 去牌子界面：列可移除的牌 + 取消。
+    if (state.shop.removing) {
+      const cards = state.deck.map(card => {
+        const def = getCardDef(card.defId);
+        return `移除「${def.name}${card.upgraded ? "+" : ""}」`;
+      });
+      cards.push("取消");
+      return cards;
+    }
     const options = state.shop.items.map(item => {
       const name = shopItemName(item);
       if (item.sold) {
@@ -218,7 +227,10 @@ export function currentOptions(state: GameState): string[] {
       const affordable = state.gold >= item.cost ? "" : "（金币不足）";
       return `${name} — ${item.cost} 金${affordable}`;
     });
-    options.push("离开商店");
+    const purge = state.shop.purgeUsed
+      ? "去牌服务（已用过）"
+      : `移除一张牌 — ${state.shop.purgeCost} 金${state.gold >= state.shop.purgeCost ? "" : "（金币不足）"}`;
+    options.push(purge, "离开商店");
     return options;
   }
   return [];
@@ -341,17 +353,48 @@ export function applyChoose(state: GameState, optionIndex: number): ChooseResult
   }
 
   if (state.screen === "shop" && state.shop) {
-    const items = state.shop.items;
+    const shop = state.shop;
+    // 去牌子界面：选一张牌移除，或取消。
+    if (shop.removing) {
+      if (optionIndex === state.deck.length) {
+        shop.removing = false;
+        return { ok: true };
+      }
+      const card = state.deck[optionIndex];
+      if (!card) {
+        return { ok: false, reason: `选项 ${optionIndex} 无效。` };
+      }
+      state.gold -= shop.purgeCost;
+      state.deck.splice(optionIndex, 1);
+      shop.purgeUsed = true;
+      shop.removing = false;
+      state.log.push(`你花 ${shop.purgeCost} 金移除了「${getCardDef(card.defId).name}」。`);
+      return { ok: true };
+    }
+    const items = shop.items;
+    if (optionIndex < items.length) {
+      return buyShopItem(state, items[optionIndex]!);
+    }
     if (optionIndex === items.length) {
+      // 去牌服务：进入选牌子界面。
+      if (shop.purgeUsed) {
+        return { ok: false, reason: "本店的去牌服务已经用过了。" };
+      }
+      if (state.gold < shop.purgeCost) {
+        return { ok: false, reason: `金币不足：去牌需 ${shop.purgeCost}，你只有 ${state.gold}。` };
+      }
+      if (state.deck.length === 0) {
+        return { ok: false, reason: "牌组里没有可移除的牌。" };
+      }
+      shop.removing = true;
+      return { ok: true };
+    }
+    if (optionIndex === items.length + 1) {
       state.shop = null;
       backToMap(state);
       return { ok: true };
     }
-    const item = items[optionIndex];
-    if (!item) {
-      return { ok: false, reason: `选项 ${optionIndex} 无效。` };
-    }
-    return buyShopItem(state, item);
+    return { ok: false, reason: `选项 ${optionIndex} 无效。` };
   }
 
   if (state.screen === "event" && state.event) {

--- a/apps/spire/src/engine/shop/shop.ts
+++ b/apps/spire/src/engine/shop/shop.ts
@@ -19,6 +19,7 @@ const RELIC_PRICE_MIN = 140;
 const RELIC_PRICE_MAX = 180;
 const POTION_PRICE_MIN = 50;
 const POTION_PRICE_MAX = 70;
+const PURGE_COST = 75;
 
 /** 从池里不重复抽 count 个 id。 */
 function sampleUnique(rng: GameState["rng"], pool: readonly string[], count: number): string[] {
@@ -62,6 +63,11 @@ export function generateShop(state: GameState): void {
     });
   }
 
-  state.shop = { items } satisfies ShopState;
+  state.shop = {
+    items,
+    purgeCost: PURGE_COST,
+    purgeUsed: false,
+    removing: false,
+  } satisfies ShopState;
   state.screen = "shop";
 }

--- a/apps/spire/src/engine/types.ts
+++ b/apps/spire/src/engine/types.ts
@@ -208,7 +208,15 @@ export type ShopItem =
   | { kind: "potion"; id: string; cost: number; sold: boolean };
 
 /** 商店库存（进店时一次性生成，定价固定）。 */
-export type ShopState = { items: ShopItem[] };
+export type ShopState = {
+  items: ShopItem[];
+  /** 去牌服务费用。 */
+  purgeCost: number;
+  /** 本店去牌服务是否已用（每店限一次）。 */
+  purgeUsed: boolean;
+  /** 是否处于「选择要移除的牌」子界面。 */
+  removing: boolean;
+};
 
 /** RNG 内部状态：必须完整可序列化并从存档精确复原（issue #234 C11）。 */
 export type RngState = { s0: number; s1: number; s2: number; s3: number };

--- a/apps/spire/src/sim/policy.ts
+++ b/apps/spire/src/sim/policy.ts
@@ -46,6 +46,13 @@ export function legalActions(state: GameState): GameAction[] {
     }));
   }
   if (state.screen === "shop" && state.shop) {
+    // 去牌子界面：移除任意一张牌或取消（都推进流程）。
+    if (state.shop.removing) {
+      return Array.from({ length: state.deck.length + 1 }, (_, optionIndex) => ({
+        type: "choose" as const,
+        optionIndex,
+      }));
+    }
     // 只列「买得起且未售」的商品 + 离开，避免策略卡在非法购买上。
     const actions: GameAction[] = [];
     state.shop.items.forEach((item, optionIndex) => {
@@ -54,7 +61,7 @@ export function legalActions(state: GameState): GameAction[] {
         actions.push({ type: "choose", optionIndex });
       }
     });
-    actions.push({ type: "choose", optionIndex: state.shop.items.length }); // 离开
+    actions.push({ type: "choose", optionIndex: state.shop.items.length + 1 }); // 离开
     return actions;
   }
   if (state.screen === "reward" || state.screen === "rest") {
@@ -90,9 +97,12 @@ export class RandomPolicy implements Policy {
 /** 贪心：能打的攻击往最低血敌人砸、否则出防御，最后 end_turn；非战斗屏永远选第一项。 */
 export class GreedyPolicy implements Policy {
   public decide(state: GameState): GameAction {
-    // 商店：贪心不购物，直接离开（离开是最后一个选项），避免卡在售罄/买不起上。
+    // 商店：贪心不购物也不去牌，直接离开（去牌子界面则取消），避免卡在售罄/买不起上。
     if (state.screen === "shop" && state.shop) {
-      return { type: "choose", optionIndex: state.shop.items.length };
+      if (state.shop.removing) {
+        return { type: "choose", optionIndex: state.deck.length }; // 取消
+      }
+      return { type: "choose", optionIndex: state.shop.items.length + 1 }; // 离开
     }
     if (state.screen !== "combat" || !state.combat) {
       return { type: "choose", optionIndex: 0 };

--- a/apps/spire/test/shop.test.ts
+++ b/apps/spire/test/shop.test.ts
@@ -26,11 +26,12 @@ describe("商店库存", () => {
     }
   });
 
-  it("选项 = 各商品 + 离开", () => {
+  it("选项 = 各商品 + 去牌 + 离开", () => {
     const s = shop();
     const options = currentOptions(s);
-    expect(options).toHaveLength(s.shop!.items.length + 1);
+    expect(options).toHaveLength(s.shop!.items.length + 2);
     expect(options[options.length - 1]).toBe("离开商店");
+    expect(options[options.length - 2]).toContain("移除一张牌");
   });
 });
 
@@ -90,9 +91,57 @@ describe("购买", () => {
 describe("离开", () => {
   it("选最后一项离开 → 回地图、清空 shop", () => {
     const s = shop();
-    const leaveIdx = s.shop!.items.length;
+    const leaveIdx = s.shop!.items.length + 1; // 商品 + 去牌 + 离开
     expect(applyChoose(s, leaveIdx).ok).toBe(true);
     expect(s.screen).toBe("map");
     expect(s.shop).toBeNull();
+  });
+});
+
+describe("去牌服务", () => {
+  function purgeIndex(s: GameState): number {
+    return s.shop!.items.length; // 商品之后、离开之前
+  }
+
+  it("选去牌 → 进选牌子界面，列牌组 + 取消", () => {
+    const s = shop();
+    s.gold = 9999;
+    expect(applyChoose(s, purgeIndex(s)).ok).toBe(true);
+    expect(s.shop!.removing).toBe(true);
+    const options = currentOptions(s);
+    expect(options).toHaveLength(s.deck.length + 1);
+    expect(options[options.length - 1]).toBe("取消");
+  });
+
+  it("移除一张牌：扣 75 金、牌组少一张、每店限一次", () => {
+    const s = shop();
+    s.gold = 200;
+    const deckBefore = s.deck.length;
+    applyChoose(s, purgeIndex(s)); // 进子界面
+    expect(applyChoose(s, 0).ok).toBe(true); // 移除第 0 张
+    expect(s.deck.length).toBe(deckBefore - 1);
+    expect(s.gold).toBe(125);
+    expect(s.shop!.purgeUsed).toBe(true);
+    expect(s.shop!.removing).toBe(false);
+    // 再次去牌被拒
+    expect(applyChoose(s, purgeIndex(s)).ok).toBe(false);
+  });
+
+  it("金币不足不能去牌", () => {
+    const s = shop();
+    s.gold = 10;
+    expect(applyChoose(s, purgeIndex(s)).ok).toBe(false);
+    expect(s.shop!.removing).toBe(false);
+  });
+
+  it("子界面选取消 → 回商店、不扣钱", () => {
+    const s = shop();
+    s.gold = 200;
+    applyChoose(s, purgeIndex(s));
+    const cancelIdx = s.deck.length;
+    expect(applyChoose(s, cancelIdx).ok).toBe(true);
+    expect(s.shop!.removing).toBe(false);
+    expect(s.gold).toBe(200);
+    expect(s.shop!.purgeUsed).toBe(false);
   });
 });


### PR DESCRIPTION
补上商店的**去牌服务**——去牌是 StS 组牌核心（洗掉起始打击/防御瘦身）。Refs #234。

- ShopState 加 purgeCost(75)/purgeUsed/removing；商店多「移除一张牌」选项。
- 两步子界面：选去牌→列牌组+取消→移除一张(扣75金)或取消；每店限一次。options 驱动无契约改动。
- sim 适配 leave 索引+1、子界面枚举。

门禁全绿：spire 182/182（+去牌 4 例）。sim 双策略 stuck=0。纯 spire 部署。