### PR TITLE
feat(spire): 幕框架（Phase B · B1）

### DIFF
--- a/apps/spire/src/engine/engine.ts
+++ b/apps/spire/src/engine/engine.ts
@@ -3,7 +3,7 @@ import { IRONCLAD_STARTER_DECK } from "./cards/cards.js";
 import { IRONCLAD_STARTER_RELIC } from "./relics/relics.js";
 import { seedRng } from "./rng.js";
 import { endTurn, playCard, usePotion } from "./combat/combat.js";
-import { applyChoose, buildMap, generateReward } from "./run/run.js";
+import { TOTAL_ACTS, advanceToNextAct, applyChoose, buildMap, generateReward } from "./run/run.js";
 import { POTION_SLOTS } from "./potions/potions.js";
 import { NEOW_EVENT_ID } from "./events/events.js";
 
@@ -41,6 +41,7 @@ export function newRun(input: {
     seed: input.seed,
     character,
     ascension: input.ascension ?? 0,
+    act: 1,
     screen: "map",
     hp: IRONCLAD_MAX_HP,
     maxHp: IRONCLAD_MAX_HP,
@@ -117,9 +118,14 @@ export function applyAction(state: GameState, action: GameAction): ActionResult 
   }
 }
 
-/** 战斗胜利后收尾：非 Boss 胜利（combat 清空但 screen 仍为 combat）转卡奖励。 */
+/** 战斗胜利后收尾：非 Boss 转卡奖励；Boss 胜利若还有后续幕则携带状态进入下一幕，否则通关。 */
 function settleAfterCombat(state: GameState): void {
   if (state.combat === null && state.screen === "combat") {
     generateReward(state);
+    return;
+  }
+  // Boss 胜利（combat.ts 已置 screen="victory"）：非最终幕则进入下一幕。
+  if (state.screen === "victory" && state.act < TOTAL_ACTS) {
+    advanceToNextAct(state);
   }
 }

--- a/apps/spire/src/engine/run/run.ts
+++ b/apps/spire/src/engine/run/run.ts
@@ -53,10 +53,21 @@ const NODE_TYPE_LABELS: Record<MapNodeType, string> = {
   boss: "首领",
 };
 
+/** 有内容的幕数：打完第 TOTAL_ACTS 幕 Boss 即通关；之前的 Boss 则进入下一幕。 */
+export const TOTAL_ACTS = 1;
+
 export function buildMap(state: GameState): void {
   state.map = generateMap(state.rng, ENABLED_MAP_TYPES);
   state.currentNodeId = null;
   state.screen = "map";
+}
+
+/** 进入下一幕：幕号 +1、重置本幕战斗计数、生成新地图，携带血/牌/遗物/金币/药水。 */
+export function advanceToNextAct(state: GameState): void {
+  state.act += 1;
+  state.combatsEntered = 0;
+  buildMap(state);
+  state.log.push(`你踏入第 ${state.act} 幕。`);
 }
 
 /** 进入一个地图节点：按类型路由。战斗/Boss 起战斗；篝火切 rest 屏；宝箱即时给金币后回地图。 */

--- a/apps/spire/src/engine/types.ts
+++ b/apps/spire/src/engine/types.ts
@@ -238,6 +238,8 @@ export type GameState = {
   seed: number;
   character: CharacterId;
   ascension: number;
+  /** 当前幕（1-based）。打完本幕 Boss 若还有后续幕则携带状态进入下一幕。 */
+  act: number;
   screen: Screen;
   hp: number;
   maxHp: number;

--- a/apps/spire/test/act-framework.test.ts
+++ b/apps/spire/test/act-framework.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { advanceToNextAct, TOTAL_ACTS } from "../src/engine/run/run.js";
+
+// B1：幕框架——幕号、跨幕携带状态、Boss→下一幕过渡机制。
+
+describe("幕状态", () => {
+  it("新对局在第 1 幕", () => {
+    const s = newRun({ runId: "a", seed: 1 });
+    expect(s.act).toBe(1);
+  });
+
+  it("TOTAL_ACTS 至少 1（有内容的幕数）", () => {
+    expect(TOTAL_ACTS).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("进入下一幕", () => {
+  it("幕号 +1、重置本幕战斗计数、生成新地图、回到地图屏", () => {
+    const s = newRun({ runId: "b", seed: 1 });
+    s.combatsEntered = 5;
+    s.currentNodeId = "3-2";
+    const oldMap = s.map;
+    advanceToNextAct(s);
+    expect(s.act).toBe(2);
+    expect(s.combatsEntered).toBe(0);
+    expect(s.currentNodeId).toBeNull();
+    expect(s.screen).toBe("map");
+    expect(s.map).not.toBe(oldMap); // 新地图对象
+    expect(s.map.startNodeIds.length).toBeGreaterThan(0);
+  });
+
+  it("携带血量/牌组/遗物/金币/药水进入下一幕", () => {
+    const s = newRun({ runId: "c", seed: 1 });
+    s.hp = 42;
+    s.maxHp = 88;
+    s.gold = 217;
+    s.deck.push({ uid: s.nextUid++, defId: "bludgeon", upgraded: true });
+    s.relics.push({ id: "anchor", counter: 0 });
+    s.potions[0] = "fire_potion";
+    const deckLen = s.deck.length;
+    const relicLen = s.relics.length;
+    advanceToNextAct(s);
+    expect(s.hp).toBe(42);
+    expect(s.maxHp).toBe(88);
+    expect(s.gold).toBe(217);
+    expect(s.deck).toHaveLength(deckLen);
+    expect(s.deck.some(c => c.defId === "bludgeon" && c.upgraded)).toBe(true);
+    expect(s.relics).toHaveLength(relicLen);
+    expect(s.potions[0]).toBe("fire_potion");
+  });
+
+  it("可连续推进多幕", () => {
+    const s = newRun({ runId: "d", seed: 1 });
+    advanceToNextAct(s);
+    advanceToNextAct(s);
+    expect(s.act).toBe(3);
+  });
+});


### PR DESCRIPTION
多幕结构的**地基**：幕号 + 跨幕携带状态 + Boss→下一幕过渡机制。**本批次不部署**。Refs #234。

## 改动
- `GameState.act`（1-based）；`newRun` 起于第 1 幕。
- `run.ts`：`TOTAL_ACTS`（有内容的幕数，暂 **1**）+ `advanceToNextAct`（幕号 +1、重置本幕战斗计数、生成新地图，**携带血/牌/遗物/金币/药水**）。
- `engine.settleAfterCombat`：Boss 胜利若 `act < TOTAL_ACTS` 则进入下一幕，否则通关。（TOTAL_ACTS=1 时行为不变：打完第一幕 Boss 即通关；**B2 填第二幕内容后把 TOTAL_ACTS bump 到 2**，act1→act2 过渡即生效。）

## 验证
门禁全绿：build/typecheck/lint(0)/format + **spire 204/204**（新增 `act-framework.test.ts` 5 例：幕号、`advanceToNextAct` 换图+重置计数+携带 hp/牌/遗物/金/药水、多幕连推）· **agent 806**。sim stuck=0。