### PR TITLE
fix(spire): 存档读回迁移，修老对局「orbs/stance required」崩溃

### DIFF
--- a/apps/spire/src/persistence/migrate.ts
+++ b/apps/spire/src/persistence/migrate.ts
@@ -1,0 +1,65 @@
+import type { GameState } from "../engine/types.js";
+
+// === 存档迁移 ===
+//
+// 引擎的 GameState 形状会随里程碑增长（C3 加充能球 orbs/orbSlots、C4 加姿态 playerStance、
+// 三幕加 act/enemy.hasRevived、药水加 potions…）。老版本二进制存下的 save.json 会缺这些后加字段；
+// 新二进制读回后若直接序列化，registerJsonRoute 的 output.parse 会因缺字段 500（表现为
+// 「orbs / stance required」），把小镜的对局卡死。
+//
+// 迁移策略：读盘后回填**缺失**字段的默认值（只在 undefined 时填，不覆盖已有值），让老存档能继续，
+// 而不是整局作废。加新字段时，若老存档缺了会崩，就在这里补一行默认值。
+
+function backfill(obj: Record<string, unknown>, key: string, value: unknown): void {
+  if (obj[key] === undefined) {
+    obj[key] = value;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : null;
+}
+
+/** 回填老存档缺失的后加字段，就地改并返回同一对象（类型收敛回 GameState）。 */
+export function migrateLoadedState(raw: unknown): GameState {
+  const state = asRecord(raw);
+  if (!state) {
+    // 不是对象（极端坏档）——交回上层，load 会当作无档处理。
+    return raw as GameState;
+  }
+  // 顶层后加字段。
+  backfill(state, "character", "ironclad");
+  backfill(state, "ascension", 0);
+  backfill(state, "act", 1);
+  backfill(state, "potions", [null, null, null]);
+  backfill(state, "potionDropBonus", 0);
+  backfill(state, "combatsEntered", 0);
+  backfill(state, "pendingRelicReward", false);
+
+  const combat = asRecord(state["combat"]);
+  if (combat) {
+    // 充能球（C3）/ 姿态（C4）：老战斗存档没有，回填空/无。
+    backfill(combat, "orbs", []);
+    backfill(combat, "orbSlots", state["character"] === "defect" ? 3 : 0);
+    backfill(combat, "playerStance", "none");
+    const enemies = Array.isArray(combat["enemies"]) ? combat["enemies"] : [];
+    for (const entry of enemies) {
+      const enemy = asRecord(entry);
+      if (enemy) {
+        backfill(enemy, "hasRevived", false); // 复活（三幕觉醒者）
+        backfill(enemy, "hasSplit", false);
+        backfill(enemy, "escaped", false);
+        backfill(enemy, "curlUpConsumed", false);
+        backfill(enemy, "asleep", false);
+        backfill(enemy, "rolledDamage", 0);
+        backfill(enemy, "moveHistory", []);
+        backfill(enemy, "rotationIndex", 0);
+        backfill(enemy, "modeShiftAccum", 0);
+        backfill(enemy, "modeShiftThreshold", null);
+        backfill(enemy, "stance", null);
+        backfill(enemy, "powers", []);
+      }
+    }
+  }
+  return state as unknown as GameState;
+}

--- a/apps/spire/src/persistence/save-store.ts
+++ b/apps/spire/src/persistence/save-store.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import type { GameState } from "../engine/types.js";
+import { migrateLoadedState } from "./migrate.js";
 
 // === 存档持久化 ===
 //
@@ -27,7 +28,9 @@ export class SaveStore {
       return null; // 无存档。
     }
     try {
-      return JSON.parse(raw) as GameState;
+      // 回填老版本存档缺失的后加字段（orbs/orbSlots/playerStance/act/potions…），
+      // 否则老对局会在序列化时因缺字段 500（「orbs / stance required」）卡死。
+      return migrateLoadedState(JSON.parse(raw));
     } catch {
       // 损坏：改名备份，返回 null 让上层开新局，绝不因坏档卡死服务。
       const backup = join(this.dir, `save.corrupt-${Date.now()}.json`);

--- a/apps/spire/test/save-migrate.test.ts
+++ b/apps/spire/test/save-migrate.test.ts
@@ -1,0 +1,78 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { SpireScreenSchema } from "@kagami/spire-api/contract";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat } from "../src/engine/combat/combat.js";
+import { toScreenView } from "../src/application/state-view.js";
+import { SaveStore } from "../src/persistence/save-store.js";
+import { migrateLoadedState } from "../src/persistence/migrate.js";
+
+// 回归（小镜「开新局报错 orbs/stance required」）：老版本存档缺 C3/C4 后加字段
+// （orbs/orbSlots/playerStance），新二进制读回后序列化会被 registerJsonRoute 的
+// output.parse 拒（缺字段 500）。迁移在读盘时回填默认值，让老对局能继续。
+
+/** 造一个「老版本存档」：战斗态但删掉 C3/C4 后加字段（模拟旧二进制存的档）。 */
+function makeLegacySaveJson(): string {
+  const state = newRun({ runId: "legacy", seed: 1, character: "watcher" });
+  state.version = 1;
+  startCombat(state, "cultist");
+  const loose = state as unknown as Record<string, unknown>;
+  const combat = loose["combat"] as Record<string, unknown>;
+  // 旧档没有这些字段。
+  delete combat["orbs"];
+  delete combat["orbSlots"];
+  delete combat["playerStance"];
+  for (const enemy of combat["enemies"] as Record<string, unknown>[]) {
+    delete enemy["hasRevived"];
+  }
+  return JSON.stringify(state);
+}
+
+describe("存档迁移：老档缺后加字段", () => {
+  it("未迁移的老档序列化会被契约 schema 拒（复现 bug）", () => {
+    const legacy = JSON.parse(makeLegacySaveJson()) as ReturnType<typeof newRun>;
+    // 直接喂 toScreenView：缺 orbs/stance → SpireScreenSchema.parse 抛（服务端 500 的根因）。
+    expect(() => SpireScreenSchema.parse(toScreenView(legacy, {}))).toThrow();
+  });
+
+  it("migrateLoadedState 回填后序列化通过契约 schema", () => {
+    const migrated = migrateLoadedState(JSON.parse(makeLegacySaveJson()));
+    expect(migrated.combat!.orbs).toEqual([]);
+    expect(migrated.combat!.playerStance).toBe("none");
+    // watcher 非机器人 → 0 个球槽。
+    expect(migrated.combat!.orbSlots).toBe(0);
+    expect(() => SpireScreenSchema.parse(toScreenView(migrated, {}))).not.toThrow();
+  });
+
+  it("SaveStore.load 读老档时自动迁移", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "spire-migrate-"));
+    await writeFile(path.join(dir, "save.json"), makeLegacySaveJson(), "utf8");
+    const loaded = await new SaveStore({ dir }).load();
+    expect(loaded).not.toBeNull();
+    expect(() => SpireScreenSchema.parse(toScreenView(loaded!, {}))).not.toThrow();
+  });
+
+  it("机器人老档回填 3 个球槽", () => {
+    const state = newRun({ runId: "legacy-defect", seed: 1, character: "defect" });
+    state.version = 1;
+    startCombat(state, "cultist");
+    const loose = state as unknown as Record<string, unknown>;
+    const combat = loose["combat"] as Record<string, unknown>;
+    delete combat["orbs"];
+    delete combat["orbSlots"];
+    delete combat["playerStance"];
+    const migrated = migrateLoadedState(JSON.parse(JSON.stringify(state)));
+    expect(migrated.combat!.orbSlots).toBe(3);
+  });
+
+  it("不覆盖已有字段（新档 orbs 有内容时不清空）", () => {
+    const state = newRun({ runId: "fresh-defect", seed: 1, character: "defect" });
+    state.version = 1;
+    startCombat(state, "cultist");
+    state.combat!.orbs = [{ type: "lightning" }];
+    const migrated = migrateLoadedState(JSON.parse(JSON.stringify(state)));
+    expect(migrated.combat!.orbs).toEqual([{ type: "lightning" }]);
+  });
+});


### PR DESCRIPTION
## 背景

小镜反馈：打开尖塔对局报错「orbs 和 stance 什么的 required」。

## 根因

C3 给 `CombatState` 加了 `orbs`/`orbSlots`、C4 加了 `playerStance`（三幕又给 enemy 加了 `hasRevived` 等）。但 `SaveStore.load` 只做裸 `JSON.parse`、不迁移。**旧二进制存下的 `save.json` 缺这些后加字段**，新二进制读回后 `toScreenView` 序列化时，`registerJsonRoute` 的 `output.parse`（每个响应都跑契约校验）因缺字段 500——表现为 `orbs / stance required`——把在飞的对局卡死。

`state-view-contract.test.ts` 已经钉死「引擎可达状态 ⊆ 契约 schema」，但没覆盖「老存档反序列化」这条路径。

## 修复

新增 `persistence/migrate.ts`：`load` 时回填缺失的后加字段默认值（`orbs=[]`、`orbSlots` 按角色、`playerStance="none"`、各 enemy 的 `hasRevived` 等），**只在 `undefined` 时填、不覆盖已有值**——让老对局能继续，而不是整局作废。加新字段时若老档缺了会崩，就在这里补一行默认值。

## 验证

- 四门禁全过：build / typecheck / lint（0 错）/ format
- spire **314 测试全绿**（新增 `save-migrate.test.ts` 5 例）：
  - 复现——未迁移老档序列化被契约 schema 拒（bug）
  - 迁移后序列化通过契约 schema
  - `SaveStore.load` 读老档自动迁移
  - 机器人老档回填 3 球槽
  - 不覆盖已有字段（新档 orbs 有内容时不清空）

## 部署
本 PR 属线上故障修复，合并后需 `pnpm app:deploy spire`（无 DB 迁移）让小镜能继续玩。

🤖 Generated with [Claude Code](https://claude.com/claude-code)