### PR TITLE
feat(spire): 单卡实例自我成长（架构）+ 暴走/玻璃刀/坚韧

### DIFF
--- a/apps/spire/src/engine/cards/cards.ts
+++ b/apps/spire/src/engine/cards/cards.ts
@@ -3214,6 +3214,71 @@ const CARD_LIST: CardDef[] = [
     upgradedDescription: "本回合内，你每打出一张攻击牌获得 5 点格挡。",
   },
 
+  // —— 单卡实例自我成长批次 ——
+  {
+    id: "rampage",
+    name: "暴走",
+    type: "attack",
+    rarity: "uncommon",
+    color: "red",
+    cost: 1,
+    targeted: true,
+    exhausts: false,
+    effects: [
+      { kind: "deal_damage_scaling", base: 8 },
+      { kind: "grow_self", amount: 5 },
+    ],
+    upgradedEffects: [
+      { kind: "deal_damage_scaling", base: 8 },
+      { kind: "grow_self", amount: 8 },
+    ],
+    description: "造成 8 点伤害。本场战斗内每次打出，本牌伤害 +5。",
+    upgradedDescription: "造成 8 点伤害。本场战斗内每次打出，本牌伤害 +8。",
+  },
+  {
+    id: "glass_knife",
+    name: "玻璃刀",
+    type: "attack",
+    rarity: "uncommon",
+    color: "green",
+    cost: 1,
+    targeted: true,
+    exhausts: false,
+    effects: [
+      { kind: "deal_damage_scaling", base: 8 },
+      { kind: "deal_damage_scaling", base: 8 },
+      { kind: "grow_self", amount: -2 },
+    ],
+    upgradedEffects: [
+      { kind: "deal_damage_scaling", base: 12 },
+      { kind: "deal_damage_scaling", base: 12 },
+      { kind: "grow_self", amount: -2 },
+    ],
+    description: "造成 8 点伤害两次。本场战斗内每次打出，本牌伤害 -2。",
+    upgradedDescription: "造成 12 点伤害两次。本场战斗内每次打出，本牌伤害 -2。",
+  },
+  {
+    id: "perseverance",
+    name: "坚韧",
+    type: "skill",
+    rarity: "common",
+    color: "purple",
+    cost: 1,
+    targeted: false,
+    exhausts: false,
+    retain: true,
+    effects: [
+      { kind: "gain_block_scaling", base: 5 },
+      { kind: "grow_self", amount: 2 },
+    ],
+    upgradedEffects: [
+      { kind: "gain_block_scaling", base: 7 },
+      { kind: "grow_self", amount: 3 },
+    ],
+    description: "保留。获得 5 点格挡。本场战斗内每次打出，本牌格挡 +2。",
+    upgradedDescription: "保留。获得 7 点格挡。本场战斗内每次打出，本牌格挡 +3。",
+  },
+
   // —— 敌人塞进牌组的废牌 / 伤口（不可打出）——
   {
     id: "miracle",

--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -333,9 +333,10 @@ function applyEffects(
   actor: ActorRef,
   targetEnemyIndex: number | null,
   xValue = 0,
+  sourceCard?: CardInstance,
 ): void {
   for (const effect of effects) {
-    applyEffect(state, effect, actor, targetEnemyIndex, xValue);
+    applyEffect(state, effect, actor, targetEnemyIndex, xValue, sourceCard);
   }
 }
 
@@ -345,6 +346,7 @@ function applyEffect(
   actor: ActorRef,
   targetEnemyIndex: number | null,
   xValue = 0,
+  sourceCard?: CardInstance,
 ): void {
   const combat = state.combat!;
   const powers = actorPowers(state, actor);
@@ -969,6 +971,29 @@ function applyEffect(
       }
       break;
     }
+    case "deal_damage_scaling": {
+      // 暴走/玻璃刀：对目标造成 base + 本牌 bonus 的伤害。
+      if (actor.side === "player" && targetEnemyIndex !== null) {
+        const dmg = Math.max(0, effect.base + (sourceCard?.bonus ?? 0));
+        dealDamageToEnemy(state, targetEnemyIndex, dmg, powers);
+      }
+      break;
+    }
+    case "gain_block_scaling": {
+      // 坚韧：获得 base + 本牌 bonus 的格挡。
+      if (actor.side === "player") {
+        const amount = Math.max(0, effect.base + (sourceCard?.bonus ?? 0));
+        applyEffect(state, { kind: "gain_block", amount }, actor, targetEnemyIndex);
+      }
+      break;
+    }
+    case "grow_self": {
+      // 本牌 bonus += amount（本场战斗内持续；下场战斗从牌组复制重置）。
+      if (sourceCard) {
+        sourceCard.bonus = (sourceCard.bonus ?? 0) + effect.amount;
+      }
+      break;
+    }
     default: {
       const _exhaustive: never = effect;
       void _exhaustive;
@@ -1413,6 +1438,7 @@ export function playCard(
     { side: "player" },
     resolvedTarget,
     xValue,
+    instance,
   );
   // 终结技计数：本回合已打出的攻击牌 +1（在效果结算后，故本张攻击不计入自身）。
   if (def.type === "attack") {

--- a/apps/spire/src/engine/types.ts
+++ b/apps/spire/src/engine/types.ts
@@ -168,7 +168,11 @@ export type Effect =
   | { kind: "change_max_energy"; delta: number } // 增减每回合最大能量（苦修 -1）
   | { kind: "gain_block_if_wrath"; base: number; bonus: number } // 获得 base 格挡；若处于愤怒姿态再 +bonus（止）
   | { kind: "execute_if_below"; threshold: number } // 若目标当前生命 ≤ threshold 则直接击杀（审判）
-  | { kind: "apply_strength_temp"; amount: number }; // 立即 +amount 力量，本回合结束时失去（屈伸）
+  | { kind: "apply_strength_temp"; amount: number } // 立即 +amount 力量，本回合结束时失去（屈伸）
+  // —— 单卡实例自我成长（读写打出的这张牌的 bonus，本场战斗内有效）——
+  | { kind: "deal_damage_scaling"; base: number } // 对目标造成 base + 本牌 bonus 的伤害（暴走/玻璃刀）
+  | { kind: "gain_block_scaling"; base: number } // 获得 base + 本牌 bonus 的格挡（坚韧）
+  | { kind: "grow_self"; amount: number }; // 本牌 bonus += amount（可负，玻璃刀 -2）
 
 /** 卡定义（静态数据表）。cost=null 表示不可打出（status/废牌）。 */
 export type CardDef = {
@@ -199,8 +203,8 @@ export type CardDef = {
   upgradedDescription: string;
 };
 
-/** 牌组里的一张牌实例（追踪是否已升级）。 */
-export type CardInstance = { uid: number; defId: string; upgraded: boolean };
+/** 牌组里的一张牌实例（追踪是否已升级）。bonus 是本场战斗内自我成长的数值（暴走/玻璃刀），省略=0。 */
+export type CardInstance = { uid: number; defId: string; upgraded: boolean; bonus?: number };
 
 export type PowerInstance = { id: PowerId; amount: number };
 

--- a/apps/spire/test/instance-state.test.ts
+++ b/apps/spire/test/instance-state.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat, playCard } from "../src/engine/combat/combat.js";
+import { cardPoolOf } from "../src/engine/cards/cards.js";
+import type { CardInstance, GameState } from "../src/engine/types.js";
+
+// 单卡实例自我成长（本场战斗内）：暴走/玻璃刀/坚韧。
+
+function combat(character: GameState["character"] = "ironclad"): GameState {
+  const s = newRun({ runId: "inst", seed: 20, character });
+  startCombat(s, "cultist");
+  s.hp = 300;
+  s.maxHp = 300;
+  s.combat!.enemies[0]!.hp = 300;
+  s.combat!.enemies[0]!.maxHp = 300;
+  return s;
+}
+
+/** 打出同一张实例对象（模拟抽回后再打，验证 bonus 持续）。 */
+function replay(s: GameState, card: CardInstance, target: number | null = 0): void {
+  s.combat!.hand = [card];
+  s.combat!.discardPile = [];
+  s.combat!.energy = 9;
+  expect(playCard(s, 0, target).ok).toBe(true);
+}
+
+describe("暴走：每次打出伤害 +5", () => {
+  it("首打 8，再打 13", () => {
+    const s = combat();
+    const card: CardInstance = { uid: s.nextUid++, defId: "rampage", upgraded: false };
+    const e = s.combat!.enemies[0]!;
+    let before = e.hp;
+    replay(s, card, 0);
+    expect(e.hp).toBe(before - 8);
+    expect(card.bonus).toBe(5);
+    before = e.hp;
+    replay(s, card, 0);
+    expect(e.hp).toBe(before - 13); // 8 + 5
+  });
+});
+
+describe("玻璃刀：每次打出伤害 -2", () => {
+  it("首打 8×2=16，再打 6×2=12", () => {
+    const s = combat("silent");
+    const card: CardInstance = { uid: s.nextUid++, defId: "glass_knife", upgraded: false };
+    const e = s.combat!.enemies[0]!;
+    let before = e.hp;
+    replay(s, card, 0);
+    expect(e.hp).toBe(before - 16);
+    before = e.hp;
+    replay(s, card, 0);
+    expect(e.hp).toBe(before - 12); // (8-2)×2
+  });
+});
+
+describe("坚韧：每次打出格挡 +2", () => {
+  it("首打 5，再打 7", () => {
+    const s = combat("watcher");
+    const card: CardInstance = { uid: s.nextUid++, defId: "perseverance", upgraded: false };
+    s.combat!.playerBlock = 0;
+    replay(s, card, null);
+    expect(s.combat!.playerBlock).toBe(5);
+    s.combat!.playerBlock = 0;
+    replay(s, card, null);
+    expect(s.combat!.playerBlock).toBe(7); // 5 + 2
+  });
+});
+
+describe("成长只在本场战斗内（不写回牌组）", () => {
+  it("下场战斗从牌组复制重置 bonus", () => {
+    const s = newRun({ runId: "reset", seed: 4, character: "ironclad" });
+    const deckCard: CardInstance = { uid: s.nextUid++, defId: "rampage", upgraded: false };
+    s.deck.push(deckCard);
+    startCombat(s, "cultist");
+    // 找到战斗里的暴走副本并打出成长。
+    const copy = s.combat!.drawPile.find(c => c.defId === "rampage")!;
+    s.combat!.hand = [copy];
+    s.combat!.energy = 9;
+    playCard(s, 0, 0);
+    expect(copy.bonus).toBe(5);
+    // 牌组原件不受影响。
+    expect(deckCard.bonus).toBeUndefined();
+  });
+});
+
+describe("卡池归属", () => {
+  it("成长卡进入正确池", () => {
+    expect(cardPoolOf("red", "uncommon")).toContain("rampage");
+    expect(cardPoolOf("green", "uncommon")).toContain("glass_knife");
+    expect(cardPoolOf("purple", "common")).toContain("perseverance");
+  });
+});


### PR DESCRIPTION
## 背景

「对齐原版」所需的**架构解锁**：一批卡（暴走/玻璃刀/坚韧/仪式匕首/风车斩…）每次打出会永久改变自身数值，此前 `CardInstance` 无可变字段无法表达。

## 架构改动
- `CardInstance` 加 `bonus` 字段（本场战斗内自我成长，省略=0）
- `applyEffects`/`applyEffect` 加 `sourceCard` 参数；`playCard` 传入打出的 instance，效果可读写它
- 战斗牌是牌组的**副本**（`deck.map(c => ({...c}))`），故 bonus 天然限本场——下场战斗从牌组重新复制、重置

## 新增效果
- `deal_damage_scaling`（base + 本牌 bonus）
- `gain_block_scaling`（base + 本牌 bonus）
- `grow_self`（本牌 bonus ±amount）

## 新增卡牌（3 张）
暴走（红，每打 +5）/ 玻璃刀（绿，每打 -2）/ 坚韧（紫，每打 +2）

## 验证
- 四门禁全过：build / typecheck / lint（0 错）/ format
- spire **423 测试全绿**（新增 `instance-state.test.ts`，含「成长限本场、不写回牌组」回归）
- 四角色 sim 各 50 局 **stuck=0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)