### PR TITLE
feat(spire): 药水补全——通用 + 角色专属药水 + gain_max_hp 原语

### DIFF
--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -438,6 +438,14 @@ function applyEffect(
       }
       break;
     }
+    case "gain_max_hp": {
+      // 玩家永久 +最大生命并回复等量（果汁药水）。
+      if (actor.side === "player") {
+        state.maxHp += effect.amount;
+        state.hp += effect.amount;
+      }
+      break;
+    }
     case "double_strength": {
       // 玩家当前力量翻倍（极限爆发）；负力量同样翻倍。
       if (actor.side === "player") {

--- a/apps/spire/src/engine/potions/potions.ts
+++ b/apps/spire/src/engine/potions/potions.ts
@@ -1,4 +1,4 @@
-import type { Effect } from "../types.js";
+import type { CharacterId, Effect } from "../types.js";
 
 // === 药水数据表 ===
 //
@@ -16,6 +16,8 @@ export type PotionDef = {
   targeted: boolean;
   /** 只能在战斗中使用（多数如此；回血类可放宽，此切片统一战斗内用）。 */
   combatOnly: boolean;
+  /** 角色专属：仅该角色的掉落 / 商店池里出现（省略=通用，任何角色可得）。 */
+  characterLock?: CharacterId;
   effects: Effect[];
 };
 
@@ -155,6 +157,67 @@ const POTION_LIST: PotionDef[] = [
     combatOnly: true,
     effects: [{ kind: "apply_power", power: "ritual", amount: 1, on: "self" }],
   },
+
+  // —— 补全批次：通用药水 ——
+  {
+    id: "poison_potion",
+    name: "剧毒药水",
+    description: "对一个敌人施加 6 层中毒。",
+    rarity: "common",
+    targeted: true,
+    combatOnly: true,
+    effects: [{ kind: "apply_power", power: "poison", amount: 6, on: "target" }],
+  },
+  {
+    id: "heart_of_iron_potion",
+    name: "铁心药水",
+    description: "获得 6 层金属化（每回合结束获得 6 点格挡）。",
+    rarity: "rare",
+    targeted: false,
+    combatOnly: true,
+    effects: [{ kind: "apply_power", power: "metallicize", amount: 6, on: "self" }],
+  },
+  {
+    id: "fruit_juice",
+    name: "果汁",
+    description: "永久提升 5 点最大生命，并回复 5 点生命。",
+    rarity: "rare",
+    targeted: false,
+    combatOnly: true,
+    effects: [{ kind: "gain_max_hp", amount: 5 }],
+  },
+
+  // —— 补全批次：角色专属药水 ——
+  {
+    id: "cunning_potion",
+    name: "狡诈药水",
+    description: "将 3 张飞刀加入手牌。",
+    rarity: "uncommon",
+    targeted: false,
+    combatOnly: true,
+    characterLock: "silent",
+    effects: [{ kind: "add_card", cardId: "shiv", pile: "hand", count: 3 }],
+  },
+  {
+    id: "focus_potion",
+    name: "集中药水",
+    description: "获得 2 点集中（充能球效果 +2）。",
+    rarity: "common",
+    targeted: false,
+    combatOnly: true,
+    characterLock: "defect",
+    effects: [{ kind: "apply_power", power: "focus", amount: 2, on: "self" }],
+  },
+  {
+    id: "bottled_miracle",
+    name: "瓶装奇迹",
+    description: "将 2 张奇迹加入手牌。",
+    rarity: "uncommon",
+    targeted: false,
+    combatOnly: true,
+    characterLock: "watcher",
+    effects: [{ kind: "add_card", cardId: "miracle", pile: "hand", count: 2 }],
+  },
 ];
 
 const POTION_MAP: ReadonlyMap<string, PotionDef> = new Map(
@@ -171,26 +234,48 @@ export function getPotionDef(id: string): PotionDef {
   return def;
 }
 
+// 通用药水（无 characterLock）按稀有度取 id；角色专属药水由 character 参数单独并入。
 function potionIdsOfRarity(rarity: PotionRarity): readonly string[] {
-  return POTION_LIST.filter(potion => potion.rarity === rarity).map(potion => potion.id);
+  return POTION_LIST.filter(
+    potion => potion.rarity === rarity && potion.characterLock === undefined,
+  ).map(potion => potion.id);
+}
+
+function potionIdsForCharacter(character: CharacterId, rarity: PotionRarity): readonly string[] {
+  return POTION_LIST.filter(
+    potion => potion.rarity === rarity && potion.characterLock === character,
+  ).map(potion => potion.id);
 }
 
 export const COMMON_POTION_POOL: readonly string[] = potionIdsOfRarity("common");
 export const UNCOMMON_POTION_POOL: readonly string[] = potionIdsOfRarity("uncommon");
 export const RARE_POTION_POOL: readonly string[] = potionIdsOfRarity("rare");
 
-/** 全部药水 id（商店 / 无视稀有度场景用）。 */
-export const POTION_DROP_POOL: readonly string[] = POTION_LIST.map(potion => potion.id);
+/** 全部通用药水 id（不含角色专属）。 */
+export const POTION_DROP_POOL: readonly string[] = POTION_LIST.filter(
+  potion => potion.characterLock === undefined,
+).map(potion => potion.id);
 
-/** 取某稀有度的药水池。 */
-export function potionPoolOfRarity(rarity: PotionRarity): readonly string[] {
-  if (rarity === "rare") {
-    return RARE_POTION_POOL;
+/** 取某稀有度的药水池；给了角色则并入该角色专属药水。 */
+export function potionPoolOfRarity(
+  rarity: PotionRarity,
+  character?: CharacterId,
+): readonly string[] {
+  const base = potionIdsOfRarity(rarity);
+  if (character === undefined) {
+    return base;
   }
-  if (rarity === "uncommon") {
-    return UNCOMMON_POTION_POOL;
-  }
-  return COMMON_POTION_POOL;
+  return [...base, ...potionIdsForCharacter(character, rarity)];
+}
+
+/** 某角色实际可得的商店药水池 = 通用 + 该角色专属（全稀有度）。 */
+export function shopPotionPool(character: CharacterId): readonly string[] {
+  return [
+    ...POTION_DROP_POOL,
+    ...potionIdsForCharacter(character, "common"),
+    ...potionIdsForCharacter(character, "uncommon"),
+    ...potionIdsForCharacter(character, "rare"),
+  ];
 }
 
 export const POTION_SLOTS = 3;

--- a/apps/spire/src/engine/run/run.ts
+++ b/apps/spire/src/engine/run/run.ts
@@ -161,7 +161,7 @@ function rollPotionDrop(state: GameState): void {
     // 掷稀有度（稀有 5% / 罕见 30% / 普通 65%），再从该档抽一瓶。
     const roll = nextInt(state.rng, 100);
     const rarity = roll < 5 ? "rare" : roll < 35 ? "uncommon" : "common";
-    const pool = potionPoolOfRarity(rarity);
+    const pool = potionPoolOfRarity(rarity, state.character);
     const id = pool[nextInt(state.rng, pool.length)]!;
     state.potions[emptySlot] = id;
     state.potionDropBonus -= 10;

--- a/apps/spire/src/engine/shop/shop.ts
+++ b/apps/spire/src/engine/shop/shop.ts
@@ -2,7 +2,7 @@ import type { GameState, ShopItem, ShopState } from "../types.js";
 import { rewardCardPoolOf } from "../cards/cards.js";
 import { getCharacterConfig } from "../characters/characters.js";
 import { SHOP_RELIC_POOL, hasRelic } from "../relics/relics.js";
-import { POTION_DROP_POOL } from "../potions/potions.js";
+import { shopPotionPool } from "../potions/potions.js";
 import { nextInt, nextRange } from "../rng.js";
 
 // === 商店库存生成 ===
@@ -69,7 +69,7 @@ export function generateShop(state: GameState): void {
     });
   }
 
-  for (const id of sampleUnique(state.rng, POTION_DROP_POOL, SHOP_POTION_COUNT)) {
+  for (const id of sampleUnique(state.rng, shopPotionPool(state.character), SHOP_POTION_COUNT)) {
     items.push({
       kind: "potion",
       id,

--- a/apps/spire/src/engine/types.ts
+++ b/apps/spire/src/engine/types.ts
@@ -73,6 +73,8 @@ export type Effect =
   | { kind: "heal"; amount: number }
   // 玩家用：当前力量翻倍（极限爆发）。
   | { kind: "double_strength" }
+  // 玩家永久提升最大生命并回复等量（果汁药水）。
+  | { kind: "gain_max_hp"; amount: number }
   // 敌人用：偷取玩家金币（拾荒者，最多偷 amount，玩家金币不足则偷光）。
   | { kind: "steal_gold"; amount: number }
   // 敌人用：本敌人逃离战斗（拾荒者烟雾弹后逃跑）。

--- a/apps/spire/test/potions-full.test.ts
+++ b/apps/spire/test/potions-full.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat, usePotion } from "../src/engine/combat/combat.js";
+import { getPower } from "../src/engine/powers/powers.js";
+import { potionPoolOfRarity, shopPotionPool } from "../src/engine/potions/potions.js";
+import type { GameState } from "../src/engine/types.js";
+
+// 药水补全：新原语 gain_max_hp、新药水效果、角色专属药水锁池。
+
+function combat(character: GameState["character"] = "ironclad", encounter = "cultist"): GameState {
+  const s = newRun({ runId: "potion", seed: 6, character });
+  startCombat(s, encounter);
+  s.hp = 100;
+  s.maxHp = 100;
+  return s;
+}
+
+function drink(s: GameState, potionId: string, target: number | null = null): void {
+  s.potions[0] = potionId;
+  const r = usePotion(s, 0, target);
+  expect(r.ok).toBe(true);
+}
+
+describe("新原语：永久提升最大生命", () => {
+  it("果汁 +5 最大生命并回复 5", () => {
+    const s = combat();
+    s.hp = 50;
+    drink(s, "fruit_juice");
+    expect(s.maxHp).toBe(105);
+    expect(s.hp).toBe(55);
+  });
+});
+
+describe("通用新药水", () => {
+  it("剧毒药水给目标 6 层中毒", () => {
+    const s = combat();
+    drink(s, "poison_potion", 0);
+    expect(getPower(s.combat!.enemies[0]!.powers, "poison")).toBe(6);
+  });
+
+  it("铁心药水给 6 层金属化", () => {
+    const s = combat();
+    drink(s, "heart_of_iron_potion");
+    expect(getPower(s.combat!.playerPowers, "metallicize")).toBe(6);
+  });
+});
+
+describe("角色专属药水效果", () => {
+  it("狡诈药水给静默 3 张飞刀", () => {
+    const s = combat("silent");
+    const before = s.combat!.hand.filter(c => c.defId === "shiv").length;
+    drink(s, "cunning_potion");
+    const after = s.combat!.hand.filter(c => c.defId === "shiv").length;
+    expect(after).toBe(before + 3);
+  });
+
+  it("集中药水给机器人 2 点集中", () => {
+    const s = combat("defect");
+    drink(s, "focus_potion");
+    expect(getPower(s.combat!.playerPowers, "focus")).toBe(2);
+  });
+
+  it("瓶装奇迹给观者 2 张奇迹", () => {
+    const s = combat("watcher");
+    const before = s.combat!.hand.filter(c => c.defId === "miracle").length;
+    drink(s, "bottled_miracle");
+    const after = s.combat!.hand.filter(c => c.defId === "miracle").length;
+    expect(after).toBe(before + 2);
+  });
+});
+
+describe("角色专属药水只进对应角色的池", () => {
+  it("集中药水只在机器人的普通药水池", () => {
+    expect(potionPoolOfRarity("common", "defect")).toContain("focus_potion");
+    expect(potionPoolOfRarity("common", "ironclad")).not.toContain("focus_potion");
+    expect(potionPoolOfRarity("common")).not.toContain("focus_potion"); // 无角色=纯通用
+  });
+
+  it("狡诈药水只在静默商店池；观者不含", () => {
+    expect(shopPotionPool("silent")).toContain("cunning_potion");
+    expect(shopPotionPool("watcher")).not.toContain("cunning_potion");
+  });
+
+  it("通用药水对所有角色可得", () => {
+    for (const c of ["ironclad", "silent", "defect", "watcher"] as const) {
+      expect(shopPotionPool(c)).toContain("poison_potion");
+      expect(potionPoolOfRarity("rare", c)).toContain("fruit_juice");
+    }
+  });
+});


### PR DESCRIPTION
## 背景

三 PR 补全计划第三步（收尾）：把药水池补到当前引擎机制可支持的全量。所有药水名/描述为原创中文，仅复刻功能性机制/数值。

## 引擎扩展

- 新增 `gain_max_hp` 战斗 Effect：玩家永久 +最大生命并回复等量（果汁）
- `PotionDef.characterLock`：角色专属药水只进对应角色的掉落/商店池
- `potionPoolOfRarity(rarity, character?)` + `shopPotionPool(character)`；`run` 掉落 / `shop` 库存改用之（与遗物的角色感知池同构）

## 新增药水

- **通用**：剧毒药水（6 毒）、铁心药水（6 金属化）、果汁（+5 最大生命）
- **静默**：狡诈药水（3 飞刀入手）
- **机器人**：集中药水（2 集中）
- **观者**：瓶装奇迹（2 奇迹入手）

## 验证
- 四门禁全过：build / typecheck / lint（0 错）/ format
- spire **309 测试全绿**（新增 `potions-full.test.ts` 覆盖 gain_max_hp / 各新药水 / 角色锁池）
- 四角色 sim 各 50 局 **stuck=0**
- 已 merge 最新 master（含遗物补全 #339，解决 shop.ts import 冲突：`shopRelicPool` + `shopPotionPool` 并存）后重新全量验证

## 三 PR 补全计划完成
本 PR 为 #337（卡池）/#339（遗物）/本 PR（药水）三连的收尾。

🤖 Generated with [Claude Code](https://claude.com/claude-code)