### PR TITLE
feat(spire): 第二幕 Boss 补齐（青铜自动机/收藏家）——第二幕完整

### DIFF
--- a/apps/spire/src/engine/enemies/enemies.ts
+++ b/apps/spire/src/engine/enemies/enemies.ts
@@ -830,6 +830,147 @@ const ENEMY_LIST: EnemyDef[] = [
     },
   },
 
+  // —— 第二幕 Boss：青铜自动机（召唤青铜球 + 超射线）——
+  {
+    id: "bronze_automaton",
+    name: "青铜自动机",
+    hpMin: 300,
+    hpMax: 300,
+    moves: [
+      {
+        id: "spawn_orbs",
+        name: "召唤青铜球",
+        effects: [{ kind: "summon", defIds: ["bronze_orb", "bronze_orb"] }],
+        intent: "unknown",
+      },
+      {
+        id: "flail",
+        name: "连枷",
+        effects: [{ kind: "deal_damage_multi", amount: 7, times: 2 }],
+        intent: "attack",
+      },
+      {
+        id: "boost",
+        name: "增益",
+        effects: [
+          { kind: "gain_block", amount: 9 },
+          { kind: "apply_power", power: "strength", amount: 3, on: "self" },
+        ],
+        intent: "buff",
+      },
+      {
+        id: "hyperbeam",
+        name: "超射线",
+        effects: [{ kind: "deal_damage", amount: 45 }],
+        intent: "attack",
+      },
+    ],
+    // 首招召唤两颗青铜球，之后 连枷/增益/超射线。
+    intentRule: {
+      scripted: ["spawn_orbs"],
+      weighted: [
+        { move: "flail", weight: 40, maxInARow: 2 },
+        { move: "boost", weight: 35, maxInARow: 1 },
+        { move: "hyperbeam", weight: 25, maxInARow: 1 },
+      ],
+    },
+  },
+  {
+    id: "bronze_orb",
+    name: "青铜球",
+    hpMin: 52,
+    hpMax: 52,
+    moves: [
+      {
+        id: "orb_beam",
+        name: "光束",
+        effects: [{ kind: "deal_damage", amount: 8 }],
+        intent: "attack",
+      },
+      {
+        id: "orb_support",
+        name: "支援",
+        effects: [{ kind: "gain_block", amount: 6 }],
+        intent: "defend",
+      },
+    ],
+    intentRule: {
+      scripted: [],
+      weighted: [
+        { move: "orb_beam", weight: 70, maxInARow: 2 },
+        { move: "orb_support", weight: 30, maxInARow: 1 },
+      ],
+    },
+  },
+
+  // —— 第二幕 Boss：收藏家（召唤火把头 + 群体减益）——
+  {
+    id: "the_collector",
+    name: "收藏家",
+    hpMin: 282,
+    hpMax: 300,
+    moves: [
+      {
+        id: "spawn_torches",
+        name: "召唤火把头",
+        effects: [{ kind: "summon", defIds: ["torch_head", "torch_head"] }],
+        intent: "unknown",
+      },
+      {
+        id: "fireball",
+        name: "火球",
+        effects: [{ kind: "deal_damage", amount: 18 }],
+        intent: "attack",
+      },
+      {
+        id: "collector_buff",
+        name: "增幅",
+        effects: [
+          { kind: "gain_block", amount: 15 },
+          { kind: "apply_power", power: "strength", amount: 3, on: "self" },
+        ],
+        intent: "buff",
+      },
+      {
+        id: "mega_debuff",
+        name: "巨型削弱",
+        effects: [
+          { kind: "apply_power", power: "weak", amount: 3, on: "target" },
+          { kind: "apply_power", power: "vulnerable", amount: 3, on: "target" },
+          { kind: "apply_power", power: "frail", amount: 3, on: "target" },
+        ],
+        intent: "debuff",
+      },
+    ],
+    // 首招召唤两个火把头，之后 火球/增幅/巨型削弱。
+    intentRule: {
+      scripted: ["spawn_torches"],
+      weighted: [
+        { move: "fireball", weight: 40, maxInARow: 2 },
+        { move: "collector_buff", weight: 25, maxInARow: 1 },
+        { move: "mega_debuff", weight: 35, maxInARow: 1 },
+      ],
+    },
+  },
+  {
+    id: "torch_head",
+    name: "火把头",
+    hpMin: 38,
+    hpMax: 40,
+    moves: [
+      {
+        id: "torch_tackle",
+        name: "冲撞",
+        effects: [{ kind: "deal_damage", amount: 7 }],
+        intent: "attack",
+      },
+    ],
+    intentRule: {
+      scripted: [],
+      weighted: [{ move: "torch_tackle", weight: 1, maxInARow: 99 }],
+    },
+  },
+
   // —— 精英：地精头目（Enrage = 玩家出技能牌它加力量）——
   {
     id: "gremlin_nob",
@@ -1223,6 +1364,8 @@ const ENCOUNTERS: Record<string, EncounterDef> = {
   // 奴隶主小队：工头 + 蓝/红奴隶主。
   slavers: { id: "slavers", enemies: ["taskmaster", "blue_slaver", "red_slaver"], isBoss: false },
   champ: { id: "champ", enemies: ["champ"], isBoss: true },
+  bronze_automaton: { id: "bronze_automaton", enemies: ["bronze_automaton"], isBoss: true },
+  the_collector: { id: "the_collector", enemies: ["the_collector"], isBoss: true },
   guardian: { id: "guardian", enemies: ["the_guardian"], isBoss: true },
   hexaghost: { id: "hexaghost", enemies: ["hexaghost"], isBoss: true },
   slime_boss: { id: "slime_boss", enemies: ["slime_boss"], isBoss: true },
@@ -1340,7 +1483,11 @@ const BOSS_ENCOUNTER_POOL: readonly WeightedEncounter[] = [
 ];
 
 // Act2 Boss 池（切片：冠军；后续补 青铜自动机 / 收藏家）。
-const ACT2_BOSS_POOL: readonly WeightedEncounter[] = [{ id: "champ", weight: 1 }];
+const ACT2_BOSS_POOL: readonly WeightedEncounter[] = [
+  { id: "champ", weight: 1 },
+  { id: "bronze_automaton", weight: 1 },
+  { id: "the_collector", weight: 1 },
+];
 
 /** Boss 节点：随机挑一个 Boss encounter id（按幕选池）。 */
 export function pickBossEncounter(rng: RngState, act = 1): string {

--- a/apps/spire/test/act2-bosses.test.ts
+++ b/apps/spire/test/act2-bosses.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat, endTurn, playCard } from "../src/engine/combat/combat.js";
+import { getPower } from "../src/engine/powers/powers.js";
+import { pickBossEncounter } from "../src/engine/enemies/enemies.js";
+import { seedRng } from "../src/engine/rng.js";
+import type { GameState } from "../src/engine/types.js";
+
+// B2 补齐：第二幕 Boss——青铜自动机(召唤球+超射线)、收藏家(召唤火把头+群体削弱)。
+
+function fight(encounter: string): GameState {
+  const s = newRun({ runId: encounter, seed: 1 });
+  startCombat(s, encounter);
+  s.hp = 9999;
+  s.maxHp = 9999;
+  return s;
+}
+
+describe("第二幕 Boss 池", () => {
+  it("含 冠军 / 青铜自动机 / 收藏家", () => {
+    const seen = new Set<string>();
+    for (let seed = 0; seed < 60; seed += 1) {
+      seen.add(pickBossEncounter(seedRng(seed), 2));
+    }
+    expect(seen.has("champ")).toBe(true);
+    expect(seen.has("bronze_automaton")).toBe(true);
+    expect(seen.has("the_collector")).toBe(true);
+  });
+});
+
+describe("青铜自动机", () => {
+  it("首招召唤两颗青铜球", () => {
+    const s = fight("bronze_automaton");
+    expect(s.combat!.enemies[0]!.currentMove).toBe("spawn_orbs");
+    s.combat!.hand = [];
+    endTurn(s);
+    const orbs = s.combat!.enemies.filter(e => e.defId === "bronze_orb");
+    expect(orbs).toHaveLength(2);
+  });
+
+  it("超射线造成 45", () => {
+    const s = fight("bronze_automaton");
+    s.hp = 100;
+    s.combat!.hand = [];
+    s.combat!.enemies[0]!.currentMove = "hyperbeam";
+    endTurn(s);
+    expect(s.hp).toBe(55);
+  });
+});
+
+describe("收藏家", () => {
+  it("首招召唤两个火把头", () => {
+    const s = fight("the_collector");
+    expect(s.combat!.enemies[0]!.currentMove).toBe("spawn_torches");
+    s.combat!.hand = [];
+    endTurn(s);
+    expect(s.combat!.enemies.filter(e => e.defId === "torch_head")).toHaveLength(2);
+  });
+
+  it("巨型削弱给玩家 3 虚弱 + 3 易伤 + 3 脆弱", () => {
+    const s = fight("the_collector");
+    s.combat!.hand = [];
+    s.combat!.enemies[0]!.currentMove = "mega_debuff";
+    endTurn(s);
+    expect(getPower(s.combat!.playerPowers, "weak")).toBe(3);
+    expect(getPower(s.combat!.playerPowers, "vulnerable")).toBe(3);
+    expect(getPower(s.combat!.playerPowers, "frail")).toBe(3);
+  });
+});
+
+describe("击败第二幕 Boss 掉金币 ~100", () => {
+  it("秒杀青铜自动机得 95-105 金", () => {
+    const s = fight("bronze_automaton");
+    s.gold = 0;
+    s.combat!.enemies[0]!.hp = 1;
+    s.combat!.hand = [{ uid: s.nextUid++, defId: "bludgeon", upgraded: false }];
+    s.combat!.energy = 9;
+    playCard(s, 0, 0);
+    expect(s.screen).toBe("victory");
+    expect(s.gold).toBeGreaterThanOrEqual(95);
+    expect(s.gold).toBeLessThanOrEqual(105);
+  });
+});


### PR DESCRIPTION
第二幕 Boss 1→3，**第二幕内容全齐**。**本批次不部署**。Refs #234。

## 2 新 Boss（复用召唤机制）
- **青铜自动机** 300：首招召唤 2 颗青铜球(52血, 光束8/支援)，之后 连枷7×2 / 增益(格挡9+力量3) / **超射线45**。
- **收藏家** 282-300：首招召唤 2 个火把头(38-40, 冲撞7)，之后 火球18 / 增幅(格挡15+力量3) / **巨型削弱**(玩家 虚弱3+易伤3+脆弱3)。

ACT2 Boss 池 = 冠军 / 青铜自动机 / 收藏家（各 1/3）。

## 验证
门禁全绿：build/typecheck/lint(0)/format + **spire 234/234**（新增 `act2-bosses.test.ts` 6 例：Boss 池、自动机召唤球+超射线45、收藏家召唤火把头+群体削弱、击败得 95-105 金）。sim 贪心 400 局 **stuck=0**（召唤+跨幕必然终止）。纯 spire。

## 第二幕现已完整
普通怪 7 + 精英 3 + Boss 3。剩幕间篝火（可选）。下一大块是 B3 第三幕 / C 角色。