### PR TITLE
feat(spire): 角色框架（Phase C · C1）——多角色地基

### DIFF
--- a/apps/spire/src/engine/cards/cards.ts
+++ b/apps/spire/src/engine/cards/cards.ts
@@ -12,6 +12,7 @@ const CARD_LIST: CardDef[] = [
     name: "打击",
     type: "attack",
     rarity: "starter",
+    color: "red",
     cost: 1,
     targeted: true,
     exhausts: false,
@@ -25,6 +26,7 @@ const CARD_LIST: CardDef[] = [
     name: "防御",
     type: "skill",
     rarity: "starter",
+    color: "red",
     cost: 1,
     targeted: false,
     exhausts: false,
@@ -38,6 +40,7 @@ const CARD_LIST: CardDef[] = [
     name: "痛击",
     type: "attack",
     rarity: "starter",
+    color: "red",
     cost: 2,
     targeted: true,
     exhausts: false,
@@ -59,6 +62,7 @@ const CARD_LIST: CardDef[] = [
     name: "愤怒",
     type: "attack",
     rarity: "common",
+    color: "red",
     cost: 0,
     targeted: true,
     exhausts: false,
@@ -78,6 +82,7 @@ const CARD_LIST: CardDef[] = [
     name: "横扫",
     type: "attack",
     rarity: "common",
+    color: "red",
     cost: 1,
     targeted: false,
     exhausts: false,
@@ -91,6 +96,7 @@ const CARD_LIST: CardDef[] = [
     name: "铁臂勾拳",
     type: "attack",
     rarity: "common",
+    color: "red",
     cost: 2,
     targeted: true,
     exhausts: false,
@@ -110,6 +116,7 @@ const CARD_LIST: CardDef[] = [
     name: "铁浪",
     type: "attack",
     rarity: "common",
+    color: "red",
     cost: 1,
     targeted: true,
     exhausts: false,
@@ -129,6 +136,7 @@ const CARD_LIST: CardDef[] = [
     name: "剑柄打击",
     type: "attack",
     rarity: "common",
+    color: "red",
     cost: 1,
     targeted: true,
     exhausts: false,
@@ -148,6 +156,7 @@ const CARD_LIST: CardDef[] = [
     name: "双重打击",
     type: "attack",
     rarity: "common",
+    color: "red",
     cost: 1,
     targeted: true,
     exhausts: false,
@@ -161,6 +170,7 @@ const CARD_LIST: CardDef[] = [
     name: "泰然自若",
     type: "skill",
     rarity: "common",
+    color: "red",
     cost: 1,
     targeted: false,
     exhausts: false,
@@ -180,6 +190,7 @@ const CARD_LIST: CardDef[] = [
     name: "力压",
     type: "attack",
     rarity: "common",
+    color: "red",
     cost: 1,
     upgradedCost: 0,
     targeted: true,
@@ -194,6 +205,7 @@ const CARD_LIST: CardDef[] = [
     name: "疾雷",
     type: "attack",
     rarity: "common",
+    color: "red",
     cost: 1,
     targeted: false,
     exhausts: false,
@@ -215,6 +227,7 @@ const CARD_LIST: CardDef[] = [
     name: "重刃",
     type: "attack",
     rarity: "common",
+    color: "red",
     cost: 2,
     targeted: true,
     exhausts: false,
@@ -228,6 +241,7 @@ const CARD_LIST: CardDef[] = [
     name: "上勾拳",
     type: "attack",
     rarity: "uncommon",
+    color: "red",
     cost: 1,
     targeted: true,
     exhausts: false,
@@ -249,6 +263,7 @@ const CARD_LIST: CardDef[] = [
     name: "血魔法",
     type: "attack",
     rarity: "uncommon",
+    color: "red",
     cost: 1,
     targeted: true,
     exhausts: false,
@@ -268,6 +283,7 @@ const CARD_LIST: CardDef[] = [
     name: "乱拳",
     type: "attack",
     rarity: "uncommon",
+    color: "red",
     cost: 1,
     targeted: true,
     exhausts: true,
@@ -281,6 +297,7 @@ const CARD_LIST: CardDef[] = [
     name: "重锤",
     type: "attack",
     rarity: "rare",
+    color: "red",
     cost: 3,
     targeted: true,
     exhausts: false,
@@ -294,6 +311,7 @@ const CARD_LIST: CardDef[] = [
     name: "狂野劈砍",
     type: "attack",
     rarity: "common",
+    color: "red",
     cost: 1,
     targeted: true,
     exhausts: false,
@@ -313,6 +331,7 @@ const CARD_LIST: CardDef[] = [
     name: "剑刃回旋镖",
     type: "attack",
     rarity: "common",
+    color: "red",
     cost: 1,
     targeted: false,
     exhausts: false,
@@ -326,6 +345,7 @@ const CARD_LIST: CardDef[] = [
     name: "燃怒",
     type: "power",
     rarity: "uncommon",
+    color: "red",
     cost: 1,
     targeted: false,
     exhausts: false,
@@ -340,6 +360,7 @@ const CARD_LIST: CardDef[] = [
     name: "金属化",
     type: "power",
     rarity: "uncommon",
+    color: "red",
     cost: 1,
     targeted: false,
     exhausts: false,
@@ -353,6 +374,7 @@ const CARD_LIST: CardDef[] = [
     name: "恶魔形态",
     type: "power",
     rarity: "rare",
+    color: "red",
     cost: 3,
     targeted: false,
     exhausts: false,
@@ -366,6 +388,7 @@ const CARD_LIST: CardDef[] = [
     name: "鲁莽冲锋",
     type: "attack",
     rarity: "common",
+    color: "red",
     cost: 0,
     targeted: true,
     exhausts: false,
@@ -386,6 +409,7 @@ const CARD_LIST: CardDef[] = [
     name: "献焰",
     type: "attack",
     rarity: "rare",
+    color: "red",
     cost: 2,
     targeted: false,
     exhausts: false,
@@ -405,6 +429,7 @@ const CARD_LIST: CardDef[] = [
     name: "献祭",
     type: "skill",
     rarity: "rare",
+    color: "red",
     cost: 0,
     targeted: false,
     exhausts: true,
@@ -428,6 +453,7 @@ const CARD_LIST: CardDef[] = [
     name: "虚魂护甲",
     type: "skill",
     rarity: "uncommon",
+    color: "red",
     cost: 1,
     targeted: false,
     exhausts: false,
@@ -442,6 +468,7 @@ const CARD_LIST: CardDef[] = [
     name: "恫吓",
     type: "skill",
     rarity: "uncommon",
+    color: "red",
     cost: 0,
     targeted: false,
     exhausts: true,
@@ -455,6 +482,7 @@ const CARD_LIST: CardDef[] = [
     name: "震荡波",
     type: "skill",
     rarity: "uncommon",
+    color: "red",
     cost: 2,
     targeted: false,
     exhausts: true,
@@ -474,6 +502,7 @@ const CARD_LIST: CardDef[] = [
     name: "缴械",
     type: "skill",
     rarity: "uncommon",
+    color: "red",
     cost: 1,
     targeted: true,
     exhausts: true,
@@ -487,6 +516,7 @@ const CARD_LIST: CardDef[] = [
     name: "放血",
     type: "skill",
     rarity: "uncommon",
+    color: "red",
     cost: 0,
     targeted: false,
     exhausts: false,
@@ -506,6 +536,7 @@ const CARD_LIST: CardDef[] = [
     name: "见红",
     type: "skill",
     rarity: "uncommon",
+    color: "red",
     cost: 1,
     upgradedCost: 0,
     targeted: false,
@@ -520,6 +551,7 @@ const CARD_LIST: CardDef[] = [
     name: "强渡",
     type: "skill",
     rarity: "uncommon",
+    color: "red",
     cost: 1,
     targeted: false,
     exhausts: false,
@@ -539,6 +571,7 @@ const CARD_LIST: CardDef[] = [
     name: "坚守",
     type: "skill",
     rarity: "uncommon",
+    color: "red",
     cost: 2,
     upgradedCost: 1,
     targeted: false,
@@ -555,6 +588,7 @@ const CARD_LIST: CardDef[] = [
     name: "伤口",
     type: "status",
     rarity: "special",
+    color: "status",
     cost: null,
     targeted: false,
     exhausts: false,
@@ -568,6 +602,7 @@ const CARD_LIST: CardDef[] = [
     name: "灼烧",
     type: "status",
     rarity: "special",
+    color: "status",
     cost: null,
     targeted: false,
     exhausts: false,
@@ -581,6 +616,7 @@ const CARD_LIST: CardDef[] = [
     name: "眩晕",
     type: "status",
     rarity: "special",
+    color: "status",
     cost: null,
     targeted: false,
     exhausts: false,
@@ -595,6 +631,7 @@ const CARD_LIST: CardDef[] = [
     name: "泥泞",
     type: "status",
     rarity: "special",
+    color: "status",
     cost: null,
     targeted: false,
     exhausts: true,
@@ -632,32 +669,30 @@ export const IRONCLAD_STARTER_DECK: readonly string[] = [
   "bash",
 ];
 
-function idsByRarity(rarity: CardDef["rarity"]): readonly string[] {
-  return CARD_LIST.filter(card => card.rarity === rarity).map(card => card.id);
+/** 取某角色颜色 + 某稀有度的卡池（自动从 CARD_LIST 派生，加卡即入对应池）。 */
+export function cardPoolOf(
+  color: CardDef["color"],
+  rarity: "common" | "uncommon" | "rare",
+): readonly string[] {
+  return CARD_LIST.filter(card => card.color === color && card.rarity === rarity).map(
+    card => card.id,
+  );
 }
 
-/** 按稀有度分档的卡池（自动从 CARD_LIST 派生，加卡即入池）。 */
-export const COMMON_CARD_POOL: readonly string[] = idsByRarity("common");
-export const UNCOMMON_CARD_POOL: readonly string[] = idsByRarity("uncommon");
-export const RARE_CARD_POOL: readonly string[] = idsByRarity("rare");
-
-/** 全部可获得卡（普通+罕见+稀有；不含起始专属与废牌）：商店与「无视稀有度」场景用。 */
-export const REWARD_CARD_POOL: readonly string[] = [
-  ...COMMON_CARD_POOL,
-  ...UNCOMMON_CARD_POOL,
-  ...RARE_CARD_POOL,
-];
-
-/** 取某稀有度的卡池。 */
-export function cardPoolOfRarity(rarity: "common" | "uncommon" | "rare"): readonly string[] {
-  if (rarity === "rare") {
-    return RARE_CARD_POOL;
-  }
-  if (rarity === "uncommon") {
-    return UNCOMMON_CARD_POOL;
-  }
-  return COMMON_CARD_POOL;
+/** 某角色颜色全部可获得卡（普通+罕见+稀有）：商店 / 无视稀有度场景用。 */
+export function rewardCardPoolOf(color: CardDef["color"]): readonly string[] {
+  return [
+    ...cardPoolOf(color, "common"),
+    ...cardPoolOf(color, "uncommon"),
+    ...cardPoolOf(color, "rare"),
+  ];
 }
+
+// 铁甲战士（红）各档池 —— 兼容既有引用。
+export const COMMON_CARD_POOL: readonly string[] = cardPoolOf("red", "common");
+export const UNCOMMON_CARD_POOL: readonly string[] = cardPoolOf("red", "uncommon");
+export const RARE_CARD_POOL: readonly string[] = cardPoolOf("red", "rare");
+export const REWARD_CARD_POOL: readonly string[] = rewardCardPoolOf("red");
 
 /** 取一张牌当前生效的效果（升级则用升级效果）。 */
 export function effectsOf(def: CardDef, upgraded: boolean): CardDef["effects"] {

--- a/apps/spire/src/engine/characters/characters.ts
+++ b/apps/spire/src/engine/characters/characters.ts
@@ -1,0 +1,41 @@
+import type { CardColor, CharacterId } from "../types.js";
+import { IRONCLAD_STARTER_DECK } from "../cards/cards.js";
+import { IRONCLAD_STARTER_RELIC } from "../relics/relics.js";
+
+// === 角色配置 ===
+//
+// 每个角色的起始参数（血量 / 起始牌组 / 起始遗物 / 卡池颜色）集中在这张表。
+// newRun 据此初始化；奖励卡池按角色颜色过滤。新增角色 = 往这里加一行 + 填对应颜色的卡。
+
+export type CharacterConfig = {
+  id: CharacterId;
+  name: string;
+  maxHp: number;
+  starterRelic: string;
+  starterDeck: readonly string[];
+  /** 该角色的卡牌颜色（决定奖励 / 商店抽哪一池卡）。 */
+  color: CardColor;
+};
+
+const CHARACTERS: Partial<Record<CharacterId, CharacterConfig>> = {
+  ironclad: {
+    id: "ironclad",
+    name: "铁甲战士",
+    maxHp: 80,
+    starterRelic: IRONCLAD_STARTER_RELIC,
+    starterDeck: IRONCLAD_STARTER_DECK,
+    color: "red",
+  },
+};
+
+export function getCharacterConfig(id: CharacterId): CharacterConfig {
+  const config = CHARACTERS[id];
+  if (!config) {
+    throw new Error(`未实现的角色: ${id}`);
+  }
+  return config;
+}
+
+export const ALL_CHARACTERS: readonly CharacterConfig[] = Object.values(CHARACTERS).filter(
+  (c): c is CharacterConfig => c !== undefined,
+);

--- a/apps/spire/src/engine/engine.ts
+++ b/apps/spire/src/engine/engine.ts
@@ -1,6 +1,5 @@
 import type { CardInstance, CharacterId, GameState } from "./types.js";
-import { IRONCLAD_STARTER_DECK } from "./cards/cards.js";
-import { IRONCLAD_STARTER_RELIC } from "./relics/relics.js";
+import { getCharacterConfig } from "./characters/characters.js";
 import { seedRng } from "./rng.js";
 import { endTurn, playCard, usePotion } from "./combat/combat.js";
 import { TOTAL_ACTS, advanceToNextAct, applyChoose, buildMap, generateReward } from "./run/run.js";
@@ -10,8 +9,6 @@ import { NEOW_EVENT_ID } from "./events/events.js";
 // === 引擎顶层：新建对局 + 动作分发 ===
 //
 // 纯函数式副作用：applyAction 原地改传入的 GameState。HTTP 层负责 version 自增与存档。
-
-const IRONCLAD_MAX_HP = 80;
 
 export type GameAction =
   | { type: "play_card"; handIndex: number; targetIndex?: number | null }
@@ -28,9 +25,10 @@ export function newRun(input: {
   ascension?: number;
 }): GameState {
   const character: CharacterId = input.character ?? "ironclad";
+  const config = getCharacterConfig(character);
   const rng = seedRng(input.seed);
   let nextUid = 1;
-  const deck: CardInstance[] = IRONCLAD_STARTER_DECK.map(defId => ({
+  const deck: CardInstance[] = config.starterDeck.map(defId => ({
     uid: nextUid++,
     defId,
     upgraded: false,
@@ -43,11 +41,11 @@ export function newRun(input: {
     ascension: input.ascension ?? 0,
     act: 1,
     screen: "map",
-    hp: IRONCLAD_MAX_HP,
-    maxHp: IRONCLAD_MAX_HP,
+    hp: config.maxHp,
+    maxHp: config.maxHp,
     gold: 0,
     deck,
-    relics: [{ id: IRONCLAD_STARTER_RELIC, counter: 0 }],
+    relics: [{ id: config.starterRelic, counter: 0 }],
     potions: new Array<string | null>(POTION_SLOTS).fill(null),
     potionDropBonus: 0,
     map: { nodes: {}, rows: 0, startNodeIds: [], bossNodeId: "" },

--- a/apps/spire/src/engine/run/run.ts
+++ b/apps/spire/src/engine/run/run.ts
@@ -1,5 +1,6 @@
 import type { GameState, MapNode, MapNodeType } from "../types.js";
-import { cardPoolOfRarity, getCardDef, costOf } from "../cards/cards.js";
+import { cardPoolOf, getCardDef, costOf } from "../cards/cards.js";
+import { getCharacterConfig } from "../characters/characters.js";
 import { pickBossEncounter, pickEliteEncounter, pickNormalEncounter } from "../enemies/enemies.js";
 import { REWARD_RELIC_POOL, getRelicDef, hasRelic } from "../relics/relics.js";
 import {
@@ -198,13 +199,14 @@ export function generateReward(state: GameState): void {
   state.screen = "reward";
 }
 
-/** 掷一张奖励卡：先掷稀有度（稀有 4% / 罕见 36% / 普通 60%），再从该档池里挑未重复的。 */
+/** 掷一张奖励卡：先掷稀有度（稀有 4% / 罕见 36% / 普通 60%），再从本角色该档池里挑未重复的。 */
 function rollRewardCard(state: GameState, exclude: ReadonlySet<string>): string | null {
+  const color = getCharacterConfig(state.character).color;
   const roll = nextInt(state.rng, 100);
   const rarity = roll < 4 ? "rare" : roll < 40 ? "uncommon" : "common";
   // 依次尝试目标档 → 降级兜底，保证总能给出一张不重复的卡。
   for (const tier of [rarity, "uncommon", "common"] as const) {
-    const candidates = cardPoolOfRarity(tier).filter(id => !exclude.has(id));
+    const candidates = cardPoolOf(color, tier).filter(id => !exclude.has(id));
     if (candidates.length > 0) {
       return candidates[nextInt(state.rng, candidates.length)]!;
     }

--- a/apps/spire/src/engine/shop/shop.ts
+++ b/apps/spire/src/engine/shop/shop.ts
@@ -1,5 +1,6 @@
 import type { GameState, ShopItem, ShopState } from "../types.js";
-import { REWARD_CARD_POOL } from "../cards/cards.js";
+import { rewardCardPoolOf } from "../cards/cards.js";
+import { getCharacterConfig } from "../characters/characters.js";
 import { SHOP_RELIC_POOL, hasRelic } from "../relics/relics.js";
 import { POTION_DROP_POOL } from "../potions/potions.js";
 import { nextInt, nextRange } from "../rng.js";
@@ -35,7 +36,8 @@ function sampleUnique(rng: GameState["rng"], pool: readonly string[], count: num
 export function generateShop(state: GameState): void {
   const items: ShopItem[] = [];
 
-  for (const defId of sampleUnique(state.rng, REWARD_CARD_POOL, SHOP_CARD_COUNT)) {
+  const cardPool = rewardCardPoolOf(getCharacterConfig(state.character).color);
+  for (const defId of sampleUnique(state.rng, cardPool, SHOP_CARD_COUNT)) {
     items.push({
       kind: "card",
       defId,

--- a/apps/spire/src/engine/types.ts
+++ b/apps/spire/src/engine/types.ts
@@ -5,9 +5,12 @@
 //
 // 设计依据：本仓库根 AGENTS.md「KV 缓存优先」+ office-hours 设计文档 + issue #234。
 
-export type CharacterId = "ironclad";
+export type CharacterId = "ironclad" | "silent" | "defect" | "watcher";
 
 export type CardType = "attack" | "skill" | "power" | "status";
+
+/** 卡牌颜色：决定属于哪个角色的卡池；status = 敌人塞的废牌（不进任何奖励池）。 */
+export type CardColor = "red" | "green" | "blue" | "purple" | "colorless" | "status";
 
 /** 卡稀有度：奖励按稀有度加权抽取；starter/special 不进普通奖励池。 */
 export type CardRarity = "starter" | "common" | "uncommon" | "rare" | "special";
@@ -76,6 +79,8 @@ export type CardDef = {
   name: string;
   type: CardType;
   rarity: CardRarity;
+  /** 卡牌颜色（所属角色卡池）。 */
+  color: CardColor;
   cost: number | null;
   /** 升级后的费用（省略=不变）；用于力压/见红等升级降费卡。 */
   upgradedCost?: number;

--- a/apps/spire/test/character-framework.test.ts
+++ b/apps/spire/test/character-framework.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { getCharacterConfig, ALL_CHARACTERS } from "../src/engine/characters/characters.js";
+import { generateReward } from "../src/engine/run/run.js";
+import { cardPoolOf, rewardCardPoolOf, getCardDef } from "../src/engine/cards/cards.js";
+
+// C1：角色框架——角色配置驱动起始参数，卡池按颜色过滤。
+
+describe("角色配置", () => {
+  it("铁甲战士：80 血、红色、燃烧之血起始遗物、10 张起始牌", () => {
+    const c = getCharacterConfig("ironclad");
+    expect(c.maxHp).toBe(80);
+    expect(c.color).toBe("red");
+    expect(c.starterRelic).toBe("burning_blood");
+    expect(c.starterDeck).toHaveLength(10);
+  });
+
+  it("newRun 用角色配置初始化血量/牌组/遗物", () => {
+    const s = newRun({ runId: "c", seed: 1, character: "ironclad" });
+    expect(s.maxHp).toBe(80);
+    expect(s.hp).toBe(80);
+    expect(s.deck).toHaveLength(10);
+    expect(s.relics[0]!.id).toBe("burning_blood");
+    expect(s.character).toBe("ironclad");
+  });
+
+  it("未实现角色抛错（守卫栏杆，防止无效角色开局）", () => {
+    expect(() => newRun({ runId: "x", seed: 1, character: "silent" })).toThrow();
+  });
+});
+
+describe("卡池按颜色过滤", () => {
+  it("红色卡池非空，且里面每张都是红色", () => {
+    const red = rewardCardPoolOf("red");
+    expect(red.length).toBeGreaterThan(0);
+    for (const id of red) {
+      expect(getCardDef(id).color).toBe("red");
+    }
+  });
+
+  it("绿/蓝/紫色卡池当前为空（角色未实现）", () => {
+    expect(rewardCardPoolOf("green")).toHaveLength(0);
+    expect(rewardCardPoolOf("blue")).toHaveLength(0);
+    expect(rewardCardPoolOf("purple")).toHaveLength(0);
+  });
+
+  it("按颜色+稀有度取池：红色各档非空", () => {
+    expect(cardPoolOf("red", "common").length).toBeGreaterThan(0);
+    expect(cardPoolOf("red", "uncommon").length).toBeGreaterThan(0);
+    expect(cardPoolOf("red", "rare").length).toBeGreaterThan(0);
+  });
+
+  it("铁甲战士奖励只给红色卡（不含废牌）", () => {
+    for (let seed = 0; seed < 40; seed += 1) {
+      const s = newRun({ runId: `r${seed}`, seed });
+      generateReward(s);
+      for (const choice of s.reward!.cardChoices) {
+        expect(getCardDef(choice.defId).color).toBe("red");
+      }
+    }
+  });
+});
+
+describe("已实现角色清单", () => {
+  it("目前只有铁甲战士", () => {
+    expect(ALL_CHARACTERS.map(c => c.id)).toEqual(["ironclad"]);
+  });
+});


### PR DESCRIPTION
把写死的铁甲专属抽成**角色配置**，为静默/机器人/观者铺路（像稀有度系统那样的地基 PR）。**本批次不部署**。Refs #234。

## 改动
- `CharacterId` 扩到四角色；`CardColor`(red/green/blue/purple/colorless/status)；`CardDef` 加 `color`。**37 张现有卡标 color**（铁甲 red、废牌 status）。
- 卡池**按颜色+稀有度**派生：`cardPoolOf(color,rarity)` / `rewardCardPoolOf(color)`；奖励 `rollRewardCard` 与商店按本局角色颜色过滤。
- `engine/characters/characters.ts`：`CharacterConfig` 表（铁甲：80血/红/燃烧之血/起始牌组），`getCharacterConfig`；`newRun` 改由角色配置驱动血量/牌组/遗物（去掉 `IRONCLAD_MAX_HP` 等写死）。
- 未实现角色 `getCharacterConfig` 抛错（守卫栏杆）。

## 验证
**行为不变**（既有 240 测试全过）+ 门禁全绿：build/typecheck/lint(0)/format + **spire 248/248**（新增 `character-framework.test.ts` 8 例：角色配置驱动开局、卡池颜色过滤、绿/蓝/紫池为空、奖励只给本色卡、未实现角色抛错）· **agent 807**。sim stuck=0。纯 spire。

**新增角色 = 加一行 CharacterConfig + 填对应颜色的卡**（下一步 C2 静默）。