### PR TITLE
docs(todos): usage→provider 策略下沉重构备忘

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -26,6 +26,13 @@
 
 ## architecture
 
+### usage→provider 策略下沉到 agent，kagami-llm 只留 provider/凭据/机械执行
+
+- **Priority:** P2
+- **Status:** open
+- **Context:** `innerVoice` / `contextSummarizer` / `webSearchAgent` / `todoSuggestionAgent` 这些 usage 全是 **agent 的业务词汇**（命名"agent 为什么发这次 LLM 调用"），但当前 usage→(provider, model, attempts) 的解析 + 多 attempt 重试循环整个跑在 **kagami-llm 内部**的 `@kagami/llm-client`（`client.ts:137` `requireUsageConfig`），`usages.{...}` 还是 config 里逐字段硬编码的对象。抽象泄漏：号称"通用 LLM + OAuth 网关"的服务被迫认识每个 agent 私有 usage 名 + 替它保管 provider 策略。**具体代价**（2026-07-04 踩到）：agent 新增 `innerVoice` usage 后只 `app:deploy agent` 不够——kagami-llm 没重载读到新 `usages.innerVoice`，每次调用报 `LlmClient usage is not configured: innerVoice`、被 extension 吞成 `agent.inner_voice.failed`。加一个 usage 就要连带重启一个通用基础设施服务，这是边界画错的信号。多 Agent 未来更糟：网关会堆积每个 agent 的私有 usage 词汇，而共享网关本该只管 provider/凭据/OAuth。
+- **Notes:** 正确边界 = kagami-llm 拥有 provider 凭据/OAuth + "拿 provider X + model Y 打这一发"的机械执行 + 落库 observation（词汇是 provider/model，通用稳定）；agent 拥有 usage→provider 策略表 + attempt 重试循环。**机制已现成**：`chatDirect(providerId, model)` 就是"caller 定 provider、网关只执行"（playground 已在用 `llm-playground.impl.service.ts:40`）。重构 = 把 `usages` 配置从共享 llm 段（`config.loader.ts:365`）挪到 agent 段、把 attempt-loop 从 `@kagami/llm-client` 搬到 agent 侧解析器、重写 `HttpLlmClient.chat`（`http-llm-client.ts:47`）为"本地解析 usage→provider→chatDirect"。收益：加 usage 永不碰/不重启 llm，那个 failed bug 结构性消失，边界对上"通用网关"定位。走 spec 流水线单开 issue，别 inline。
+
 ### 治理对外部时间/外部条件的直接依赖，核心逻辑改为可注入的状态机
 
 - **Priority:** P2


### PR DESCRIPTION
## 背景
2026-07-04 部署 inner-voice（#265 系列）后发现 `agent.inner_voice.triggered` 全部转成 `failed`，根因 `LlmClient usage is not configured: innerVoice`——usage→provider 解析住在 kagami-llm，光 `app:deploy agent` 没重载 llm 读到新 `usages.innerVoice`。

## 本 PR
纯 TODOS.md：把"usage→provider 策略下沉到 agent、kagami-llm 只留 provider/凭据/机械执行"记为 architecture 分组 P2 备忘（含诊断、正确边界、`chatDirect` 现成抓手、落地路径）。不动任何代码。

留待走 spec 流水线单独立项。