### PR TITLE
feat(spire): 第二幕（城市）切片 + 战斗池按幕分化（Phase B · B2）

### DIFF
--- a/apps/agent/src/agent/capabilities/spire/render/spire-screen.ts
+++ b/apps/agent/src/agent/capabilities/spire/render/spire-screen.ts
@@ -77,6 +77,7 @@ function handView(card: SpireHandCardView): Record<string, unknown> {
 export function renderSpireScreen(screen: SpireScreen): string {
   const combat = screen.combat;
   return renderServerStaticTemplate(import.meta.url, "context/spire-screen.hbs", {
+    act: screen.act,
     isMap: screen.screen === "map",
     isCombat: screen.screen === "combat",
     isReward: screen.screen === "reward",

--- a/apps/agent/static/context/spire-screen.hbs
+++ b/apps/agent/static/context/spire-screen.hbs
@@ -1,6 +1,6 @@
 <spire_screen>
 {{#if isMap}}
-你在尖塔地图上。生命 {{hp}}/{{maxHp}}　金币 {{gold}}　牌组 {{deckCount}} 张。
+你在尖塔第 {{act}} 幕的地图上。生命 {{hp}}/{{maxHp}}　金币 {{gold}}　牌组 {{deckCount}} 张。
 {{#if hasRelics}}遗物：{{#each relics}}{{name}}（{{description}}）{{/each}}
 {{/if}}
 {{#if hasPotions}}药水：{{#each potions}}[槽{{slot}}]{{name}}（{{description}}）{{/each}}

--- a/apps/agent/test/spire/spire-client.test.ts
+++ b/apps/agent/test/spire/spire-client.test.ts
@@ -12,6 +12,7 @@ function screenOf(version: number): SpireScreen {
   return {
     version,
     screen: "map",
+    act: 1,
     player: { hp: 80, maxHp: 80, gold: 99 },
     deckCount: 10,
     relics: [{ name: "燃烧之血", description: "每场战斗结束后，回复 6 点生命。" }],

--- a/apps/spire/src/application/state-view.ts
+++ b/apps/spire/src/application/state-view.ts
@@ -33,6 +33,7 @@ export function toScreenView(state: GameState, opts: { suppressLog?: boolean }):
   return {
     version: state.version,
     screen: state.screen,
+    act: state.act,
     player: { hp: state.hp, maxHp: state.maxHp, gold: state.gold },
     deckCount: state.deck.length,
     relics: state.relics.map(relic => {

--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -90,6 +90,10 @@ function createEnemyState(state: GameState, defId: string, hpOverride?: number):
     // 哨卫开局各带 1 层神器（抵消你首个减益）。
     powers.push({ id: "artifact", amount: 1 });
   }
+  if (defId === "spheric_guardian") {
+    // 球形守卫开局自带 3 层神器（抵消你前三个减益）。
+    powers.push({ id: "artifact", amount: 3 });
+  }
   if (defId === "fungi_beast") {
     // 真菌兽开局自带孢子云（显示用；死亡给玩家 2 易伤由 deathEffects 结算）。
     powers.push({ id: "spore_cloud", amount: 2 });
@@ -875,6 +879,16 @@ function selectNextMove(state: GameState, enemyIndex: number): void {
     }
     enemy.rotationIndex = (enemy.rotationIndex + 1) % cycle.length;
     enemy.currentMove = cycle[enemy.rotationIndex]!;
+    return;
+  }
+
+  // 冠军（第二幕 Boss）：血量首次降到 ≤半血时暴怒一次（+6 力量），其余走 weighted。
+  if (
+    enemy.defId === "champ" &&
+    enemy.hp <= Math.floor(enemy.maxHp / 2) &&
+    !enemy.moveHistory.includes("anger")
+  ) {
+    enemy.currentMove = "anger";
     return;
   }
 

--- a/apps/spire/src/engine/enemies/enemies.ts
+++ b/apps/spire/src/engine/enemies/enemies.ts
@@ -438,6 +438,199 @@ const ENEMY_LIST: EnemyDef[] = [
     intentRule: { scripted: [], weighted: [] },
   },
 
+  // —— 第二幕（城市）普通敌人 ——
+  {
+    id: "snake_plant",
+    name: "食蛇草",
+    hpMin: 75,
+    hpMax: 79,
+    moves: [
+      {
+        id: "sp_chomp",
+        name: "撕咬",
+        effects: [{ kind: "deal_damage", amount: 7 }],
+        intent: "attack",
+      },
+      {
+        id: "sp_spores",
+        name: "散播孢子",
+        effects: [
+          { kind: "apply_power", power: "weak", amount: 2, on: "target" },
+          { kind: "apply_power", power: "frail", amount: 2, on: "target" },
+        ],
+        intent: "debuff",
+      },
+    ],
+    intentRule: {
+      scripted: [],
+      weighted: [
+        { move: "sp_chomp", weight: 65, maxInARow: 2 },
+        { move: "sp_spores", weight: 35, maxInARow: 1 },
+      ],
+    },
+  },
+  {
+    id: "spheric_guardian",
+    name: "球形守卫",
+    hpMin: 20,
+    hpMax: 20,
+    moves: [
+      {
+        id: "sg_activate",
+        name: "激活",
+        effects: [{ kind: "gain_block", amount: 25 }],
+        intent: "defend",
+      },
+      {
+        id: "sg_slam",
+        name: "猛击",
+        effects: [{ kind: "deal_damage", amount: 10 }],
+        intent: "attack",
+      },
+      {
+        id: "sg_harden",
+        name: "硬化",
+        effects: [{ kind: "gain_block", amount: 15 }],
+        intent: "defend",
+      },
+    ],
+    // 首招激活(大格挡)，之后 猛击/硬化 交替；开局自带 3 层神器（见 createEnemyState）。
+    intentRule: {
+      scripted: ["sg_activate"],
+      weighted: [
+        { move: "sg_slam", weight: 50, maxInARow: 1 },
+        { move: "sg_harden", weight: 50, maxInARow: 1 },
+      ],
+    },
+  },
+  {
+    id: "centurion",
+    name: "百夫长",
+    hpMin: 76,
+    hpMax: 80,
+    moves: [
+      {
+        id: "cent_slash",
+        name: "斩击",
+        effects: [{ kind: "deal_damage", amount: 12 }],
+        intent: "attack",
+      },
+      {
+        id: "cent_fury",
+        name: "狂怒连斩",
+        effects: [{ kind: "deal_damage_multi", amount: 6, times: 3 }],
+        intent: "attack",
+      },
+      {
+        id: "cent_defend",
+        name: "防守",
+        effects: [{ kind: "gain_block", amount: 15 }],
+        intent: "defend",
+      },
+    ],
+    intentRule: {
+      scripted: [],
+      weighted: [
+        { move: "cent_slash", weight: 50, maxInARow: 2 },
+        { move: "cent_fury", weight: 25, maxInARow: 1 },
+        { move: "cent_defend", weight: 25, maxInARow: 1 },
+      ],
+    },
+  },
+
+  // —— 第二幕精英：穿刺之书（多段攻击）——
+  {
+    id: "book_of_stabbing",
+    name: "穿刺之书",
+    hpMin: 160,
+    hpMax: 162,
+    moves: [
+      {
+        id: "multi_stab",
+        name: "乱刺",
+        effects: [{ kind: "deal_damage_multi", amount: 6, times: 3 }],
+        intent: "attack",
+      },
+      {
+        id: "big_stab",
+        name: "重刺",
+        effects: [{ kind: "deal_damage", amount: 21 }],
+        intent: "attack",
+      },
+    ],
+    intentRule: {
+      scripted: [],
+      weighted: [
+        { move: "multi_stab", weight: 70, maxInARow: 99 },
+        { move: "big_stab", weight: 30, maxInARow: 1 },
+      ],
+    },
+  },
+
+  // —— 第二幕 Boss：冠军（半血暴怒）——
+  {
+    id: "champ",
+    name: "冠军",
+    hpMin: 420,
+    hpMax: 440,
+    moves: [
+      {
+        id: "champ_slash",
+        name: "重斩",
+        effects: [{ kind: "deal_damage", amount: 16 }],
+        intent: "attack",
+      },
+      {
+        id: "face_slap",
+        name: "扇脸",
+        effects: [
+          { kind: "deal_damage", amount: 12 },
+          { kind: "apply_power", power: "weak", amount: 2, on: "target" },
+          { kind: "apply_power", power: "frail", amount: 2, on: "target" },
+        ],
+        intent: "attack",
+      },
+      {
+        id: "champ_defend",
+        name: "防御姿态",
+        effects: [
+          { kind: "gain_block", amount: 15 },
+          { kind: "apply_power", power: "metallicize", amount: 5, on: "self" },
+        ],
+        intent: "defend",
+      },
+      {
+        id: "execute",
+        name: "处决",
+        effects: [{ kind: "deal_damage_multi", amount: 10, times: 2 }],
+        intent: "attack",
+      },
+      {
+        id: "gloat",
+        name: "自夸",
+        effects: [{ kind: "apply_power", power: "strength", amount: 3, on: "self" }],
+        intent: "buff",
+      },
+      {
+        id: "anger",
+        name: "暴怒",
+        effects: [{ kind: "apply_power", power: "strength", amount: 6, on: "self" }],
+        intent: "buff",
+      },
+    ],
+    // 半血暴怒（一次性）由 combat.ts champ 分支覆盖；其余走 weighted。
+    intentRule: {
+      scripted: [],
+      weighted: [
+        { move: "champ_slash", weight: 30, maxInARow: 2 },
+        { move: "face_slap", weight: 20, maxInARow: 1 },
+        { move: "champ_defend", weight: 20, maxInARow: 1 },
+        { move: "execute", weight: 15, maxInARow: 1 },
+        { move: "gloat", weight: 15, maxInARow: 1 },
+      ],
+    },
+  },
+
   // —— 精英：地精头目（Enrage = 玩家出技能牌它加力量）——
   {
     id: "gremlin_nob",
@@ -811,6 +1004,13 @@ const ENCOUNTERS: Record<string, EncounterDef> = {
   },
   looter: { id: "looter", enemies: ["looter"], isBoss: false },
   red_slaver: { id: "red_slaver", enemies: ["red_slaver"], isBoss: false },
+  // 第二幕
+  snake_plant: { id: "snake_plant", enemies: ["snake_plant"], isBoss: false },
+  spheric_guardian: { id: "spheric_guardian", enemies: ["spheric_guardian"], isBoss: false },
+  centurion: { id: "centurion", enemies: ["centurion"], isBoss: false },
+  two_centurions: { id: "two_centurions", enemies: ["centurion", "centurion"], isBoss: false },
+  book_of_stabbing: { id: "book_of_stabbing", enemies: ["book_of_stabbing"], isBoss: false },
+  champ: { id: "champ", enemies: ["champ"], isBoss: true },
   guardian: { id: "guardian", enemies: ["the_guardian"], isBoss: true },
   hexaghost: { id: "hexaghost", enemies: ["hexaghost"], isBoss: true },
   slime_boss: { id: "slime_boss", enemies: ["slime_boss"], isBoss: true },
@@ -865,9 +1065,25 @@ function weightedPick(rng: RngState, pool: readonly WeightedEncounter[]): string
   return pool[pool.length - 1]!.id;
 }
 
-/** 按已进入的普通战斗数选池 + 加权随机挑一个 encounter id。 */
-export function pickNormalEncounter(rng: RngState, combatsEntered: number): string {
-  const pool = combatsEntered < WEAK_COMBAT_COUNT ? WEAK_ENCOUNTER_POOL : STRONG_ENCOUNTER_POOL;
+// —— 第二幕（城市）战斗池（切片：3 普通 + 1 精英 + 1 Boss；后续里程碑补齐 6 火之灵/自动机/收藏家等）——
+const ACT2_WEAK_POOL: readonly WeightedEncounter[] = [
+  { id: "spheric_guardian", weight: 1 },
+  { id: "snake_plant", weight: 1 },
+  { id: "centurion", weight: 1 },
+];
+
+const ACT2_STRONG_POOL: readonly WeightedEncounter[] = [
+  { id: "centurion", weight: 2 },
+  { id: "snake_plant", weight: 2 },
+  { id: "two_centurions", weight: 1 },
+  { id: "spheric_guardian", weight: 1 },
+];
+
+/** 按已进入的普通战斗数选池 + 加权随机挑一个 encounter id（按幕选池）。 */
+export function pickNormalEncounter(rng: RngState, combatsEntered: number, act = 1): string {
+  const weak = act >= 2 ? ACT2_WEAK_POOL : WEAK_ENCOUNTER_POOL;
+  const strong = act >= 2 ? ACT2_STRONG_POOL : STRONG_ENCOUNTER_POOL;
+  const pool = combatsEntered < WEAK_COMBAT_COUNT ? weak : strong;
   const picked = weightedPick(rng, pool);
   if (picked === "small_slimes") {
     // 小史莱姆组的两种组成 50/50。
@@ -881,26 +1097,31 @@ export function pickNormalEncounter(rng: RngState, combatsEntered: number): stri
 }
 
 // Act1 精英池（等权重，不重复限制由 StS 的洗牌保证；此处简化为等权随机）。
-// 拉加维林 / 哨卫在 M3b-2 加入。
 const ELITE_ENCOUNTER_POOL: readonly WeightedEncounter[] = [
   { id: "gremlin_nob", weight: 1 },
   { id: "lagavulin", weight: 1 },
   { id: "three_sentries", weight: 1 },
 ];
 
-/** 精英节点：从精英池挑一个 encounter id。 */
-export function pickEliteEncounter(rng: RngState): string {
-  return weightedPick(rng, ELITE_ENCOUNTER_POOL);
+// Act2 精英池（切片：穿刺之书；后续补 地精首领 / 夜魔）。
+const ACT2_ELITE_POOL: readonly WeightedEncounter[] = [{ id: "book_of_stabbing", weight: 1 }];
+
+/** 精英节点：从精英池挑一个 encounter id（按幕选池）。 */
+export function pickEliteEncounter(rng: RngState, act = 1): string {
+  return weightedPick(rng, act >= 2 ? ACT2_ELITE_POOL : ELITE_ENCOUNTER_POOL);
 }
 
-// Act1 Boss 池（等权重随机）。史莱姆王待分裂机制里程碑加入。
+// Act1 Boss 池（等权重随机）。
 const BOSS_ENCOUNTER_POOL: readonly WeightedEncounter[] = [
   { id: "guardian", weight: 1 },
   { id: "hexaghost", weight: 1 },
   { id: "slime_boss", weight: 1 },
 ];
 
-/** Boss 节点：随机挑一个 Boss encounter id。 */
-export function pickBossEncounter(rng: RngState): string {
-  return weightedPick(rng, BOSS_ENCOUNTER_POOL);
+// Act2 Boss 池（切片：冠军；后续补 青铜自动机 / 收藏家）。
+const ACT2_BOSS_POOL: readonly WeightedEncounter[] = [{ id: "champ", weight: 1 }];
+
+/** Boss 节点：随机挑一个 Boss encounter id（按幕选池）。 */
+export function pickBossEncounter(rng: RngState, act = 1): string {
+  return weightedPick(rng, act >= 2 ? ACT2_BOSS_POOL : BOSS_ENCOUNTER_POOL);
 }

--- a/apps/spire/src/engine/run/run.ts
+++ b/apps/spire/src/engine/run/run.ts
@@ -54,7 +54,7 @@ const NODE_TYPE_LABELS: Record<MapNodeType, string> = {
 };
 
 /** 有内容的幕数：打完第 TOTAL_ACTS 幕 Boss 即通关；之前的 Boss 则进入下一幕。 */
-export const TOTAL_ACTS = 1;
+export const TOTAL_ACTS = 2;
 
 export function buildMap(state: GameState): void {
   state.map = generateMap(state.rng, ENABLED_MAP_TYPES);
@@ -76,19 +76,19 @@ function resolveNode(state: GameState, node: MapNode): void {
   switch (node.type) {
     case "combat": {
       // 前若干场抽 weak 池、其余抽 strong 池（复刻 StS Act1 战斗节奏）。
-      const encounterId = pickNormalEncounter(state.rng, state.combatsEntered);
+      const encounterId = pickNormalEncounter(state.rng, state.combatsEntered, state.act);
       state.combatsEntered += 1;
       startCombat(state, encounterId);
       return;
     }
     case "elite": {
       // 精英战：独立精英池；胜利后必发 1 个遗物。
-      startCombat(state, pickEliteEncounter(state.rng));
+      startCombat(state, pickEliteEncounter(state.rng, state.act));
       state.pendingRelicReward = true;
       return;
     }
     case "boss": {
-      startCombat(state, pickBossEncounter(state.rng));
+      startCombat(state, pickBossEncounter(state.rng, state.act));
       return;
     }
     case "event": {

--- a/apps/spire/test/act2.test.ts
+++ b/apps/spire/test/act2.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat, endTurn } from "../src/engine/combat/combat.js";
+import { getPower } from "../src/engine/powers/powers.js";
+import {
+  pickNormalEncounter,
+  pickEliteEncounter,
+  pickBossEncounter,
+} from "../src/engine/enemies/enemies.js";
+import { seedRng } from "../src/engine/rng.js";
+import { TOTAL_ACTS } from "../src/engine/run/run.js";
+import type { GameState } from "../src/engine/types.js";
+
+// B2：第二幕（城市）切片——act-aware 池 + 3 普通 + 穿刺之书 + 冠军。
+
+describe("多幕", () => {
+  it("TOTAL_ACTS = 2（第二幕已有内容）", () => {
+    expect(TOTAL_ACTS).toBe(2);
+  });
+});
+
+describe("第二幕战斗池", () => {
+  const ACT2_NORMALS = new Set(["spheric_guardian", "snake_plant", "centurion", "two_centurions"]);
+
+  it("act=2 普通池只出第二幕怪", () => {
+    for (let seed = 0; seed < 40; seed += 1) {
+      const rng = seedRng(seed);
+      for (const entered of [0, 2, 5]) {
+        expect(ACT2_NORMALS.has(pickNormalEncounter(rng, entered, 2))).toBe(true);
+      }
+    }
+  });
+
+  it("act=2 精英是穿刺之书、Boss 是冠军", () => {
+    expect(pickEliteEncounter(seedRng(1), 2)).toBe("book_of_stabbing");
+    expect(pickBossEncounter(seedRng(1), 2)).toBe("champ");
+  });
+
+  it("act=1 仍是第一幕内容", () => {
+    const bosses = new Set<string>();
+    for (let seed = 0; seed < 40; seed += 1) {
+      bosses.add(pickBossEncounter(seedRng(seed), 1));
+    }
+    expect([...bosses].every(b => ["guardian", "hexaghost", "slime_boss"].includes(b))).toBe(true);
+  });
+});
+
+function fight(encounter: string): GameState {
+  const s = newRun({ runId: encounter, seed: 1 });
+  startCombat(s, encounter);
+  s.hp = 9999;
+  s.maxHp = 9999;
+  return s;
+}
+
+describe("球形守卫：3 层神器", () => {
+  it("开局自带 3 层神器", () => {
+    const s = fight("spheric_guardian");
+    expect(getPower(s.combat!.enemies[0]!.powers, "artifact")).toBe(3);
+    expect(s.combat!.enemies[0]!.currentMove).toBe("sg_activate"); // 首招激活
+  });
+});
+
+describe("冠军：半血暴怒", () => {
+  it("血量降到 ≤半血时暴怒一次（+6 力量），不重复", () => {
+    const s = fight("champ");
+    const champ = s.combat!.enemies[0]!;
+    champ.maxHp = 400;
+    champ.hp = 190; // ≤半血
+    s.combat!.hand = [];
+    endTurn(s); // selectNextMove 应先给暴怒
+    // 暴怒在上一回合末 telegraph；这里 champ 已执行暴怒或已 telegraph
+    // 通过多回合确认力量增加且暴怒只出现一次
+    let angerCount = champ.moveHistory.filter(m => m === "anger").length;
+    for (let i = 0; i < 20; i += 1) {
+      s.hp = 9999;
+      s.combat!.hand = [];
+      endTurn(s);
+    }
+    angerCount = s.combat!.enemies[0]!.moveHistory.filter(m => m === "anger").length;
+    expect(angerCount).toBe(1);
+    expect(getPower(s.combat!.enemies[0]!.powers, "strength")).toBeGreaterThanOrEqual(6);
+  });
+
+  it("满血不暴怒", () => {
+    const s = fight("champ");
+    s.combat!.enemies[0]!.hp = s.combat!.enemies[0]!.maxHp;
+    s.combat!.hand = [];
+    endTurn(s);
+    expect(s.combat!.enemies[0]!.moveHistory.includes("anger")).toBe(false);
+  });
+});

--- a/packages/spire-api/src/contract.ts
+++ b/packages/spire-api/src/contract.ts
@@ -80,6 +80,7 @@ export const SpireEventViewSchema = z.object({
 export const SpireScreenSchema = z.object({
   version: z.number().int(),
   screen: z.enum(["map", "combat", "reward", "rest", "event", "shop", "gameover", "victory"]),
+  act: z.number().int(),
   player: z.object({
     hp: z.number().int(),
     maxHp: z.number().int(),


### PR DESCRIPTION
多幕结构真正落地：**act-aware 战斗池**，第一幕→第二幕过渡端到端生效。**本批次不部署**。Refs #234。

## 框架
- `pickNormal/Elite/BossEncounter` 加 `act` 参数按幕选池；新 `ACT2_WEAK/STRONG/ELITE/BOSS` 池。
- `TOTAL_ACTS=2`：打完第一幕 Boss **携带血/牌/遗物/金币/药水**进第二幕，打完冠军才通关。
- 契约 `ScreenView` 加 `act`；agent 地图屏显示「第 N 幕」。

## 第二幕内容（切片）
| 类型 | 敌人 |
|---|---|
| 普通 | 食蛇草(75-79) · 球形守卫(20+3神器) · 百夫长(76-80) |
| 精英 | 穿刺之书(160-162, 乱刺6×3/重刺21) |
| Boss | **冠军**(420-440, 重斩/扇脸/防御姿态+金属化/处决/自夸 + **半血一次性暴怒+6力量**) |

## 验证
门禁全绿：build/typecheck/lint(0)/format + **spire 211/211**（新增 `act2.test.ts` 7 例：TOTAL_ACTS、act-aware 池只出对应幕、球形守卫 3 神器、冠军半血暴怒一次/满血不暴怒）· **agent 806**。sim 贪心 400 局 **stuck=0、平均 171 步（跨 2 幕）**——多幕过渡端到端跑通。

## 后续（B2 之外）
补齐第二幕：更多普通怪、精英(地精首领/夜魔)、Boss(青铜自动机/收藏家)、幕间篝火。骨架已通，填内容即可。