### PR TITLE
feat(http/oss): 服务端绑定 BinaryEnvelopeRouteContract 的 headers schema，收口 header 单一事实源

### DIFF
--- a/apps/oss/src/http/server.ts
+++ b/apps/oss/src/http/server.ts
@@ -76,11 +76,13 @@ export function buildOssApp(store: ObjectStore, maxBodyBytes: number): FastifyIn
 }
 
 function registerOssRoutes(app: FastifyInstance, store: ObjectStore, maxBodyBytes: number): void {
-  registerBinaryEnvelopeRoute(app, ossApiContract.putObject, async ({ body, request }) => {
+  registerBinaryEnvelopeRoute(app, ossApiContract.putObject, async ({ body, headers }) => {
     if (!body) {
       throw new Error("[oss] putObject 缺少上行字节流（bytesIn 路由不应至此）");
     }
-    const mime = parseMime(request.headers["content-type"]);
+    // content-type 由契约 headers schema 校验后交来（不再裸读 request.headers）；parseMime 再剥
+    // `; charset=...` 参数。空 content-type 已由 onRequest 钩子归一成 application/octet-stream。
+    const mime = parseMime(headers["content-type"]);
     // 请求体直接作为流交给 store，边流边算 sha256 落临时文件，不整块驻留内存。
     return await store.put(body, mime, { maxBytes: maxBodyBytes });
   });

--- a/packages/http/src/register.ts
+++ b/packages/http/src/register.ts
@@ -6,6 +6,7 @@ import type {
   BinaryEnvelopeRouteContract,
   BinaryHttpMethod,
   BinaryRawRouteContract,
+  BinaryRouteHeaders,
   JsonRouteContract,
   JsonRouteParams,
 } from "./contract.js";
@@ -68,8 +69,14 @@ export function registerJsonRoute<
   }
 }
 
-type BinaryEnvelopeExecute<TParams extends z.ZodTypeAny, TOutput extends z.ZodTypeAny> = (args: {
+type BinaryEnvelopeExecute<
+  TParams extends z.ZodTypeAny,
+  TOutput extends z.ZodTypeAny,
+  THeaders extends z.ZodTypeAny | undefined = z.ZodTypeAny | undefined,
+> = (args: {
   params: z.infer<TParams>;
+  /** 声明了 headers 通道时为校验后的入站请求头（`z.infer<contract.headers>`）；否则 undefined。 */
+  headers: BinaryRouteHeaders<THeaders>;
   /** bytesIn 时为未消费的原始上行字节流；否则 undefined。 */
   body: Readable | undefined;
   request: FastifyRequest;
@@ -86,18 +93,24 @@ type BinaryEnvelopeExecute<TParams extends z.ZodTypeAny, TOutput extends z.ZodTy
 export function registerBinaryEnvelopeRoute<
   TParams extends z.ZodTypeAny,
   TOutput extends z.ZodTypeAny,
+  THeaders extends z.ZodTypeAny | undefined = z.ZodTypeAny | undefined,
 >(
   app: FastifyInstance,
-  contract: BinaryEnvelopeRouteContract<TParams, TOutput>,
-  execute: BinaryEnvelopeExecute<TParams, TOutput>,
+  contract: BinaryEnvelopeRouteContract<TParams, TOutput, THeaders>,
+  execute: BinaryEnvelopeExecute<TParams, TOutput, THeaders>,
 ): void {
   const handler = async (request: FastifyRequest, reply: FastifyReply): Promise<unknown> => {
     const params = contract.params.parse(request.params) as z.infer<TParams>;
+    // 声明了 headers 通道时按 schema 校验入站请求头（z.object 默认 strip 未知键，只抽出声明的头）——
+    // 与客户端 createBinaryClient 共享同一份 schema，收口 header 单一事实源。未声明则 undefined。
+    const headers = (
+      contract.headers ? contract.headers.parse(request.headers) : undefined
+    ) as BinaryRouteHeaders<THeaders>;
     // 透传 parser 下 body 即原始流；无 content-type 时 Fastify 跳过 parser，退回 request.raw。
     const body = contract.bytesIn
       ? ((request.body as Readable | undefined) ?? request.raw)
       : undefined;
-    const result = await execute({ params, body, request, reply });
+    const result = await execute({ params, headers, body, request, reply });
     const parsed = contract.output.parse(result) as z.infer<TOutput>;
     return reply.code(contract.statusCode ?? 200).send(parsed);
   };

--- a/packages/http/test/register.test.ts
+++ b/packages/http/test/register.test.ts
@@ -1,0 +1,72 @@
+import type { AddressInfo } from "node:net";
+import Fastify, { type FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+import { defineBinaryEnvelopeRoute } from "../src/contract.js";
+import { registerBinaryEnvelopeRoute, useRawBodyPassthrough } from "../src/register.js";
+
+// registerBinaryEnvelopeRoute 的 headers 通道绑定（issue #324）：声明了 headers 契约时，服务端
+// 按同一份 schema 校验入站请求头并以 typed 参数交给 execute；未声明则为 undefined。
+
+const withHeaders = defineBinaryEnvelopeRoute({
+  method: "POST",
+  path: "/with-headers",
+  params: z.object({}),
+  bytesIn: false,
+  headers: z.object({ "x-thing": z.string().min(1) }),
+  output: z.object({ echoed: z.string() }),
+});
+
+const noHeaders = defineBinaryEnvelopeRoute({
+  method: "POST",
+  path: "/no-headers",
+  params: z.object({}),
+  bytesIn: false,
+  output: z.object({ headersWasUndefined: z.boolean() }),
+});
+
+let app: FastifyInstance;
+let baseUrl: string;
+
+beforeEach(async () => {
+  app = Fastify();
+  useRawBodyPassthrough(app);
+
+  registerBinaryEnvelopeRoute(app, withHeaders, async ({ headers }) => {
+    // headers 是校验后的 typed 值（未知头如 host/content-length 已被 z.object strip）。
+    return { echoed: headers["x-thing"] };
+  });
+  registerBinaryEnvelopeRoute(app, noHeaders, async ({ headers }) => {
+    return { headersWasUndefined: headers === undefined };
+  });
+
+  await app.listen({ port: 0, host: "127.0.0.1" });
+  const { port } = app.server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+afterEach(async () => {
+  await app.close();
+});
+
+describe("registerBinaryEnvelopeRoute — headers 通道", () => {
+  it("声明了 headers 契约：execute 收到校验后的 typed 请求头", async () => {
+    const res = await fetch(`${baseUrl}/with-headers`, {
+      method: "POST",
+      headers: { "x-thing": "hello" },
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ echoed: "hello" });
+  });
+
+  it("未声明 headers 契约：execute 收到的 headers 为 undefined", async () => {
+    const res = await fetch(`${baseUrl}/no-headers`, { method: "POST" });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ headersWasUndefined: true });
+  });
+
+  it("请求头不合 schema（缺 x-thing）→ 校验失败 500，不进 execute", async () => {
+    const res = await fetch(`${baseUrl}/with-headers`, { method: "POST" });
+    expect(res.status).toBe(500);
+  });
+});

--- a/packages/oss-api/src/contract.ts
+++ b/packages/oss-api/src/contract.ts
@@ -15,10 +15,9 @@ export const ossApiContract = {
     path: "/objects",
     params: z.object({}),
     bytesIn: true,
-    // content-type 随对象存取，是契约的一部分（不再是 client 里硬编码的裸 header）：client 按此
-    // schema 校验后写进请求头。注意服务端目前仍从 request 原样读 content-type、未绑定此 schema——
-    // 把 header 校验下沉到 registerBinaryEnvelopeRoute 是后续工作，当前只约束了 client 这一端
-    // （issue #310）。
+    // content-type 随对象存取，是契约的一部分（不再是 client 里硬编码的裸 header）：两端共享同一份
+    // schema——client 按它校验后写进请求头（createBinaryClient，#310），服务端也按它校验入站头再交
+    // 给 handler（registerBinaryEnvelopeRoute，#324）。收紧此 schema 两端一起强制。
     headers: z.object({ "content-type": z.string().min(1) }),
     output: z.object({ key: z.string().min(1) }),
     statusCode: 201,


### PR DESCRIPTION
Closes #324

#310/#312 给二进制契约加了 `headers` 通道并绑了**客户端**（`createBinaryClient` 按 schema 校验出站头），但服务端只 parse `params`、content-type 是 OSS handler 裸读 `request.headers` 抓的，从不碰 `contract.headers`——header schema 改了只有 client 认。本 PR 把服务端也绑上，让 `headers` 通道和 `params` 一样两端共享同一份 schema。设计已对齐 + 两路 finder review（0 correctness / 0 type-safety 缺陷；一条 doc-drift 注释同 PR 更新）。

## 改动
- **`packages/http/src/register.ts`**：`BinaryEnvelopeExecute` / `registerBinaryEnvelopeRoute` 加第三类型参 `THeaders`；handler 在声明了 headers 通道时按 `contract.headers` 校验 `request.headers`（z.object 默认 strip 未知键，只抽出声明的头），以 typed 参数交给 execute；未声明则 `undefined`。
- **`apps/oss/src/http/server.ts`**：putObject handler 从校验后的 `headers["content-type"]` 读 mime，不再裸读 `request.headers`。`onRequest` 归一化钩子（空 content-type→octet-stream，Fastify 绕行硬需求）与 `parseMime`（剥 `; charset` 参数）都留。
- **`packages/oss-api/src/contract.ts`**：更新 headers 注释（#310 时标注的「服务端未绑定」缺口本 PR 已关）。

## 价值定性（诚实）
机制补全，不是修今天的 bug：服务端不再裸访问 `request.headers`（与读 `params` 对称），将来收紧 header schema（限定 mime 枚举 / 加 content-encoding）两端自动一起强制。今天 schema 是 `z.string().min(1)` 且 `onRequest` 钩子保证 content-type 必到非空，故服务端校验恒过、**wire 行为不变**。

## 范围外
- 不动 `createBinaryClient`（客户端侧 #310 已绑）、不动 binary-raw（不声明 headers）。
- 不把 mime 归一化 / octet-stream 默认搬进 schema（钩子 + parseMime 各司其职）。
- content-type 不改 optional；metric 独立 SDK 另立。

## 测试
- 新增 `packages/http/test/register.test.ts`：headers 契约→execute 收校验后 typed 头 / 无 headers→undefined / 缺必填头→500。
- `apps/oss/test/server.test.ts` 的 `image/svg+xml`、空 content-type→octet-stream 两条 e2e 天然覆盖服务端绑定路径。
- `pnpm build / typecheck / lint / format` 全绿，`pnpm test` 全过（207 files）。