### PR TITLE
feat(spire): reference 端点扩到可查遗物与药水

### DIFF
--- a/apps/agent/src/agent/capabilities/spire/render/spire-screen.ts
+++ b/apps/agent/src/agent/capabilities/spire/render/spire-screen.ts
@@ -155,13 +155,28 @@ const CARD_TYPE_LABELS: Record<string, string> = {
   status: "状态牌",
 };
 
+const SPIRE_RARITY_LABELS: Record<string, string> = {
+  starter: "起始",
+  common: "普通",
+  uncommon: "罕见",
+  rare: "稀有",
+  boss: "首领",
+  special: "特殊",
+};
+
 /** lookup 结果 → 文字（卡牌信息 + 术语定义）。框架文案在 .hbs，游戏数据插值。 */
 export function renderSpireReference(ref: SpireReference): string {
   return renderServerStaticTemplate(import.meta.url, "context/spire-reference.hbs", {
     query: ref.query,
     hasQuery: ref.query.trim().length > 0,
-    hasResults: ref.cards.length > 0 || ref.terms.length > 0,
+    hasResults:
+      ref.cards.length > 0 ||
+      ref.relics.length > 0 ||
+      ref.potions.length > 0 ||
+      ref.terms.length > 0,
     hasCards: ref.cards.length > 0,
+    hasRelics: ref.relics.length > 0,
+    hasPotions: ref.potions.length > 0,
     hasTerms: ref.terms.length > 0,
     cards: ref.cards.map(card => ({
       name: card.name,
@@ -173,6 +188,17 @@ export function renderSpireReference(ref: SpireReference): string {
       targeted: card.targeted,
       description: card.description,
       upgradedDescription: card.upgradedDescription,
+    })),
+    relics: ref.relics.map(relic => ({
+      name: relic.name,
+      rarityLabel: SPIRE_RARITY_LABELS[relic.rarity] ?? relic.rarity,
+      description: relic.description,
+    })),
+    potions: ref.potions.map(potion => ({
+      name: potion.name,
+      rarityLabel: SPIRE_RARITY_LABELS[potion.rarity] ?? potion.rarity,
+      targeted: potion.targeted,
+      description: potion.description,
     })),
     terms: ref.terms,
   });

--- a/apps/agent/src/agent/capabilities/spire/tools/lookup.tool.ts
+++ b/apps/agent/src/agent/capabilities/spire/tools/lookup.tool.ts
@@ -11,11 +11,11 @@ const Schema = z.object({ query: z.string().optional() });
 export class SpireLookupTool extends SpireToolComponent<typeof Schema> {
   public readonly name = SPIRE_LOOKUP_TOOL_NAME;
   public readonly description =
-    "查询卡牌信息或游戏术语（不消耗任何动作）。query 可以是卡名（如 打击）或术语（如 易伤、虚弱、格挡）；不传 query 则列出全部卡牌与术语。";
+    "查询卡牌 / 遗物 / 药水信息或游戏术语（不消耗任何动作）。query 可以是卡名（如 打击）、遗物名（如 燃烧之血）、药水名（如 火焰药水）或术语（如 易伤、虚弱、格挡）；不传 query 则列出全部。";
   public readonly parameters = {
     type: "object",
     properties: {
-      query: { type: "string", description: "卡名或术语；留空列出全部。" },
+      query: { type: "string", description: "卡名 / 遗物名 / 药水名 / 术语；留空列出全部。" },
     },
     required: [],
   } as const;

--- a/apps/agent/static/context/spire-reference.hbs
+++ b/apps/agent/static/context/spire-reference.hbs
@@ -8,6 +8,20 @@
 　升级：{{upgradedDescription}}
 {{/each}}
 {{/if}}
+{{#if hasRelics}}
+————遗物————
+{{#each relics}}
+「{{name}}」（{{rarityLabel}}）
+　效果：{{description}}
+{{/each}}
+{{/if}}
+{{#if hasPotions}}
+————药水————
+{{#each potions}}
+「{{name}}」（{{rarityLabel}}）{{#if targeted}}　需指定敌人{{/if}}
+　效果：{{description}}
+{{/each}}
+{{/if}}
 {{#if hasTerms}}
 ————术语————
 {{#each terms}}
@@ -15,6 +29,6 @@
 {{/each}}
 {{/if}}
 {{else}}
-没查到「{{query}}」。可以查卡名（如 打击、防御）或术语（如 易伤、虚弱、格挡）。不带查询词调用 lookup 会列出全部卡牌与术语。
+没查到「{{query}}」。可以查卡名（如 打击）、遗物名（如 燃烧之血）、药水名（如 火焰药水）或术语（如 易伤、虚弱、格挡）。不带查询词调用 lookup 会列出全部内容。
 {{/if}}
 </spire_reference>

--- a/apps/spire/src/application/reference.ts
+++ b/apps/spire/src/application/reference.ts
@@ -1,7 +1,9 @@
 import { ALL_CARDS, costOf } from "../engine/cards/cards.js";
+import { ALL_RELICS } from "../engine/relics/relics.js";
+import { ALL_POTIONS } from "../engine/potions/potions.js";
 import { GLOSSARY, type GlossaryEntry } from "../engine/glossary.js";
 
-// === 参考查询：按 query 匹配卡牌 + 术语，返回结构化数据 ===
+// === 参考查询：按 query 匹配卡牌 / 遗物 / 药水 / 术语，返回结构化数据 ===
 //
 // 供 agent 侧 lookup 工具消费（GET /reference?q=）。数据是游戏事实，渲染框架文案在 agent .hbs。
 
@@ -15,9 +17,24 @@ export type CardRef = {
   upgradedDescription: string;
 };
 
+export type RelicRef = {
+  name: string;
+  rarity: string;
+  description: string;
+};
+
+export type PotionRef = {
+  name: string;
+  rarity: string;
+  targeted: boolean;
+  description: string;
+};
+
 export type ReferenceResult = {
   query: string;
   cards: CardRef[];
+  relics: RelicRef[];
+  potions: PotionRef[];
   terms: GlossaryEntry[];
 };
 
@@ -35,28 +52,36 @@ function toCardRef(cardId: string): CardRef {
 }
 
 /**
- * query 为空 → 返回全部术语 + 全部卡；否则子串（不区分大小写）匹配卡名 / 卡 id 与术语名 / 别名。
+ * query 为空 → 返回全部卡 / 遗物 / 药水 / 术语；否则子串（不区分大小写）匹配名 / id / 术语别名。
  */
 export function lookupReference(query: string): ReferenceResult {
   const q = query.trim().toLowerCase();
+  const matches = (name: string, id: string): boolean =>
+    q.length === 0 || name.toLowerCase().includes(q) || id.toLowerCase().includes(q);
 
-  if (q.length === 0) {
-    return {
-      query,
-      cards: ALL_CARDS.map(card => toCardRef(card.id)),
-      terms: [...GLOSSARY],
-    };
-  }
+  const cards = ALL_CARDS.filter(card => matches(card.name, card.id)).map(card =>
+    toCardRef(card.id),
+  );
 
-  const cards = ALL_CARDS.filter(
-    card => card.name.toLowerCase().includes(q) || card.id.toLowerCase().includes(q),
-  ).map(card => toCardRef(card.id));
+  const relics = ALL_RELICS.filter(relic => matches(relic.name, relic.id)).map(relic => ({
+    name: relic.name,
+    rarity: relic.rarity,
+    description: relic.description,
+  }));
+
+  const potions = ALL_POTIONS.filter(potion => matches(potion.name, potion.id)).map(potion => ({
+    name: potion.name,
+    rarity: potion.rarity,
+    targeted: potion.targeted,
+    description: potion.description,
+  }));
 
   const terms = GLOSSARY.filter(
     entry =>
+      q.length === 0 ||
       entry.term.toLowerCase().includes(q) ||
       entry.aliases.some(alias => alias.toLowerCase().includes(q)),
   );
 
-  return { query, cards, terms };
+  return { query, cards, relics, potions, terms };
 }

--- a/apps/spire/test/reference.test.ts
+++ b/apps/spire/test/reference.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from "vitest";
 import { lookupReference } from "../src/application/reference.js";
 
 describe("lookupReference", () => {
-  it("空 query 返回全部卡牌与术语", () => {
+  it("空 query 返回全部卡牌 / 遗物 / 药水 / 术语", () => {
     const ref = lookupReference("");
     expect(ref.cards.length).toBeGreaterThan(10);
+    expect(ref.relics.length).toBeGreaterThan(10);
+    expect(ref.potions.length).toBeGreaterThan(10);
     expect(ref.terms.length).toBeGreaterThan(5);
   });
 
@@ -34,9 +36,27 @@ describe("lookupReference", () => {
     expect(bodySlam?.upgradedCost).toBe(0);
   });
 
-  it("查不到时卡与术语都为空", () => {
+  it("按遗物名匹配，带稀有度", () => {
+    const ref = lookupReference("燃烧之血");
+    const relic = ref.relics.find(r => r.name === "燃烧之血");
+    expect(relic).toBeDefined();
+    expect(relic?.rarity).toBe("starter");
+    expect(relic?.description).toContain("6");
+  });
+
+  it("按药水名匹配，带稀有度与是否指定目标", () => {
+    const ref = lookupReference("火焰药水");
+    const potion = ref.potions.find(p => p.name === "火焰药水");
+    expect(potion).toBeDefined();
+    expect(potion?.targeted).toBe(true);
+    expect(potion?.description).toContain("20");
+  });
+
+  it("查不到时卡 / 遗物 / 药水 / 术语都为空", () => {
     const ref = lookupReference("不存在的东西xyz");
     expect(ref.cards).toHaveLength(0);
+    expect(ref.relics).toHaveLength(0);
+    expect(ref.potions).toHaveLength(0);
     expect(ref.terms).toHaveLength(0);
   });
 });

--- a/packages/spire-api/src/contract.ts
+++ b/packages/spire-api/src/contract.ts
@@ -137,9 +137,24 @@ export const SpireGlossaryEntrySchema = z.object({
   definition: z.string(),
 });
 
+export const SpireRelicRefSchema = z.object({
+  name: z.string(),
+  rarity: z.string(),
+  description: z.string(),
+});
+
+export const SpirePotionRefSchema = z.object({
+  name: z.string(),
+  rarity: z.string(),
+  targeted: z.boolean(),
+  description: z.string(),
+});
+
 export const SpireReferenceSchema = z.object({
   query: z.string(),
   cards: z.array(SpireCardRefSchema),
+  relics: z.array(SpireRelicRefSchema),
+  potions: z.array(SpirePotionRefSchema),
   terms: z.array(SpireGlossaryEntrySchema),
 });
 


### PR DESCRIPTION
## 背景

补全部署后发现的一个盲点：`lookup`/reference 端点只索引**卡牌 + 术语**，小镜查不到遗物 / 药水的说明文字（新补的一批遗物/药水尤其查不到）。

## 改动

- **契约（source of truth）**：`SpireReferenceSchema` 增加 `relics` / `potions` 两个数组
  - `SpireRelicRefSchema` = `{ name, rarity, description }`
  - `SpirePotionRefSchema` = `{ name, rarity, targeted, description }`
- **`reference.ts`**：`lookupReference` 同时按名 / id 子串匹配 `ALL_RELICS` / `ALL_POTIONS`；空 query 返回全部（门面类型由契约 `z.infer` 反推，漂移即编译报错）
- **agent 侧**：
  - `renderSpireReference` 增遗物 / 药水段（rarity 中文标签）
  - `spire-reference.hbs` 加「遗物」「药水」两块 + 更新无结果提示
  - `lookup` 工具 description 说明可查遗物 / 药水名

## 验证
- 四门禁全过：build / typecheck / lint（0 错）/ format
- spire **316 测试全绿**（`reference.test` 新增遗物 / 药水匹配 + 空 / 无结果断言；`state-view-contract` 用新 `SpireReferenceSchema` 校验运行时产出）
- agent **854 测试全绿**

## 部署
改了契约 + reference + agent 渲染，部署需 `app:deploy spire` + `app:deploy agent`（无 DB 迁移）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)