### PR TITLE
feat(spire): 第三幕（超越）切片 + 三幕结构（Phase B · B3）

### DIFF
--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -101,6 +101,10 @@ function createEnemyState(state: GameState, defId: string, hpOverride?: number):
     // 带壳寄生虫开局自带 14 层镀甲（每回合结束回格挡，被穿甲攻击时递减）。
     powers.push({ id: "plated_armor", amount: 14 });
   }
+  if (defId === "spiker") {
+    // 尖刺客开局自带 3 层反甲（你每攻击它一次反弹 3 点无视格挡伤害）。
+    powers.push({ id: "sharp_hide", amount: 3 });
+  }
   if (defId === "fungi_beast") {
     // 真菌兽开局自带孢子云（显示用；死亡给玩家 2 易伤由 deathEffects 结算）。
     powers.push({ id: "spore_cloud", amount: 2 });

--- a/apps/spire/src/engine/enemies/enemies.ts
+++ b/apps/spire/src/engine/enemies/enemies.ts
@@ -971,6 +971,199 @@ const ENEMY_LIST: EnemyDef[] = [
     },
   },
 
+  // —— 第三幕（超越）普通敌人 ——
+  {
+    id: "exploder",
+    name: "爆破怪",
+    hpMin: 30,
+    hpMax: 30,
+    // 亡语：死亡时爆炸，对玩家造成 30 点伤害（杀它有代价）。
+    deathEffects: [{ kind: "deal_damage", amount: 30 }],
+    moves: [
+      {
+        id: "exp_slam",
+        name: "撞击",
+        effects: [{ kind: "deal_damage", amount: 9 }],
+        intent: "attack",
+      },
+    ],
+    intentRule: {
+      scripted: [],
+      weighted: [{ move: "exp_slam", weight: 1, maxInARow: 99 }],
+    },
+  },
+  {
+    id: "spiker",
+    name: "尖刺客",
+    hpMin: 42,
+    hpMax: 56,
+    // 开局自带反甲 3（你每攻击它一次反弹 3；见 createEnemyState）。
+    moves: [
+      {
+        id: "spk_cut",
+        name: "切割",
+        effects: [{ kind: "deal_damage", amount: 7 }],
+        intent: "attack",
+      },
+      {
+        id: "spk_spike",
+        name: "增生尖刺",
+        effects: [{ kind: "apply_power", power: "sharp_hide", amount: 2, on: "self" }],
+        intent: "buff",
+      },
+    ],
+    intentRule: {
+      scripted: [],
+      weighted: [
+        { move: "spk_cut", weight: 60, maxInARow: 2 },
+        { move: "spk_spike", weight: 40, maxInARow: 1 },
+      ],
+    },
+  },
+  {
+    id: "orb_walker",
+    name: "球行者",
+    hpMin: 90,
+    hpMax: 96,
+    moves: [
+      {
+        id: "ow_laser",
+        name: "激光",
+        effects: [
+          { kind: "deal_damage", amount: 10 },
+          { kind: "add_card", cardId: "burn", pile: "discard", count: 1 },
+        ],
+        intent: "attack",
+      },
+      {
+        id: "ow_claw",
+        name: "利爪",
+        effects: [{ kind: "deal_damage", amount: 16 }],
+        intent: "attack",
+      },
+    ],
+    intentRule: {
+      scripted: [],
+      weighted: [
+        { move: "ow_laser", weight: 50, maxInARow: 2 },
+        { move: "ow_claw", weight: 50, maxInARow: 1 },
+      ],
+    },
+  },
+
+  // —— 第三幕精英：蛇法师（召唤匕首）——
+  {
+    id: "reptomancer",
+    name: "蛇法师",
+    hpMin: 180,
+    hpMax: 190,
+    moves: [
+      {
+        id: "summon_daggers",
+        name: "召唤匕首",
+        effects: [{ kind: "summon", defIds: ["dagger", "dagger"] }],
+        intent: "unknown",
+      },
+      {
+        id: "snake_strike",
+        name: "毒牙",
+        effects: [
+          { kind: "deal_damage", amount: 13 },
+          { kind: "apply_power", power: "weak", amount: 1, on: "target" },
+        ],
+        intent: "attack",
+      },
+      {
+        id: "big_bite",
+        name: "巨口",
+        effects: [{ kind: "deal_damage", amount: 30 }],
+        intent: "attack",
+      },
+    ],
+    // 首招召唤匕首，之后 毒牙/巨口（身边匕首少时再召唤由 reptomancer 分支处理）。
+    intentRule: {
+      scripted: ["summon_daggers"],
+      weighted: [
+        { move: "snake_strike", weight: 60, maxInARow: 2 },
+        { move: "big_bite", weight: 40, maxInARow: 1 },
+      ],
+    },
+  },
+  {
+    id: "dagger",
+    name: "匕首",
+    hpMin: 20,
+    hpMax: 25,
+    moves: [
+      {
+        id: "dagger_stab",
+        name: "突刺",
+        effects: [{ kind: "deal_damage", amount: 9 }],
+        intent: "attack",
+      },
+    ],
+    intentRule: {
+      scripted: [],
+      weighted: [{ move: "dagger_stab", weight: 1, maxInARow: 99 }],
+    },
+  },
+
+  // —— 第三幕 Boss：铎努与迪卡（双子，互相增益）——
+  {
+    id: "deca",
+    name: "迪卡",
+    hpMin: 250,
+    hpMax: 250,
+    moves: [
+      {
+        id: "deca_beam",
+        name: "光束",
+        effects: [{ kind: "deal_damage_multi", amount: 10, times: 2 }],
+        intent: "attack",
+      },
+      {
+        id: "deca_protect",
+        name: "守护",
+        effects: [{ kind: "gain_block", amount: 16 }],
+        intent: "defend",
+      },
+    ],
+    intentRule: {
+      scripted: [],
+      weighted: [
+        { move: "deca_beam", weight: 50, maxInARow: 1 },
+        { move: "deca_protect", weight: 50, maxInARow: 1 },
+      ],
+    },
+  },
+  {
+    id: "donu",
+    name: "铎努",
+    hpMin: 250,
+    hpMax: 250,
+    moves: [
+      {
+        id: "donu_beam",
+        name: "光束",
+        effects: [{ kind: "deal_damage_multi", amount: 10, times: 2 }],
+        intent: "attack",
+      },
+      {
+        id: "donu_power",
+        name: "赋能",
+        effects: [{ kind: "apply_power", power: "strength", amount: 3, on: "all_enemies" }],
+        intent: "buff",
+      },
+    ],
+    intentRule: {
+      scripted: [],
+      weighted: [
+        { move: "donu_beam", weight: 50, maxInARow: 1 },
+        { move: "donu_power", weight: 50, maxInARow: 1 },
+      ],
+    },
+  },
+
   // —— 精英：地精头目（Enrage = 玩家出技能牌它加力量）——
   {
     id: "gremlin_nob",
@@ -1366,6 +1559,13 @@ const ENCOUNTERS: Record<string, EncounterDef> = {
   champ: { id: "champ", enemies: ["champ"], isBoss: true },
   bronze_automaton: { id: "bronze_automaton", enemies: ["bronze_automaton"], isBoss: true },
   the_collector: { id: "the_collector", enemies: ["the_collector"], isBoss: true },
+  // 第三幕
+  exploder: { id: "exploder", enemies: ["exploder"], isBoss: false },
+  spiker: { id: "spiker", enemies: ["spiker"], isBoss: false },
+  orb_walker: { id: "orb_walker", enemies: ["orb_walker"], isBoss: false },
+  two_exploders: { id: "two_exploders", enemies: ["exploder", "exploder"], isBoss: false },
+  reptomancer: { id: "reptomancer", enemies: ["reptomancer"], isBoss: false },
+  donu_deca: { id: "donu_deca", enemies: ["deca", "donu"], isBoss: true },
   guardian: { id: "guardian", enemies: ["the_guardian"], isBoss: true },
   hexaghost: { id: "hexaghost", enemies: ["hexaghost"], isBoss: true },
   slime_boss: { id: "slime_boss", enemies: ["slime_boss"], isBoss: true },
@@ -1439,11 +1639,33 @@ const ACT2_STRONG_POOL: readonly WeightedEncounter[] = [
   { id: "spheric_guardian", weight: 1 },
 ];
 
+// —— 第三幕（超越）战斗池（切片）——
+const ACT3_WEAK_POOL: readonly WeightedEncounter[] = [
+  { id: "spiker", weight: 1 },
+  { id: "orb_walker", weight: 1 },
+  { id: "exploder", weight: 1 },
+];
+
+const ACT3_STRONG_POOL: readonly WeightedEncounter[] = [
+  { id: "orb_walker", weight: 2 },
+  { id: "spiker", weight: 2 },
+  { id: "two_exploders", weight: 1 },
+];
+
+function actWeakPool(act: number): readonly WeightedEncounter[] {
+  if (act >= 3) return ACT3_WEAK_POOL;
+  if (act >= 2) return ACT2_WEAK_POOL;
+  return WEAK_ENCOUNTER_POOL;
+}
+function actStrongPool(act: number): readonly WeightedEncounter[] {
+  if (act >= 3) return ACT3_STRONG_POOL;
+  if (act >= 2) return ACT2_STRONG_POOL;
+  return STRONG_ENCOUNTER_POOL;
+}
+
 /** 按已进入的普通战斗数选池 + 加权随机挑一个 encounter id（按幕选池）。 */
 export function pickNormalEncounter(rng: RngState, combatsEntered: number, act = 1): string {
-  const weak = act >= 2 ? ACT2_WEAK_POOL : WEAK_ENCOUNTER_POOL;
-  const strong = act >= 2 ? ACT2_STRONG_POOL : STRONG_ENCOUNTER_POOL;
-  const pool = combatsEntered < WEAK_COMBAT_COUNT ? weak : strong;
+  const pool = combatsEntered < WEAK_COMBAT_COUNT ? actWeakPool(act) : actStrongPool(act);
   const picked = weightedPick(rng, pool);
   if (picked === "small_slimes") {
     // 小史莱姆组的两种组成 50/50。
@@ -1470,8 +1692,12 @@ const ACT2_ELITE_POOL: readonly WeightedEncounter[] = [
   { id: "slavers", weight: 1 },
 ];
 
+// Act3 精英池（切片：蛇法师；后续补 巨型头颅 / 复仇者）。
+const ACT3_ELITE_POOL: readonly WeightedEncounter[] = [{ id: "reptomancer", weight: 1 }];
+
 /** 精英节点：从精英池挑一个 encounter id（按幕选池）。 */
 export function pickEliteEncounter(rng: RngState, act = 1): string {
+  if (act >= 3) return weightedPick(rng, ACT3_ELITE_POOL);
   return weightedPick(rng, act >= 2 ? ACT2_ELITE_POOL : ELITE_ENCOUNTER_POOL);
 }
 
@@ -1489,7 +1715,11 @@ const ACT2_BOSS_POOL: readonly WeightedEncounter[] = [
   { id: "the_collector", weight: 1 },
 ];
 
+// Act3 Boss 池（切片：铎努与迪卡；后续补 觉醒者 / 时间吞噬者）。
+const ACT3_BOSS_POOL: readonly WeightedEncounter[] = [{ id: "donu_deca", weight: 1 }];
+
 /** Boss 节点：随机挑一个 Boss encounter id（按幕选池）。 */
 export function pickBossEncounter(rng: RngState, act = 1): string {
+  if (act >= 3) return weightedPick(rng, ACT3_BOSS_POOL);
   return weightedPick(rng, act >= 2 ? ACT2_BOSS_POOL : BOSS_ENCOUNTER_POOL);
 }

--- a/apps/spire/src/engine/run/run.ts
+++ b/apps/spire/src/engine/run/run.ts
@@ -59,7 +59,7 @@ const NODE_TYPE_LABELS: Record<MapNodeType, string> = {
 };
 
 /** 有内容的幕数：打完第 TOTAL_ACTS 幕 Boss 即通关；之前的 Boss 则进入下一幕。 */
-export const TOTAL_ACTS = 2;
+export const TOTAL_ACTS = 3;
 
 export function buildMap(state: GameState): void {
   state.map = generateMap(state.rng, ENABLED_MAP_TYPES);

--- a/apps/spire/test/act2.test.ts
+++ b/apps/spire/test/act2.test.ts
@@ -14,8 +14,8 @@ import type { GameState } from "../src/engine/types.js";
 // B2：第二幕（城市）切片——act-aware 池 + 3 普通 + 穿刺之书 + 冠军。
 
 describe("多幕", () => {
-  it("TOTAL_ACTS = 2（第二幕已有内容）", () => {
-    expect(TOTAL_ACTS).toBe(2);
+  it("TOTAL_ACTS ≥ 2（第二幕已有内容）", () => {
+    expect(TOTAL_ACTS).toBeGreaterThanOrEqual(2);
   });
 });
 

--- a/apps/spire/test/act3.test.ts
+++ b/apps/spire/test/act3.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat, playCard, endTurn } from "../src/engine/combat/combat.js";
+import { getPower } from "../src/engine/powers/powers.js";
+import {
+  pickNormalEncounter,
+  pickEliteEncounter,
+  pickBossEncounter,
+} from "../src/engine/enemies/enemies.js";
+import { seedRng } from "../src/engine/rng.js";
+import { TOTAL_ACTS } from "../src/engine/run/run.js";
+import type { CardInstance, GameState } from "../src/engine/types.js";
+
+// B3：第三幕（超越）切片——3 普通 + 蛇法师 + 铎努与迪卡。
+
+function fight(encounter: string): GameState {
+  const s = newRun({ runId: encounter, seed: 1 });
+  startCombat(s, encounter);
+  s.hp = 9999;
+  s.maxHp = 9999;
+  return s;
+}
+
+function play(s: GameState, defId: string, target: number | null = 0): void {
+  const card: CardInstance = { uid: s.nextUid++, defId, upgraded: false };
+  s.combat!.hand = [card];
+  s.combat!.energy = 9;
+  expect(playCard(s, 0, target).ok).toBe(true);
+}
+
+describe("三幕", () => {
+  it("TOTAL_ACTS = 3", () => {
+    expect(TOTAL_ACTS).toBe(3);
+  });
+
+  it("act=3 池只出第三幕内容", () => {
+    const ACT3_NORMALS = new Set(["spiker", "orb_walker", "exploder", "two_exploders"]);
+    for (let seed = 0; seed < 40; seed += 1) {
+      const rng = seedRng(seed);
+      for (const entered of [0, 2, 5]) {
+        expect(ACT3_NORMALS.has(pickNormalEncounter(rng, entered, 3))).toBe(true);
+      }
+    }
+    expect(pickEliteEncounter(seedRng(1), 3)).toBe("reptomancer");
+    expect(pickBossEncounter(seedRng(1), 3)).toBe("donu_deca");
+  });
+});
+
+describe("爆破怪：亡语爆炸", () => {
+  it("被杀死时对玩家造成 30 伤害", () => {
+    const s = fight("two_exploders"); // 双爆破怪：杀一只战斗不结束，便于观察
+    s.hp = 100;
+    s.combat!.enemies[0]!.hp = 1;
+    play(s, "strike", 0); // 打死 0 号
+    expect(s.combat!.enemies[0]!.hp).toBe(0);
+    expect(s.hp).toBe(70); // 亡语爆炸 30
+  });
+});
+
+describe("尖刺客：反甲", () => {
+  it("开局自带 3 反甲，攻击它反弹 3", () => {
+    const s = fight("spiker");
+    expect(getPower(s.combat!.enemies[0]!.powers, "sharp_hide")).toBe(3);
+    s.hp = 100;
+    s.combat!.enemies[0]!.hp = 50;
+    play(s, "strike", 0); // 打它 → 反弹 3
+    expect(s.hp).toBe(97);
+  });
+});
+
+describe("蛇法师：召唤匕首", () => {
+  it("首招召唤两把匕首", () => {
+    const s = fight("reptomancer");
+    expect(s.combat!.enemies[0]!.currentMove).toBe("summon_daggers");
+    s.combat!.hand = [];
+    endTurn(s);
+    expect(s.combat!.enemies.filter(e => e.defId === "dagger")).toHaveLength(2);
+  });
+});
+
+describe("铎努与迪卡：双子 Boss", () => {
+  it("两只登场；铎努赋能给双方 +3 力量", () => {
+    const s = fight("donu_deca");
+    expect(s.combat!.enemies.map(e => e.defId)).toEqual(["deca", "donu"]);
+    const donu = s.combat!.enemies.find(e => e.defId === "donu")!;
+    donu.currentMove = "donu_power";
+    s.combat!.enemies.find(e => e.defId === "deca")!.currentMove = "deca_protect";
+    s.combat!.hand = [];
+    endTurn(s);
+    for (const e of s.combat!.enemies) {
+      expect(getPower(e.powers, "strength")).toBeGreaterThanOrEqual(3);
+    }
+  });
+});


### PR DESCRIPTION
`TOTAL_ACTS=3`，**铁甲三幕之旅端到端可玩**。**本批次不部署**。Refs #234。

## 框架
- 池按幕三分（`actWeakPool/actStrongPool` + `act>=3`）；ACT3 weak/strong/elite/boss 池。`TOTAL_ACTS=3`：第一幕→第二幕→第三幕 Boss 才通关，全程携带状态。

## 第三幕内容（切片，全用既有机制）
- 普通：爆破怪30(**亡语爆炸30**) · 尖刺客42-56(**开局反甲3**) · 球行者90-96(激光+灼烧/利爪16)
- 精英：蛇法师180-190(**召唤匕首**)
- Boss：**铎努与迪卡**(双子250×2, 光束10×2/守护/赋能全体+3力量)

## 验证
门禁全绿：build/typecheck/lint(0)/format + **spire 240/240**（新增 `act3.test.ts` 6 例）。sim 贪心 400 局 **stuck=0**（跨 3 幕必然终止）。纯 spire。

三幕结构通了：第一幕完整、第二幕完整、第三幕切片。