### PR TITLE
feat(spire): 开局涅奥祝福（Phase A · A6）

### DIFF
--- a/apps/agent/static/context/spire-screen.hbs
+++ b/apps/agent/static/context/spire-screen.hbs
@@ -46,7 +46,7 @@
 {{/each}}
 用 invoke(tool="choose", option_index=编号) 选择。
 {{else if isEvent}}
-未知房间。你：生命 {{hp}}/{{maxHp}}　金币 {{gold}}　牌组 {{deckCount}} 张。
+你：生命 {{hp}}/{{maxHp}}　金币 {{gold}}　牌组 {{deckCount}} 张。
 {{eventDescription}}
 你可以：
 {{#each options}}

--- a/apps/spire/src/engine/engine.ts
+++ b/apps/spire/src/engine/engine.ts
@@ -5,6 +5,7 @@ import { seedRng } from "./rng.js";
 import { endTurn, playCard, usePotion } from "./combat/combat.js";
 import { applyChoose, buildMap, generateReward } from "./run/run.js";
 import { POTION_SLOTS } from "./potions/potions.js";
+import { NEOW_EVENT_ID } from "./events/events.js";
 
 // === 引擎顶层：新建对局 + 动作分发 ===
 //
@@ -61,6 +62,9 @@ export function newRun(input: {
     log: [],
   };
   buildMap(state);
+  // 开局先给涅奥祝福（复用事件界面）；选完 backToMap 回到已生成的地图。
+  state.event = { id: NEOW_EVENT_ID };
+  state.screen = "event";
   return state;
 }
 

--- a/apps/spire/src/engine/events/events.ts
+++ b/apps/spire/src/engine/events/events.ts
@@ -29,7 +29,37 @@ export type EventDef = {
   choices: EventChoice[];
 };
 
+// 开局祝福（涅奥）：不进 ? 节点池，只在 newRun 时作为第一个界面出现（复用事件机制）。
+export const NEOW_EVENT_ID = "neow_blessing";
+
 const EVENT_LIST: EventDef[] = [
+  {
+    id: NEOW_EVENT_ID,
+    description:
+      "尖塔脚下，一团柔和的光影缓缓聚成人形，向你伸出手——它说，愿为踏塔者赠上一份临行的祝福。",
+    choices: [
+      {
+        label: "强健体魄（最大生命 +8）",
+        resultText: "一股暖流沉入四肢，你觉得自己比来时更结实了。",
+        outcomes: [{ kind: "gain_max_hp", amount: 8 }],
+      },
+      {
+        label: "满囊金币（+100 金币）",
+        resultText: "沉甸甸的钱袋落进你手心。",
+        outcomes: [{ kind: "gain_gold", amount: 100 }],
+      },
+      {
+        label: "神秘馈赠（获得一件遗物）",
+        resultText: "光影散去，一件古旧的器物留在了你掌中。",
+        outcomes: [{ kind: "gain_relic" }],
+      },
+      {
+        label: "行者补给（一瓶药水 + 回 10 生命）",
+        resultText: "你的行囊里多了一瓶药水，旅途的倦意也消了几分。",
+        outcomes: [{ kind: "gain_potion" }, { kind: "heal", amount: 10 }],
+      },
+    ],
+  },
   {
     id: "cooling_embers",
     description: "半塌的石室中央，一堆灰烬还残着余温，灰里似乎埋着被人匆忙丢下的东西。",
@@ -239,4 +269,7 @@ export function getEventDef(id: string): EventDef {
   return def;
 }
 
-export const EVENT_POOL: readonly string[] = EVENT_LIST.map(event => event.id);
+/** ? 节点事件池（不含开局祝福涅奥）。 */
+export const EVENT_POOL: readonly string[] = EVENT_LIST.filter(
+  event => event.id !== NEOW_EVENT_ID,
+).map(event => event.id);

--- a/apps/spire/test/engine.test.ts
+++ b/apps/spire/test/engine.test.ts
@@ -8,15 +8,25 @@ import { GreedyPolicy } from "../src/sim/policy.js";
 import type { GameState } from "../src/engine/types.js";
 
 describe("newRun", () => {
-  it("铁甲战士开局：80 血、10 张起始牌、落在地图选路屏", () => {
+  it("铁甲战士开局：80 血、10 张起始牌、先落在涅奥祝福屏", () => {
     const state = newRun({ runId: "t", seed: 123 });
     expect(state.hp).toBe(80);
     expect(state.maxHp).toBe(80);
     expect(state.deck).toHaveLength(10);
-    expect(state.screen).toBe("map");
+    expect(state.screen).toBe("event");
+    expect(state.event?.id).toBe("neow_blessing");
     expect(state.combat).toBeNull();
     expect(state.currentNodeId).toBeNull();
     expect(state.map.startNodeIds.length).toBeGreaterThan(0);
+  });
+
+  it("选完涅奥祝福后进入地图", () => {
+    const state = newRun({ runId: "t", seed: 123 });
+    const before = state.maxHp;
+    applyAction(state, { type: "choose", optionIndex: 0 }); // 最大生命 +8
+    expect(state.screen).toBe("map");
+    expect(state.event).toBeNull();
+    expect(state.maxHp).toBe(before + 8);
   });
 
   it("分支地图：底层入口全是战斗、有 Boss 节点", () => {


### PR DESCRIPTION
每局**开场先给一次祝福四选一**——复刻 StS 的 Neow 开场。Refs #234。

## 改动
- **复用事件机制**：新增 `neow_blessing` 事件（4 boon：最大生命 +8 / +100 金 / 得遗物 / 药水+回血）；`NEOW_EVENT_ID` 从 ? 节点池 `EVENT_POOL` 排除。
- `newRun` 生成地图后先落 neow 事件屏，选完 `backToMap` 进地图。
- 事件屏 hbs 去掉硬编码「未知房间」前缀（改由各事件描述定调，涅奥不再误读成房间）。

## 验证
门禁全绿：build/typecheck/lint(0)/format + **spire 183/183**（engine 测试补「开局落祝福屏」+「选完进地图」2 例）· **agent 806**。sim 贪心 300 局 stuck=0、胜场 85、平均第 12 层。

## 部署
spire + agent（事件屏 hbs）。合并后 `app:deploy spire` + `app:deploy agent`。