### PR TITLE
feat(spire): 第二幕精英补齐（地精首领/奴隶主小队）+ 召唤机制（B2 补齐 · 精英）

### DIFF
--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -31,6 +31,7 @@ import { getPotionDef } from "../potions/potions.js";
 const STARTING_ENERGY = 3;
 const STARTING_HAND_SIZE = 5;
 const MAX_HAND_SIZE = 10;
+const MAX_ENEMIES = 5; // 场上敌人上限（地精首领召唤封顶）。
 const GUARDIAN_MODE_SHIFT_STEP = 10;
 const GUARDIAN_SHIFT_BLOCK = 20;
 const LOUSE_CURL_UP_MIN = 3;
@@ -410,6 +411,20 @@ function applyEffect(
         const targets = wounded.length > 0 ? wounded : [combat.enemies[actor.index]!];
         const pick = targets[nextInt(state.rng, targets.length)]!;
         pick.hp = Math.min(pick.maxHp, pick.hp + effect.amount);
+      }
+      break;
+    }
+    case "summon": {
+      // 敌人召唤新敌人（地精首领）；场上敌人达上限则不再召唤，新生者本回合不行动。
+      if (actor.side === "enemy") {
+        for (const defId of effect.defIds) {
+          if (livingEnemies(combat).length >= MAX_ENEMIES) {
+            break;
+          }
+          const newIndex = combat.enemies.length;
+          combat.enemies.push(createEnemyState(state, defId));
+          selectNextMove(state, newIndex);
+        }
       }
       break;
     }
@@ -910,6 +925,18 @@ function selectNextMove(state: GameState, enemyIndex: number): void {
     enemy.rotationIndex = (enemy.rotationIndex + 1) % cycle.length;
     enemy.currentMove = cycle[enemy.rotationIndex]!;
     return;
+  }
+
+  // 地精首领：身边存活地精 <2 只则召唤，否则鼓舞 / 突刺（走 weighted）。
+  if (enemy.defId === "gremlin_leader") {
+    const otherGremlins = combat.enemies.filter(
+      e => e.hp > 0 && !e.escaped && e.defId !== "gremlin_leader",
+    ).length;
+    if (otherGremlins < 2) {
+      enemy.currentMove = "summon_gremlins";
+      return;
+    }
+    // 否则落到下方 weighted（鼓舞 / 突刺）。
   }
 
   // 冠军（第二幕 Boss）：血量首次降到 ≤半血时暴怒一次（+6 力量），其余走 weighted。

--- a/apps/spire/src/engine/enemies/enemies.ts
+++ b/apps/spire/src/engine/enemies/enemies.ts
@@ -680,6 +680,63 @@ const ENEMY_LIST: EnemyDef[] = [
     },
   },
 
+  // —— 第二幕精英 ——
+  {
+    id: "gremlin_leader",
+    name: "地精首领",
+    hpMin: 140,
+    hpMax: 148,
+    moves: [
+      {
+        id: "summon_gremlins",
+        name: "召唤地精",
+        effects: [{ kind: "summon", defIds: ["mad_gremlin", "sneaky_gremlin"] }],
+        intent: "unknown",
+      },
+      {
+        id: "encourage",
+        name: "鼓舞",
+        effects: [{ kind: "apply_power", power: "strength", amount: 3, on: "all_enemies" }],
+        intent: "buff",
+      },
+      {
+        id: "gl_stab",
+        name: "突刺",
+        effects: [{ kind: "deal_damage", amount: 6 }],
+        intent: "attack",
+      },
+    ],
+    // 召唤由 combat.ts gremlin_leader 分支处理（身边地精 <2 则召唤）；否则 鼓舞/突刺。
+    intentRule: {
+      scripted: [],
+      weighted: [
+        { move: "encourage", weight: 40, maxInARow: 1 },
+        { move: "gl_stab", weight: 60, maxInARow: 2 },
+      ],
+    },
+  },
+  {
+    id: "taskmaster",
+    name: "工头",
+    hpMin: 54,
+    hpMax: 60,
+    moves: [
+      {
+        id: "scouring_whip",
+        name: "抽打",
+        effects: [
+          { kind: "deal_damage", amount: 7 },
+          { kind: "add_card", cardId: "wound", pile: "discard", count: 1 },
+        ],
+        intent: "attack",
+      },
+    ],
+    intentRule: {
+      scripted: [],
+      weighted: [{ move: "scouring_whip", weight: 1, maxInARow: 99 }],
+    },
+  },
+
   // —— 第二幕精英：穿刺之书（多段攻击）——
   {
     id: "book_of_stabbing",
@@ -1157,6 +1214,14 @@ const ENCOUNTERS: Record<string, EncounterDef> = {
   // 百夫长 + 秘法师：秘法师治疗/鼓舞百夫长，经典组合。
   centurion_mystic: { id: "centurion_mystic", enemies: ["centurion", "mystic"], isBoss: false },
   book_of_stabbing: { id: "book_of_stabbing", enemies: ["book_of_stabbing"], isBoss: false },
+  // 地精首领带 2 只地精登场；死光了会继续召唤。
+  gremlin_leader: {
+    id: "gremlin_leader",
+    enemies: ["mad_gremlin", "gremlin_leader", "sneaky_gremlin"],
+    isBoss: false,
+  },
+  // 奴隶主小队：工头 + 蓝/红奴隶主。
+  slavers: { id: "slavers", enemies: ["taskmaster", "blue_slaver", "red_slaver"], isBoss: false },
   champ: { id: "champ", enemies: ["champ"], isBoss: true },
   guardian: { id: "guardian", enemies: ["the_guardian"], isBoss: true },
   hexaghost: { id: "hexaghost", enemies: ["hexaghost"], isBoss: true },
@@ -1255,8 +1320,12 @@ const ELITE_ENCOUNTER_POOL: readonly WeightedEncounter[] = [
   { id: "three_sentries", weight: 1 },
 ];
 
-// Act2 精英池（切片：穿刺之书；后续补 地精首领 / 夜魔）。
-const ACT2_ELITE_POOL: readonly WeightedEncounter[] = [{ id: "book_of_stabbing", weight: 1 }];
+// Act2 精英池：穿刺之书 / 地精首领 / 奴隶主小队。
+const ACT2_ELITE_POOL: readonly WeightedEncounter[] = [
+  { id: "book_of_stabbing", weight: 1 },
+  { id: "gremlin_leader", weight: 1 },
+  { id: "slavers", weight: 1 },
+];
 
 /** 精英节点：从精英池挑一个 encounter id（按幕选池）。 */
 export function pickEliteEncounter(rng: RngState, act = 1): string {

--- a/apps/spire/src/engine/types.ts
+++ b/apps/spire/src/engine/types.ts
@@ -66,6 +66,8 @@ export type Effect =
   | { kind: "heal_self"; amount: number }
   // 敌人用：治疗一名受伤的友军（秘法师；无受伤友军则治自己）。
   | { kind: "heal_ally"; amount: number }
+  // 敌人用：召唤若干敌人加入战斗（地精首领召唤地精；新生者本回合不行动）。
+  | { kind: "summon"; defIds: string[] }
   | { kind: "add_card"; cardId: string; pile: "draw" | "discard" | "hand"; count: number };
 
 /** 卡定义（静态数据表）。cost=null 表示不可打出（status/废牌）。 */

--- a/apps/spire/test/act2-elites.test.ts
+++ b/apps/spire/test/act2-elites.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat, endTurn } from "../src/engine/combat/combat.js";
+import { getPower } from "../src/engine/powers/powers.js";
+import { getEncounterDef, pickEliteEncounter } from "../src/engine/enemies/enemies.js";
+import { seedRng } from "../src/engine/rng.js";
+import type { GameState } from "../src/engine/types.js";
+
+// B2 补齐：第二幕精英——地精首领(召唤)、奴隶主小队(工头)。
+
+function fight(encounter: string): GameState {
+  const s = newRun({ runId: encounter, seed: 1 });
+  startCombat(s, encounter);
+  s.hp = 9999;
+  s.maxHp = 9999;
+  return s;
+}
+
+function leaderOf(s: GameState) {
+  return s.combat!.enemies.find(e => e.defId === "gremlin_leader")!;
+}
+
+describe("地精首领：召唤", () => {
+  it("身边地精 <2 只时下一招变召唤", () => {
+    const s = fight("gremlin_leader");
+    // 杀掉两只随从地精
+    for (const e of s.combat!.enemies) {
+      if (e.defId !== "gremlin_leader") {
+        e.hp = 0;
+      }
+    }
+    s.combat!.hand = [];
+    endTurn(s); // 首领行动后重新 telegraph
+    expect(leaderOf(s).currentMove).toBe("summon_gremlins");
+  });
+
+  it("召唤把两只地精加入战斗", () => {
+    const s = fight("gremlin_leader");
+    for (const e of s.combat!.enemies) {
+      if (e.defId !== "gremlin_leader") {
+        e.hp = 0;
+      }
+    }
+    const before = s.combat!.enemies.length;
+    leaderOf(s).currentMove = "summon_gremlins";
+    s.combat!.hand = [];
+    endTurn(s);
+    expect(s.combat!.enemies.length).toBe(before + 2);
+  });
+
+  it("召唤不超过场上 5 只上限", () => {
+    const s = fight("gremlin_leader");
+    // 已经 3 只；反复召唤，存活数不应超过 5
+    for (let i = 0; i < 6; i += 1) {
+      leaderOf(s).currentMove = "summon_gremlins";
+      s.hp = 9999;
+      s.combat!.hand = [];
+      endTurn(s);
+    }
+    const living = s.combat!.enemies.filter(e => e.hp > 0 && !e.escaped).length;
+    expect(living).toBeLessThanOrEqual(5);
+  });
+
+  it("鼓舞给所有敌人 +3 力量", () => {
+    const s = fight("gremlin_leader");
+    leaderOf(s).currentMove = "encourage";
+    for (const e of s.combat!.enemies) {
+      if (e.defId !== "gremlin_leader") {
+        e.currentMove = "scratch"; // 随从随便动
+      }
+    }
+    s.combat!.hand = [];
+    endTurn(s);
+    for (const e of s.combat!.enemies) {
+      if (e.hp > 0) {
+        expect(getPower(e.powers, "strength")).toBeGreaterThanOrEqual(3);
+      }
+    }
+  });
+});
+
+describe("工头：抽打", () => {
+  it("造成 7 伤并塞一张伤口进弃牌堆", () => {
+    const s = fight("slavers");
+    const taskmaster = s.combat!.enemies.find(e => e.defId === "taskmaster")!;
+    s.hp = 100;
+    // 让另外两个奴隶主不动
+    for (const e of s.combat!.enemies) {
+      if (e.defId !== "taskmaster") {
+        e.hp = 0;
+      }
+    }
+    const before = s.combat!.discardPile.filter(c => c.defId === "wound").length;
+    s.combat!.hand = [];
+    taskmaster.currentMove = "scouring_whip";
+    endTurn(s);
+    expect(s.hp).toBe(93);
+    expect(s.combat!.discardPile.filter(c => c.defId === "wound").length).toBe(before + 1);
+  });
+});
+
+describe("第二幕精英池", () => {
+  it("奴隶主小队组成 = 工头 + 蓝奴 + 红奴", () => {
+    expect(getEncounterDef("slavers").enemies).toEqual(["taskmaster", "blue_slaver", "red_slaver"]);
+  });
+
+  it("act=2 精英池含 穿刺之书/地精首领/奴隶主小队", () => {
+    const seen = new Set<string>();
+    for (let seed = 0; seed < 60; seed += 1) {
+      seen.add(pickEliteEncounter(seedRng(seed), 2));
+    }
+    expect(seen.has("book_of_stabbing")).toBe(true);
+    expect(seen.has("gremlin_leader")).toBe(true);
+    expect(seen.has("slavers")).toBe(true);
+  });
+});


### PR DESCRIPTION
第二幕精英 1→3 种，引入**召唤机制**。**本批次不部署**。Refs #234。

## 召唤机制
- `summon` 效果：敌人召唤新敌人加入战斗（`createEnemyState` + append + telegraph，新生者本回合不行动，**场上封顶 5 只**）。

## 2 新精英
- **地精首领** 140-148：身边地精 <2 只则召唤 2 只、否则 鼓舞(全体+3力量)/突刺6；开场带 2 地精登场。
- **奴隶主小队** = 工头(54-60，抽打 7伤+塞1伤口) + 蓝奴 + 红奴。

ACT2 精英池 = 穿刺之书 / 地精首领 / 奴隶主小队。

## 验证
门禁全绿：build/typecheck/lint(0)/format + **spire 225/225**（新增 `act2-elites.test.ts` 6 例：首领召唤触发/加2怪/5只封顶/鼓舞全体、工头抽打+伤口、精英池组成）。sim 贪心+随机 **stuck=0**（召唤封顶必然终止）。纯 spire。

## 第二幕现状
普通怪 7 种 + 精英 3 种齐了。剩 Boss（青铜自动机/收藏家，目前只有冠军）+ 幕间篝火。