### PR TITLE
feat(spire): 拾荒者(偷金+逃跑) + 红色奴隶主(缠绕)（Phase A · A-mob）

### DIFF
--- a/apps/agent/src/agent/capabilities/spire/render/spire-screen.ts
+++ b/apps/agent/src/agent/capabilities/spire/render/spire-screen.ts
@@ -21,6 +21,7 @@ const POWER_LABELS: Record<string, string> = {
   vulnerable: "易伤",
   weak: "虚弱",
   frail: "脆弱",
+  entangled: "缠绕",
   metallicize: "金属化",
   ritual: "仪式",
   curl_up: "蜷缩",

--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -54,8 +54,9 @@ const HEXAGHOST_RITUAL = [
 
 type ActorRef = { side: "player" } | { side: "enemy"; index: number };
 
+/** 仍在场的敌人：活着且未逃跑（逃跑的拾荒者退出战斗，不再算作战斗目标）。 */
 function livingEnemies(combat: CombatState): EnemyState[] {
-  return combat.enemies.filter(enemy => enemy.hp > 0);
+  return combat.enemies.filter(enemy => enemy.hp > 0 && !enemy.escaped);
 }
 
 function actorPowers(state: GameState, actor: ActorRef): PowerInstance[] {
@@ -112,6 +113,7 @@ function createEnemyState(state: GameState, defId: string, hpOverride?: number):
     rolledDamage,
     asleep,
     hasSplit: false,
+    escaped: false,
     modeShiftAccum: 0,
     modeShiftThreshold: def.modeShiftThreshold ?? null,
     stance: def.stanceMoves ? "offensive" : null,
@@ -370,6 +372,21 @@ function applyEffect(
       }
       break;
     }
+    case "steal_gold": {
+      // 敌人偷金币（拾荒者）：最多偷 amount，玩家金币不足则偷光。
+      if (actor.side === "enemy") {
+        state.gold = Math.max(0, state.gold - Math.min(state.gold, effect.amount));
+      }
+      break;
+    }
+    case "escape": {
+      // 敌人逃离战斗（拾荒者）：标记 escaped，不再算作战斗目标。
+      if (actor.side === "enemy") {
+        combat.enemies[actor.index]!.escaped = true;
+        state.log.push(`${combat.enemies[actor.index]!.name}逃走了。`);
+      }
+      break;
+    }
     case "add_card": {
       addCards(state, effect.cardId, effect.pile, effect.count);
       break;
@@ -412,7 +429,12 @@ function applyPowerEffect(
   }
 }
 
-const DEBUFF_POWERS: ReadonlySet<PowerInstance["id"]> = new Set(["vulnerable", "weak", "frail"]);
+const DEBUFF_POWERS: ReadonlySet<PowerInstance["id"]> = new Set([
+  "vulnerable",
+  "weak",
+  "frail",
+  "entangled",
+]);
 
 /** 给敌人加 power；若是减益且敌人有神器，则消耗一层神器抵消（哨卫）。 */
 function applyPowerToEnemy(enemy: EnemyState, power: PowerInstance["id"], amount: number): void {
@@ -586,6 +608,9 @@ export function playCard(
     return { ok: false, reason: `手牌位 ${handIndex} 无效。` };
   }
   const def = getCardDef(instance.defId);
+  if (def.type === "attack" && getPower(combat.playerPowers, "entangled") > 0) {
+    return { ok: false, reason: "你被缠绕了，本回合无法打出攻击牌。" };
+  }
   const cost = costOf(def, instance.upgraded);
   if (cost === null) {
     return { ok: false, reason: `「${def.name}」无法打出。` };
@@ -760,7 +785,7 @@ export function endTurn(state: GameState): void {
   const enemyCount = combat.enemies.length;
   for (let i = 0; i < enemyCount; i += 1) {
     const enemy = combat.enemies[i]!;
-    if (enemy.hp <= 0) {
+    if (enemy.hp <= 0 || enemy.escaped) {
       continue;
     }
     // 半血分裂：本体消失，原位与末位各生成一个分裂体（HP = 当前值），本回合不行动。
@@ -789,6 +814,12 @@ export function endTurn(state: GameState): void {
     decayDebuffs(enemy.powers);
     // 下一招 telegraph（守卫者的姿态推进与防御→进攻切换在 selectNextMove 内处理）。
     selectNextMove(state, i);
+  }
+
+  // 敌人全部逃跑 / 死亡 → 战斗结束（拾荒者逃走后无人可打）。
+  resolveCombatIfEnded(state);
+  if (state.combat === null) {
+    return;
   }
 
   // 下个玩家回合开始。
@@ -844,6 +875,45 @@ function selectNextMove(state: GameState, enemyIndex: number): void {
     }
     enemy.rotationIndex = (enemy.rotationIndex + 1) % cycle.length;
     enemy.currentMove = cycle[enemy.rotationIndex]!;
+    return;
+  }
+
+  // 拾荒者：抢劫×2 → 猛扑或烟雾弹 → 逃跑（偷完金币就跑）。
+  if (enemy.defId === "looter") {
+    const h = enemy.moveHistory;
+    const last = h[h.length - 1];
+    if (h.length === 0 || h.length === 1) {
+      enemy.currentMove = "mug";
+    } else if (last === "mug") {
+      enemy.currentMove = nextFloat(state.rng) < 0.5 ? "lunge" : "smoke_bomb";
+    } else if (last === "lunge") {
+      enemy.currentMove = "smoke_bomb";
+    } else {
+      enemy.currentMove = "flee";
+    }
+    return;
+  }
+
+  // 红色奴隶主：首招刺击；缠绕整场一次性；其余刮擦 / 刺击（连招上限 2）。
+  if (enemy.defId === "red_slaver") {
+    const h = enemy.moveHistory;
+    if (h.length === 0) {
+      enemy.currentMove = "rs_stab";
+      return;
+    }
+    const lastTwoSame = (id: string): boolean =>
+      h.length >= 2 && h[h.length - 1] === id && h[h.length - 2] === id;
+    const usedEntangle = h.includes("entangle");
+    const roll = nextInt(state.rng, 100);
+    if (roll >= 75 && !usedEntangle) {
+      enemy.currentMove = "entangle";
+    } else if (roll >= 50 && usedEntangle && !lastTwoSame("rs_stab")) {
+      enemy.currentMove = "rs_stab";
+    } else if (!lastTwoSame("scrape")) {
+      enemy.currentMove = "scrape";
+    } else {
+      enemy.currentMove = "rs_stab";
+    }
     return;
   }
 

--- a/apps/spire/src/engine/enemies/enemies.ts
+++ b/apps/spire/src/engine/enemies/enemies.ts
@@ -366,6 +366,78 @@ const ENEMY_LIST: EnemyDef[] = [
     intentRule: { scripted: [], weighted: [] },
   },
 
+  {
+    id: "looter",
+    name: "拾荒者",
+    hpMin: 44,
+    hpMax: 48,
+    moves: [
+      {
+        id: "mug",
+        name: "抢劫",
+        effects: [
+          { kind: "deal_damage", amount: 10 },
+          { kind: "steal_gold", amount: 15 },
+        ],
+        intent: "attack",
+      },
+      {
+        id: "lunge",
+        name: "猛扑",
+        effects: [
+          { kind: "deal_damage", amount: 12 },
+          { kind: "steal_gold", amount: 15 },
+        ],
+        intent: "attack",
+      },
+      {
+        id: "smoke_bomb",
+        name: "烟雾弹",
+        effects: [{ kind: "gain_block", amount: 6 }],
+        intent: "defend",
+      },
+      {
+        id: "flee",
+        name: "逃跑",
+        effects: [{ kind: "escape" }],
+        intent: "unknown",
+      },
+    ],
+    // 出招由 combat.ts 的 looter 专属分支处理（抢劫×2 → 猛扑/烟雾弹 → 逃跑）。
+    intentRule: { scripted: [], weighted: [] },
+  },
+  {
+    id: "red_slaver",
+    name: "红色奴隶主",
+    hpMin: 46,
+    hpMax: 50,
+    moves: [
+      {
+        id: "rs_stab",
+        name: "刺击",
+        effects: [{ kind: "deal_damage", amount: 13 }],
+        intent: "attack",
+      },
+      {
+        id: "scrape",
+        name: "刮擦",
+        effects: [
+          { kind: "deal_damage", amount: 8 },
+          { kind: "apply_power", power: "vulnerable", amount: 1, on: "target" },
+        ],
+        intent: "attack",
+      },
+      {
+        id: "entangle",
+        name: "缠绕",
+        effects: [{ kind: "apply_power", power: "entangled", amount: 1, on: "target" }],
+        intent: "debuff",
+      },
+    ],
+    // 出招由 combat.ts 的 red_slaver 专属分支处理（首招刺击、缠绕一次性、刮擦/刺击）。
+    intentRule: { scripted: [], weighted: [] },
+  },
+
   // —— 精英：地精头目（Enrage = 玩家出技能牌它加力量）——
   {
     id: "gremlin_nob",
@@ -737,6 +809,8 @@ const ENCOUNTERS: Record<string, EncounterDef> = {
     enemies: ["mad_gremlin", "sneaky_gremlin", "shield_gremlin", "gremlin_wizard"],
     isBoss: false,
   },
+  looter: { id: "looter", enemies: ["looter"], isBoss: false },
+  red_slaver: { id: "red_slaver", enemies: ["red_slaver"], isBoss: false },
   guardian: { id: "guardian", enemies: ["the_guardian"], isBoss: true },
   hexaghost: { id: "hexaghost", enemies: ["hexaghost"], isBoss: true },
   slime_boss: { id: "slime_boss", enemies: ["slime_boss"], isBoss: true },
@@ -773,7 +847,9 @@ const STRONG_ENCOUNTER_POOL: readonly WeightedEncounter[] = [
   { id: "three_louse", weight: 2 },
   { id: "large_slime", weight: 2 }, // 选中后 50/50 展开为 酸液大 / 尖刺大
   { id: "two_fungi_beasts", weight: 2 },
+  { id: "looter", weight: 2 },
   { id: "gremlin_gang", weight: 1 },
+  { id: "red_slaver", weight: 1 },
   { id: "lots_of_slimes", weight: 1 },
 ];
 

--- a/apps/spire/src/engine/glossary.ts
+++ b/apps/spire/src/engine/glossary.ts
@@ -43,6 +43,11 @@ export const GLOSSARY: readonly GlossaryEntry[] = [
     definition: "获得的格挡降低 25%（×0.75，向下取整）。每回合结束 -1 层。",
   },
   {
+    term: "缠绕",
+    aliases: ["entangled", "entangle"],
+    definition: "本回合无法打出任何攻击牌（技能/能力仍可打）。回合结束后解除。红色奴隶主专属。",
+  },
+  {
     term: "荆棘",
     aliases: ["thorns"],
     definition: "每次被攻击时，对攻击者反弹等于层数的伤害（无视其格挡）。持续整场战斗。",

--- a/apps/spire/src/engine/powers/powers.ts
+++ b/apps/spire/src/engine/powers/powers.ts
@@ -27,8 +27,11 @@ function pruneEmpty(powers: PowerInstance[], id: PowerId): void {
     return;
   }
   const amount = powers[index]!.amount;
-  // 力量 / 敏捷可为负并保留；易伤/虚弱/脆弱降到 0 即移除。
-  if ((id === "vulnerable" || id === "weak" || id === "frail") && amount <= 0) {
+  // 力量 / 敏捷可为负并保留；易伤/虚弱/脆弱/缠绕降到 0 即移除。
+  if (
+    (id === "vulnerable" || id === "weak" || id === "frail" || id === "entangled") &&
+    amount <= 0
+  ) {
     powers.splice(index, 1);
   } else if (amount === 0 && id !== "strength" && id !== "dexterity") {
     powers.splice(index, 1);
@@ -43,7 +46,7 @@ export function removePower(powers: PowerInstance[], id: PowerId): void {
   }
 }
 
-/** 回合末衰减：易伤 / 虚弱 / 脆弱各 -1。 */
+/** 回合末衰减：易伤 / 虚弱 / 脆弱 / 缠绕各 -1。 */
 export function decayDebuffs(powers: PowerInstance[]): void {
   if (getPower(powers, "vulnerable") > 0) {
     addPower(powers, "vulnerable", -1);
@@ -53,6 +56,9 @@ export function decayDebuffs(powers: PowerInstance[]): void {
   }
   if (getPower(powers, "frail") > 0) {
     addPower(powers, "frail", -1);
+  }
+  if (getPower(powers, "entangled") > 0) {
+    addPower(powers, "entangled", -1);
   }
 }
 

--- a/apps/spire/src/engine/types.ts
+++ b/apps/spire/src/engine/types.ts
@@ -19,6 +19,7 @@ export type PowerId =
   | "vulnerable" // 易伤：受到攻击伤害 ×1.5（回合末 -1）
   | "weak" // 虚弱：造成攻击伤害 ×0.75（回合末 -1）
   | "frail" // 脆弱：获得的格挡 ×0.75（回合末 -1）
+  | "entangled" // 缠绕：本回合无法打出攻击牌（回合末 -1，红色奴隶主专属）
   | "metallicize" // 金属化：每当自己回合结束，获得 N 点格挡（拉加维林睡眠期）
   | "ritual" // 仪式：回合开始 +N 力量（触发）
   | "curl_up" // 蜷缩：首次被攻击时获得格挡（触发，一次性）
@@ -57,6 +58,10 @@ export type Effect =
   | { kind: "lose_hp"; amount: number }
   // 玩家回复最大生命的百分比（血之药水 40%）。
   | { kind: "heal_percent"; percent: number }
+  // 敌人用：偷取玩家金币（拾荒者，最多偷 amount，玩家金币不足则偷光）。
+  | { kind: "steal_gold"; amount: number }
+  // 敌人用：本敌人逃离战斗（拾荒者烟雾弹后逃跑）。
+  | { kind: "escape" }
   | { kind: "add_card"; cardId: string; pile: "draw" | "discard" | "hand"; count: number };
 
 /** 卡定义（静态数据表）。cost=null 表示不可打出（status/废牌）。 */
@@ -142,6 +147,8 @@ export type EnemyState = {
   asleep: boolean;
   /** 是否已分裂过（半血分裂只触发一次）。 */
   hasSplit: boolean;
+  /** 是否已逃离战斗（拾荒者烟雾弹后逃跑；逃跑后不再算作战斗目标）。 */
+  escaped: boolean;
   /** 守卫者：进攻姿态下累计受到的伤害（达阈值切姿态后清零，非每回合重置——复刻 StS 累计语义）。 */
   modeShiftAccum: number;
   modeShiftThreshold: number | null;

--- a/apps/spire/src/sim/policy.ts
+++ b/apps/spire/src/sim/policy.ts
@@ -16,11 +16,13 @@ export function legalActions(state: GameState): GameAction[] {
   if (state.screen === "combat" && state.combat) {
     const combat = state.combat;
     const target = lowestHpEnemyIndex(state);
+    const entangled = combat.playerPowers.some(p => p.id === "entangled" && p.amount > 0);
     const actions: GameAction[] = [];
     combat.hand.forEach((instance, handIndex) => {
       const def = getCardDef(instance.defId);
       const cost = costOf(def, instance.upgraded);
-      if (cost !== null && cost <= combat.energy) {
+      const blockedByEntangle = entangled && def.type === "attack";
+      if (cost !== null && cost <= combat.energy && !blockedByEntangle) {
         actions.push({
           type: "play_card",
           handIndex,
@@ -109,12 +111,16 @@ export class GreedyPolicy implements Policy {
     }
     const combat = state.combat;
     const target = lowestHpEnemyIndex(state);
+    const entangled = combat.playerPowers.some(p => p.id === "entangled" && p.amount > 0);
     // 先上能力牌（常驻收益），再出攻击牌，最后加格挡牌，够费就打。
     const order = ["power", "attack", "skill"];
     for (const wantType of order) {
       for (let handIndex = 0; handIndex < combat.hand.length; handIndex += 1) {
         const def = getCardDef(combat.hand[handIndex]!.defId);
         const cost = costOf(def, combat.hand[handIndex]!.upgraded);
+        if (entangled && def.type === "attack") {
+          continue; // 缠绕：本回合打不出攻击牌。
+        }
         if (def.type === wantType && cost !== null && cost <= combat.energy) {
           return { type: "play_card", handIndex, targetIndex: def.targeted ? target : null };
         }

--- a/apps/spire/test/mobs.test.ts
+++ b/apps/spire/test/mobs.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat, playCard, endTurn } from "../src/engine/combat/combat.js";
+import { getPower } from "../src/engine/powers/powers.js";
+import type { CardInstance, GameState } from "../src/engine/types.js";
+
+// A-mob：拾荒者（偷金+逃跑）+ 红色奴隶主（缠绕）。asc0。
+
+function fight(encounter: string): GameState {
+  const s = newRun({ runId: encounter, seed: 1 });
+  startCombat(s, encounter);
+  s.hp = 300;
+  s.maxHp = 300;
+  return s;
+}
+
+describe("拾荒者：偷金 + 逃跑", () => {
+  it("抢劫偷 15 金并造成 10 伤", () => {
+    const s = fight("looter");
+    s.gold = 100;
+    s.combat!.hand = [];
+    expect(s.combat!.enemies[0]!.currentMove).toBe("mug"); // 首招抢劫
+    endTurn(s);
+    expect(s.gold).toBe(85); // 偷 15
+    expect(s.hp).toBe(290); // 10 伤
+  });
+
+  it("金币不足则偷光、不为负", () => {
+    const s = fight("looter");
+    s.gold = 5;
+    s.combat!.hand = [];
+    endTurn(s);
+    expect(s.gold).toBe(0);
+  });
+
+  it("出招序列：抢劫→抢劫→(猛扑/烟雾弹)→…→逃跑，逃跑后战斗结束", () => {
+    const s = fight("looter");
+    s.hp = 9999;
+    s.maxHp = 9999;
+    const looter = () => s.combat?.enemies[0];
+    const seq: string[] = [looter()!.currentMove];
+    for (let i = 0; i < 6 && s.combat; i += 1) {
+      s.combat.hand = [];
+      endTurn(s);
+      if (s.combat) {
+        seq.push(looter()!.currentMove);
+      }
+    }
+    // 序列里应出现逃跑，且逃跑后战斗结束（combat 清空）
+    expect(seq).toContain("flee");
+    expect(s.combat).toBeNull();
+  });
+});
+
+describe("红色奴隶主：缠绕", () => {
+  it("缠绕期间无法打出攻击牌，技能可打", () => {
+    const s = fight("red_slaver");
+    s.hp = 300;
+    // 手动给玩家缠绕
+    s.combat!.playerPowers.push({ id: "entangled", amount: 1 });
+    const strike: CardInstance = { uid: s.nextUid++, defId: "strike", upgraded: false };
+    s.combat!.hand = [strike];
+    s.combat!.energy = 3;
+    expect(playCard(s, 0, 0).ok).toBe(false); // 攻击被缠绕挡住
+    const defend: CardInstance = { uid: s.nextUid++, defId: "defend", upgraded: false };
+    s.combat!.hand = [defend];
+    expect(playCard(s, 0, null).ok).toBe(true); // 技能可打
+  });
+
+  it("首招刺击 13；缠绕整场只放一次", () => {
+    const s = fight("red_slaver");
+    s.hp = 300;
+    expect(s.combat!.enemies[0]!.currentMove).toBe("rs_stab");
+    // 多回合推进，统计 entangle 次数
+    let entangleCount = 0;
+    for (let i = 0; i < 30; i += 1) {
+      if (s.combat!.enemies[0]!.currentMove === "entangle") {
+        entangleCount += 1;
+      }
+      s.hp = 300;
+      s.combat!.playerPowers = [];
+      s.combat!.hand = [];
+      endTurn(s);
+    }
+    expect(entangleCount).toBeLessThanOrEqual(1);
+  });
+
+  it("缠绕回合末解除", () => {
+    const s = fight("red_slaver");
+    s.hp = 300;
+    s.combat!.playerPowers.push({ id: "entangled", amount: 1 });
+    s.combat!.hand = [];
+    s.combat!.enemies[0]!.currentMove = "rs_stab";
+    endTurn(s);
+    expect(getPower(s.combat!.playerPowers, "entangled")).toBe(0);
+  });
+});


### PR DESCRIPTION
补齐第一幕最后的普通怪，引入 3 个新战斗机制。数值/AI 对齐 sts_lightspeed asc0。**本批次不部署**。Refs #234。

## 3 新机制
- **偷金 steal_gold + 逃跑 escape**：`EnemyState.escaped`，逃跑者退出战斗；`livingEnemies` 排除 escaped，敌人全逃/亡则战斗结束。
- **缠绕 entangled**（玩家 debuff）：本回合无法打出攻击牌（`playCard` 拦截），回合末衰减；入 `DEBUFF_POWERS` 可被玩家神器抵消。

## 两怪
- **拾荒者** 44-48：抢劫(10+偷15金)×2 → 猛扑/烟雾弹 → 逃跑。
- **红色奴隶主** 46-50：首招刺击13、缠绕整场一次性、刮擦(8+易伤)/刺击。
均入 strong 池；术语 缠绕 + label。

## 验证
门禁全绿：build/typecheck/lint(0)/format + **spire 199/199**（新增 `mobs.test.ts` 6 例：偷金/偷光不为负、出招序列+逃跑结束战斗、缠绕挡攻击放技能、缠绕整场一次+回合末解除）· **agent 806**。**sim 贪心+随机 stuck=0**——期间 sim 抓到并修复了「缠绕时贪心死循环打攻击」（policy 适配，引擎侧本就正确拒绝）。