### PR TITLE
feat(spire): 第二幕普通怪补齐（B2 补齐 · 普通怪）

### DIFF
--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -94,6 +94,10 @@ function createEnemyState(state: GameState, defId: string, hpOverride?: number):
     // 球形守卫开局自带 3 层神器（抵消你前三个减益）。
     powers.push({ id: "artifact", amount: 3 });
   }
+  if (defId === "shelled_parasite") {
+    // 带壳寄生虫开局自带 14 层镀甲（每回合结束回格挡，被穿甲攻击时递减）。
+    powers.push({ id: "plated_armor", amount: 14 });
+  }
   if (defId === "fungi_beast") {
     // 真菌兽开局自带孢子云（显示用；死亡给玩家 2 易伤由 deathEffects 结算）。
     powers.push({ id: "spore_cloud", amount: 2 });
@@ -391,6 +395,24 @@ function applyEffect(
       }
       break;
     }
+    case "heal_self": {
+      // 敌人回复自身生命（带壳寄生虫吸取）。
+      if (actor.side === "enemy") {
+        const self = combat.enemies[actor.index]!;
+        self.hp = Math.min(self.maxHp, self.hp + effect.amount);
+      }
+      break;
+    }
+    case "heal_ally": {
+      // 敌人治疗一名受伤的友军（秘法师）；无受伤友军则治自己。
+      if (actor.side === "enemy") {
+        const wounded = combat.enemies.filter(e => e.hp > 0 && !e.escaped && e.hp < e.maxHp);
+        const targets = wounded.length > 0 ? wounded : [combat.enemies[actor.index]!];
+        const pick = targets[nextInt(state.rng, targets.length)]!;
+        pick.hp = Math.min(pick.maxHp, pick.hp + effect.amount);
+      }
+      break;
+    }
     case "add_card": {
       addCards(state, effect.cardId, effect.pile, effect.count);
       break;
@@ -532,6 +554,10 @@ function dealDamageToEnemy(
   const angry = getPower(enemy.powers, "angry");
   if (angry > 0 && afterBlock > 0 && enemy.hp > 0) {
     addPower(enemy.powers, "strength", angry);
+  }
+  // 镀甲（带壳寄生虫）：受到穿透格挡的攻击伤害时 -1 层。
+  if (afterBlock > 0 && enemy.hp > 0 && getPower(enemy.powers, "plated_armor") > 0) {
+    addPower(enemy.powers, "plated_armor", -1);
   }
   // 半血分裂：降到 ≤maxHp/2 且未分裂过 → 下一动作强制变分裂。
   const def = getEnemyDef(enemy.defId);
@@ -810,10 +836,14 @@ export function endTurn(state: GameState): void {
       state.log.push("你倒下了。");
       return;
     }
-    // 金属化：自己回合结束获得格挡（拉加维林睡眠期每回合回 8）。
+    // 金属化 / 镀甲：自己回合结束获得格挡（拉加维林金属化 8、带壳寄生虫镀甲 14）。
     const metallicize = getPower(enemy.powers, "metallicize");
     if (metallicize > 0) {
       enemy.block += metallicize;
+    }
+    const enemyPlated = getPower(enemy.powers, "plated_armor");
+    if (enemyPlated > 0) {
+      enemy.block += enemyPlated;
     }
     decayDebuffs(enemy.powers);
     // 下一招 telegraph（守卫者的姿态推进与防御→进攻切换在 selectNextMove 内处理）。

--- a/apps/spire/src/engine/enemies/enemies.ts
+++ b/apps/spire/src/engine/enemies/enemies.ts
@@ -538,6 +538,148 @@ const ENEMY_LIST: EnemyDef[] = [
     },
   },
 
+  {
+    id: "shelled_parasite",
+    name: "带壳寄生虫",
+    hpMin: 68,
+    hpMax: 72,
+    moves: [
+      {
+        id: "double_strike",
+        name: "双重打击",
+        effects: [{ kind: "deal_damage_multi", amount: 6, times: 2 }],
+        intent: "attack",
+      },
+      {
+        id: "suck",
+        name: "吸取",
+        effects: [
+          { kind: "deal_damage", amount: 10 },
+          { kind: "heal_self", amount: 10 },
+        ],
+        intent: "attack",
+      },
+      {
+        id: "fell",
+        name: "重击",
+        effects: [
+          { kind: "deal_damage", amount: 18 },
+          { kind: "apply_power", power: "frail", amount: 2, on: "target" },
+        ],
+        intent: "attack",
+      },
+    ],
+    intentRule: {
+      scripted: [],
+      weighted: [
+        { move: "double_strike", weight: 45, maxInARow: 2 },
+        { move: "fell", weight: 30, maxInARow: 1 },
+        { move: "suck", weight: 25, maxInARow: 1 },
+      ],
+    },
+  },
+  {
+    id: "chosen",
+    name: "选民",
+    hpMin: 95,
+    hpMax: 99,
+    moves: [
+      {
+        id: "poke",
+        name: "戳刺",
+        effects: [{ kind: "deal_damage", amount: 6 }],
+        intent: "attack",
+      },
+      {
+        id: "zap",
+        name: "电击",
+        effects: [{ kind: "deal_damage", amount: 18 }],
+        intent: "attack",
+      },
+      {
+        id: "drain",
+        name: "汲取",
+        effects: [
+          { kind: "apply_power", power: "weak", amount: 3, on: "target" },
+          { kind: "apply_power", power: "strength", amount: 3, on: "self" },
+        ],
+        intent: "buff",
+      },
+    ],
+    // 首招汲取(削弱玩家+自强)，之后 戳刺/电击。
+    intentRule: {
+      scripted: ["drain"],
+      weighted: [
+        { move: "poke", weight: 55, maxInARow: 2 },
+        { move: "zap", weight: 45, maxInARow: 1 },
+      ],
+    },
+  },
+  {
+    id: "snecko",
+    name: "史尼克",
+    hpMin: 114,
+    hpMax: 120,
+    moves: [
+      {
+        id: "snecko_bite",
+        name: "撕咬",
+        effects: [{ kind: "deal_damage", amount: 15 }],
+        intent: "attack",
+      },
+      {
+        id: "tail_whip",
+        name: "尾击",
+        effects: [
+          { kind: "deal_damage", amount: 8 },
+          { kind: "apply_power", power: "weak", amount: 2, on: "target" },
+        ],
+        intent: "attack",
+      },
+    ],
+    intentRule: {
+      scripted: [],
+      weighted: [
+        { move: "snecko_bite", weight: 60, maxInARow: 2 },
+        { move: "tail_whip", weight: 40, maxInARow: 1 },
+      ],
+    },
+  },
+  {
+    id: "mystic",
+    name: "秘法师",
+    hpMin: 48,
+    hpMax: 56,
+    moves: [
+      {
+        id: "mystic_heal",
+        name: "治疗",
+        effects: [{ kind: "heal_ally", amount: 16 }],
+        intent: "buff",
+      },
+      {
+        id: "mystic_buff",
+        name: "鼓舞",
+        effects: [{ kind: "apply_power", power: "strength", amount: 2, on: "all_enemies" }],
+        intent: "buff",
+      },
+      {
+        id: "mystic_attack",
+        name: "法击",
+        effects: [{ kind: "deal_damage", amount: 8 }],
+        intent: "attack",
+      },
+    ],
+    intentRule: {
+      scripted: [],
+      weighted: [
+        { move: "mystic_heal", weight: 35, maxInARow: 1 },
+        { move: "mystic_buff", weight: 30, maxInARow: 1 },
+        { move: "mystic_attack", weight: 35, maxInARow: 2 },
+      ],
+    },
+  },
+
   // —— 第二幕精英：穿刺之书（多段攻击）——
   {
     id: "book_of_stabbing",
@@ -1009,6 +1151,11 @@ const ENCOUNTERS: Record<string, EncounterDef> = {
   spheric_guardian: { id: "spheric_guardian", enemies: ["spheric_guardian"], isBoss: false },
   centurion: { id: "centurion", enemies: ["centurion"], isBoss: false },
   two_centurions: { id: "two_centurions", enemies: ["centurion", "centurion"], isBoss: false },
+  shelled_parasite: { id: "shelled_parasite", enemies: ["shelled_parasite"], isBoss: false },
+  chosen: { id: "chosen", enemies: ["chosen"], isBoss: false },
+  snecko: { id: "snecko", enemies: ["snecko"], isBoss: false },
+  // 百夫长 + 秘法师：秘法师治疗/鼓舞百夫长，经典组合。
+  centurion_mystic: { id: "centurion_mystic", enemies: ["centurion", "mystic"], isBoss: false },
   book_of_stabbing: { id: "book_of_stabbing", enemies: ["book_of_stabbing"], isBoss: false },
   champ: { id: "champ", enemies: ["champ"], isBoss: true },
   guardian: { id: "guardian", enemies: ["the_guardian"], isBoss: true },
@@ -1070,11 +1217,16 @@ const ACT2_WEAK_POOL: readonly WeightedEncounter[] = [
   { id: "spheric_guardian", weight: 1 },
   { id: "snake_plant", weight: 1 },
   { id: "centurion", weight: 1 },
+  { id: "shelled_parasite", weight: 1 },
+  { id: "chosen", weight: 1 },
 ];
 
 const ACT2_STRONG_POOL: readonly WeightedEncounter[] = [
-  { id: "centurion", weight: 2 },
-  { id: "snake_plant", weight: 2 },
+  { id: "chosen", weight: 2 },
+  { id: "snecko", weight: 2 },
+  { id: "centurion_mystic", weight: 2 },
+  { id: "shelled_parasite", weight: 2 },
+  { id: "snake_plant", weight: 1 },
   { id: "two_centurions", weight: 1 },
   { id: "spheric_guardian", weight: 1 },
 ];

--- a/apps/spire/src/engine/types.ts
+++ b/apps/spire/src/engine/types.ts
@@ -62,6 +62,10 @@ export type Effect =
   | { kind: "steal_gold"; amount: number }
   // 敌人用：本敌人逃离战斗（拾荒者烟雾弹后逃跑）。
   | { kind: "escape" }
+  // 敌人用：本敌人回复自身生命（带壳寄生虫吸取）。
+  | { kind: "heal_self"; amount: number }
+  // 敌人用：治疗一名受伤的友军（秘法师；无受伤友军则治自己）。
+  | { kind: "heal_ally"; amount: number }
   | { kind: "add_card"; cardId: string; pile: "draw" | "discard" | "hand"; count: number };
 
 /** 卡定义（静态数据表）。cost=null 表示不可打出（status/废牌）。 */

--- a/apps/spire/test/act2-mobs.test.ts
+++ b/apps/spire/test/act2-mobs.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat, endTurn } from "../src/engine/combat/combat.js";
+import { getPower } from "../src/engine/powers/powers.js";
+import { pickNormalEncounter } from "../src/engine/enemies/enemies.js";
+import { seedRng } from "../src/engine/rng.js";
+import type { GameState } from "../src/engine/types.js";
+
+// B2 补齐：第二幕普通怪（带壳寄生虫/选民/史尼克/秘法师）+ 敌人镀甲/自愈/治疗友军。
+
+function fight(encounter: string): GameState {
+  const s = newRun({ runId: encounter, seed: 1 });
+  startCombat(s, encounter);
+  s.hp = 9999;
+  s.maxHp = 9999;
+  return s;
+}
+
+describe("带壳寄生虫：镀甲 + 吸取", () => {
+  it("开局自带 14 镀甲，回合末获得等量格挡", () => {
+    const s = fight("shelled_parasite");
+    const p = s.combat!.enemies[0]!;
+    expect(getPower(p.powers, "plated_armor")).toBe(14);
+    s.combat!.hand = [];
+    p.currentMove = "double_strike";
+    endTurn(s);
+    expect(p.block).toBe(14); // 回合末镀甲给 14 格挡
+  });
+
+  it("吸取造成 10 伤并自愈 10", () => {
+    const s = fight("shelled_parasite");
+    const p = s.combat!.enemies[0]!;
+    p.hp = 40;
+    p.maxHp = 72;
+    s.hp = 100;
+    s.combat!.hand = [];
+    p.currentMove = "suck";
+    endTurn(s);
+    expect(s.hp).toBe(90); // 玩家 -10
+    expect(p.hp).toBe(50); // 敌人 +10
+  });
+});
+
+describe("选民：汲取", () => {
+  it("首招汲取：给玩家 3 虚弱、自身 +3 力量", () => {
+    const s = fight("chosen");
+    const c = s.combat!.enemies[0]!;
+    expect(c.currentMove).toBe("drain");
+    s.combat!.hand = [];
+    endTurn(s);
+    expect(getPower(s.combat!.playerPowers, "weak")).toBe(3);
+    expect(getPower(s.combat!.enemies[0]!.powers, "strength")).toBe(3);
+  });
+});
+
+describe("史尼克：尾击削弱", () => {
+  it("尾击造成 8 伤 + 2 虚弱", () => {
+    const s = fight("snecko");
+    s.hp = 100;
+    s.combat!.hand = [];
+    s.combat!.enemies[0]!.currentMove = "tail_whip";
+    endTurn(s);
+    expect(s.hp).toBe(92);
+    expect(getPower(s.combat!.playerPowers, "weak")).toBe(2);
+  });
+});
+
+describe("秘法师：治疗 + 鼓舞友军", () => {
+  it("治疗受伤友军 16", () => {
+    const s = fight("centurion_mystic");
+    const cent = s.combat!.enemies.find(e => e.defId === "centurion")!;
+    const mystic = s.combat!.enemies.find(e => e.defId === "mystic")!;
+    cent.hp = 30;
+    cent.maxHp = 80;
+    s.combat!.hand = [];
+    mystic.currentMove = "mystic_heal";
+    endTurn(s);
+    expect(s.combat!.enemies.find(e => e.defId === "centurion")!.hp).toBe(46); // +16
+  });
+
+  it("鼓舞给所有敌人（含自己）+2 力量", () => {
+    const s = fight("centurion_mystic");
+    const mystic = s.combat!.enemies.find(e => e.defId === "mystic")!;
+    s.combat!.hand = [];
+    mystic.currentMove = "mystic_buff";
+    // 让百夫长不动
+    s.combat!.enemies.find(e => e.defId === "centurion")!.currentMove = "cent_defend";
+    endTurn(s);
+    for (const e of s.combat!.enemies) {
+      expect(getPower(e.powers, "strength")).toBeGreaterThanOrEqual(2);
+    }
+  });
+});
+
+describe("第二幕池已含新怪", () => {
+  it("act=2 普通池会抽到带壳寄生虫/选民/史尼克/秘法师组", () => {
+    const seen = new Set<string>();
+    for (let seed = 0; seed < 120; seed += 1) {
+      const rng = seedRng(seed);
+      for (const entered of [0, 1, 2, 4, 6]) {
+        seen.add(pickNormalEncounter(rng, entered, 2));
+      }
+    }
+    expect(seen.has("shelled_parasite")).toBe(true);
+    expect(seen.has("chosen")).toBe(true);
+    expect(seen.has("snecko")).toBe(true);
+    expect(seen.has("centurion_mystic")).toBe(true);
+  });
+});

--- a/apps/spire/test/act2.test.ts
+++ b/apps/spire/test/act2.test.ts
@@ -20,7 +20,16 @@ describe("多幕", () => {
 });
 
 describe("第二幕战斗池", () => {
-  const ACT2_NORMALS = new Set(["spheric_guardian", "snake_plant", "centurion", "two_centurions"]);
+  const ACT2_NORMALS = new Set([
+    "spheric_guardian",
+    "snake_plant",
+    "centurion",
+    "two_centurions",
+    "shelled_parasite",
+    "chosen",
+    "snecko",
+    "centurion_mystic",
+  ]);
 
   it("act=2 普通池只出第二幕怪", () => {
     for (let seed = 0; seed < 40; seed += 1) {


### PR DESCRIPTION
第二幕普通怪 3→7 种（带壳寄生虫/选民/史尼克/秘法师），引入敌人镀甲/自愈/治疗友军机制。**不部署**。Refs #234。spire 218/218，sim stuck=0。纯 spire。