### PR TITLE
feat(spire): 自我成长卡（遗传演算/泄压护罩/风车斩）

### DIFF
--- a/apps/spire/src/engine/cards/cards.ts
+++ b/apps/spire/src/engine/cards/cards.ts
@@ -4095,6 +4095,68 @@ const CARD_LIST: CardDef[] = [
     upgradedDescription: "抽 4 张牌。本回合无法再抽牌。",
   },
 
+  {
+    id: "genetic_algorithm",
+    name: "遗传演算",
+    type: "skill",
+    rarity: "uncommon",
+    color: "blue",
+    cost: 1,
+    targeted: false,
+    exhausts: false,
+    effects: [
+      { kind: "gain_block_scaling", base: 1 },
+      { kind: "grow_self", amount: 2 },
+    ],
+    upgradedEffects: [
+      { kind: "gain_block_scaling", base: 1 },
+      { kind: "grow_self", amount: 3 },
+    ],
+    description: "获得 1 点格挡。本场战斗内每次打出，本牌格挡 +2。",
+    upgradedDescription: "获得 1 点格挡。本场战斗内每次打出，本牌格挡 +3。",
+  },
+  {
+    id: "steam_barrier",
+    name: "泄压护罩",
+    type: "skill",
+    rarity: "common",
+    color: "blue",
+    cost: 0,
+    targeted: false,
+    exhausts: false,
+    effects: [
+      { kind: "gain_block_scaling", base: 6 },
+      { kind: "grow_self", amount: -1 },
+    ],
+    upgradedEffects: [
+      { kind: "gain_block_scaling", base: 8 },
+      { kind: "grow_self", amount: -1 },
+    ],
+    description: "获得 6 点格挡。本场战斗内每次打出，本牌格挡 -1。",
+    upgradedDescription: "获得 8 点格挡。本场战斗内每次打出，本牌格挡 -1。",
+  },
+  {
+    id: "windmill_strike",
+    name: "风车斩",
+    type: "attack",
+    rarity: "uncommon",
+    color: "purple",
+    cost: 2,
+    targeted: true,
+    exhausts: false,
+    retain: true,
+    effects: [
+      { kind: "deal_damage_scaling", base: 7 },
+      { kind: "grow_self", amount: 4 },
+    ],
+    upgradedEffects: [
+      { kind: "deal_damage_scaling", base: 10 },
+      { kind: "grow_self", amount: 5 },
+    ],
+    description: "保留。造成 7 点伤害。本场战斗内每次打出，本牌伤害 +4。",
+    upgradedDescription: "保留。造成 10 点伤害。本场战斗内每次打出，本牌伤害 +5。",
+  },
+
   // —— 敌人塞进牌组的废牌 / 伤口（不可打出）——
   {
     id: "miracle",

--- a/apps/spire/test/grow2.test.ts
+++ b/apps/spire/test/grow2.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat, playCard } from "../src/engine/combat/combat.js";
+import type { CardInstance, GameState } from "../src/engine/types.js";
+
+// 自我成长卡：遗传演算 / 泄压护罩 / 风车斩（复用 grow_self）。
+
+function combat(character: "defect" | "watcher"): GameState {
+  const s = newRun({ runId: "g2", seed: 33, character });
+  startCombat(s, "cultist");
+  s.hp = 300;
+  s.maxHp = 300;
+  s.combat!.enemies[0]!.hp = 300;
+  s.combat!.enemies[0]!.maxHp = 300;
+  s.combat!.orbs = [];
+  return s;
+}
+
+// 复用同一张卡实例（bonus 存在实例上）：打出后把同一对象放回手牌再打。
+function playTwice(s: GameState, defId: string, target: number | null): void {
+  const card: CardInstance = { uid: s.nextUid++, defId, upgraded: false };
+  for (let i = 0; i < 2; i++) {
+    s.combat!.hand = [card];
+    s.combat!.energy = 9;
+    expect(playCard(s, 0, target).ok).toBe(true);
+  }
+}
+
+describe("遗传演算：格挡逐次增长", () => {
+  it("首打 1 格挡，次打 3 格挡（+2）", () => {
+    const s = combat("defect");
+    s.combat!.playerBlock = 0;
+    playTwice(s, "genetic_algorithm", null);
+    // 1（首打）+ 3（次打，本牌已 +2）= 4。
+    expect(s.combat!.playerBlock).toBe(4);
+  });
+});
+
+describe("泄压护罩：格挡逐次递减", () => {
+  it("首打 6，次打 5（-1）", () => {
+    const s = combat("defect");
+    s.combat!.playerBlock = 0;
+    playTwice(s, "steam_barrier", null);
+    expect(s.combat!.playerBlock).toBe(11);
+  });
+});
+
+describe("风车斩：伤害逐次增长", () => {
+  it("首打 7，次打 11（+4）", () => {
+    const s = combat("watcher");
+    const before = s.combat!.enemies[0]!.hp;
+    playTwice(s, "windmill_strike", 0);
+    // 7 + 11 = 18。
+    expect(s.combat!.enemies[0]!.hp).toBe(before - 18);
+  });
+});


### PR DESCRIPTION
复用既有 grow_self 机制，纯数据补全 3 张卡。四门禁过，spire 483 测试全绿，四角色 sim stuck=0。