### PR TITLE
build(scripts): app:stop 加短名别名脚本，与 app:deploy 对称

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,9 @@ pnpm --filter @kagami/agent <script>   # 单包命令，如 test / test:watch / 
 
 pnpm app:deploy                        # 全量部署：build → prisma migrate deploy → PM2 reload(全部) → pm2 save
 pnpm app:deploy <agent|console|gateway|oss|browser|llm|metric|spire>  # 单服务：只重建重载该服务，不跑迁移、不动其它进程
+
+pnpm app:stop                          # 停掉 ecosystem 里全部进程
+pnpm app:stop <agent|console|gateway|oss|browser|llm|metric|spire>    # 只停该服务（与 app:deploy 共用同一套短名别名）
 ```
 
 - 仓库当前**没有**统一的根 `pnpm dev`。前后端联调需按实际分别启动，不要假设有一键 dev。

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "pnpm -r build",
     "app:deploy": "bash ./scripts/deploy.sh",
-    "app:stop": "pm2 stop ecosystem.config.cjs",
+    "app:stop": "bash ./scripts/stop.sh",
     "db:migrate:dev": "bash ./scripts/prisma.sh migrate dev",
     "db:migrate:deploy": "bash ./scripts/prisma.sh migrate deploy",
     "db:migrate:status": "bash ./scripts/prisma.sh migrate status",

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+SERVICE="${1:-}"
+
+# 无参：停掉 ecosystem 里的所有进程。
+if [ -z "$SERVICE" ]; then
+  pnpm exec pm2 stop ecosystem.config.cjs
+  exit 0
+fi
+
+# ── 单服务模式：pnpm app:stop <agent|console|gateway|oss|browser|llm|metric|spire> ──
+# 别名 → PM2 进程名。与 scripts/deploy.sh 的别名表保持一致，让 stop / deploy 用同一套短名。
+case "$SERVICE" in
+  agent) PM2_NAME="kagami-agent" ;;
+  console) PM2_NAME="kagami-console" ;;
+  # web 是已弃用别名，等价于 gateway（kagami-web → kagami-gateway 改名见 issue #162）。
+  gateway | web) PM2_NAME="kagami-gateway" ;;
+  oss) PM2_NAME="kagami-oss" ;;
+  browser) PM2_NAME="kagami-browser" ;;
+  llm) PM2_NAME="kagami-llm" ;;
+  metric) PM2_NAME="kagami-metric" ;;
+  spire) PM2_NAME="kagami-spire" ;;
+  *)
+    echo "用法: pnpm app:stop [<agent|console|gateway|oss|browser|llm|metric|spire>]" >&2
+    echo "  无参：停掉所有进程。" >&2
+    echo "  带服务名：只停该服务。" >&2
+    exit 1
+    ;;
+esac
+
+pnpm exec pm2 stop "${PM2_NAME}"


### PR DESCRIPTION
## 背景

`pnpm app:stop` 原先直接映射到 `pm2 stop ecosystem.config.cjs`,中间没有任何别名翻译层。而 `pnpm app:deploy <服务>` 走 `scripts/deploy.sh`,内部有一张 `case` 别名表把短名翻译成 PM2 进程名(`agent → kagami-agent` 等)。这导致两条命令不对称:`app:deploy agent` 能用短名,`app:stop` 却必须写全 `kagami-agent`(因为 PM2 的 `stop <name>` 与 `ecosystem.config.cjs` 里的 `name` 字段精确匹配,省掉 `kagami-` 前缀谁都匹配不上)。

## 改动

- 新增 [`scripts/stop.sh`](scripts/stop.sh):复用与 `deploy.sh` 一致的短名别名表(含 `web → gateway` 弃用别名)。无参停掉 ecosystem 全部进程;带短名只停单个服务;非法名字打印用法并退出。
- [`package.json`](package.json) 的 `app:stop` 从 `pm2 stop ecosystem.config.cjs` 改为 `bash ./scripts/stop.sh`。无参行为与以前一致。
- `AGENTS.md`「常用命令」补上对称的 `app:stop` 两行。

## 用法

```bash
pnpm app:stop          # 停所有进程（行为不变）
pnpm app:stop agent    # 只停 kagami-agent（新增短名支持）
pnpm app:stop gateway  # 只停 kagami-gateway
```

## 验证

- `pnpm build` / `pnpm typecheck` / `pnpm lint`(0 errors)/ `pnpm format` 全绿。
- `pnpm test`:209 文件 / 1376 测试全通过。
- 手动验证:`pnpm app:stop gateway` 正确解析为 `kagami-gateway` 并只停它一个,其余进程不受影响;之后已恢复 online(health `{"ok":true}`)。
- `bash -n scripts/stop.sh` 语法检查通过。