### PR TITLE
feat(spire): 弃牌联动（声东击西/剖体斩）

### DIFF
--- a/apps/spire/src/engine/cards/cards.ts
+++ b/apps/spire/src/engine/cards/cards.ts
@@ -4255,6 +4255,42 @@ const CARD_LIST: CardDef[] = [
     upgradedDescription: "进入神性姿态。你将在下个回合开始时死亡。保留。消耗。",
   },
 
+  {
+    id: "sneaky_strike",
+    name: "声东击西",
+    type: "attack",
+    rarity: "uncommon",
+    color: "green",
+    cost: 2,
+    targeted: true,
+    exhausts: false,
+    effects: [
+      { kind: "deal_damage", amount: 12 },
+      { kind: "gain_energy_if_discarded", amount: 2 },
+    ],
+    upgradedEffects: [
+      { kind: "deal_damage", amount: 16 },
+      { kind: "gain_energy_if_discarded", amount: 2 },
+    ],
+    description: "造成 12 点伤害。若本回合你弃过牌，获得 2 点能量。",
+    upgradedDescription: "造成 16 点伤害。若本回合你弃过牌，获得 2 点能量。",
+  },
+  {
+    id: "eviscerate",
+    name: "剖体斩",
+    type: "attack",
+    rarity: "uncommon",
+    color: "green",
+    cost: 3,
+    costMinusDiscardThisTurn: true,
+    targeted: true,
+    exhausts: false,
+    effects: [{ kind: "deal_damage_multi", amount: 7, times: 3 }],
+    upgradedEffects: [{ kind: "deal_damage_multi", amount: 9, times: 3 }],
+    description: "本回合每弃 1 张牌，费用 -1。造成 3 次 7 点伤害。",
+    upgradedDescription: "本回合每弃 1 张牌，费用 -1。造成 3 次 9 点伤害。",
+  },
+
   // —— 敌人塞进牌组的废牌 / 伤口（不可打出）——
   {
     id: "miracle",

--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -185,6 +185,7 @@ export function startCombat(state: GameState, encounterId: string): void {
     nextTurnStance: null,
     doomedNextTurn: false,
     attacksThisTurn: 0,
+    cardsDiscardedThisTurn: 0,
     lastCardType: null,
     encounterId,
     isBoss: encounter.isBoss,
@@ -910,6 +911,13 @@ function applyEffect(
       }
       break;
     }
+    case "gain_energy_if_discarded": {
+      // 声东击西：若本回合弃过牌，获得能量。
+      if (actor.side === "player" && combat.cardsDiscardedThisTurn > 0) {
+        combat.energy += effect.amount;
+      }
+      break;
+    }
     case "draw_then_block_if_skill": {
       // 脱身之策：抽 1 张，若抽到的是技能则获得格挡。
       if (actor.side === "player") {
@@ -936,6 +944,7 @@ function applyEffect(
             idx = nextInt(state.rng, combat.hand.length);
           }
           combat.discardPile.push(combat.hand.splice(idx, 1)[0]!);
+          combat.cardsDiscardedThisTurn += 1;
         }
       }
       break;
@@ -949,6 +958,7 @@ function applyEffect(
             keep.push(card);
           } else {
             combat.discardPile.push(card);
+            combat.cardsDiscardedThisTurn += 1;
           }
         }
         combat.hand = keep;
@@ -1272,6 +1282,7 @@ function applyEffect(
       if (actor.side === "player") {
         const count = combat.hand.length;
         combat.discardPile.push(...combat.hand);
+        combat.cardsDiscardedThisTurn += count;
         combat.hand = [];
         for (let n = 0; n < count; n += 1) {
           combat.hand.push({ uid: state.nextUid++, defId: "shiv", upgraded: false });
@@ -1752,8 +1763,12 @@ export function playCard(
   }
   // 腐化：技能牌费用变 0（打出后消耗，见下方入堆处理）。
   const corrupted = def.type === "skill" && getPower(combat.playerPowers, "corruption") > 0;
+  // 剖体斩：费用按本回合已弃牌数下调（下限 0）。
+  const discountedRawCost = def.costMinusDiscardThisTurn
+    ? Math.max(0, rawCost - combat.cardsDiscardedThisTurn)
+    : rawCost;
   // costZero（疯狂使其免费）或腐化时费用视为 0。
-  const cost = corrupted || instance.costZero ? 0 : rawCost;
+  const cost = corrupted || instance.costZero ? 0 : discountedRawCost;
   if (cost > combat.energy) {
     return { ok: false, reason: `能量不足：需 ${cost}，剩 ${combat.energy}。` };
   }
@@ -2065,6 +2080,7 @@ export function endTurn(state: GameState): void {
   combat.turn += 1;
   combat.lastCardType = null;
   combat.attacksThisTurn = 0;
+  combat.cardsDiscardedThisTurn = 0;
   // 亵渎：预约的死亡在新回合兑现。
   if (combat.doomedNextTurn) {
     state.hp = 0;

--- a/apps/spire/src/engine/types.ts
+++ b/apps/spire/src/engine/types.ts
@@ -166,6 +166,7 @@ export type Effect =
   | { kind: "schedule_next_turn_x" } // X 费：下回合多抽 X 张并多得 X 能量（镜影分身）
   | { kind: "schedule_stance_next_turn"; stance: PlayerStance; draw: number } // 下回合开始进入姿态并抽 draw 张（烈怒渐起）
   | { kind: "set_doomed" } // 下个回合开始时角色死亡（亵渎）
+  | { kind: "gain_energy_if_discarded"; amount: number } // 若本回合弃过牌，获得 amount 能量（声东击西）
   | { kind: "draw_then_block_if_skill"; amount: number } // 抽 1 张，若为技能则获得 amount 格挡（脱身之策）
   | { kind: "discard_random"; count: number } // 随机弃掉 count 张手牌（优先状态牌）（杂技/有备而来）
   | { kind: "discard_non_attacks" } // 弃掉手牌中所有非攻击牌（卸货）
@@ -229,6 +230,8 @@ export type CardDef = {
   xCost?: boolean;
   /** 固有：战斗开局必定在起手牌中（背刺等）。 */
   innate?: boolean;
+  /** 打出时费用按本回合已弃牌数下调（下限 0）（剖体斩）。 */
+  costMinusDiscardThisTurn?: boolean;
   /** 需要选择一个敌人目标（攻击类多为 true；AoE / 自身增益为 false）。 */
   targeted: boolean;
   /** 打出后进入消耗堆而非弃牌堆。 */
@@ -363,6 +366,8 @@ export type CombatState = {
   doomedNextTurn: boolean;
   /** 本回合已打出的攻击牌数（终结技按此结算；每回合开始清零）。 */
   attacksThisTurn: number;
+  /** 本回合已（由牌效果）弃掉的手牌数（剖体斩降费 / 声东击西给能量按此；回合开始清零）。 */
+  cardsDiscardedThisTurn: number;
   /** 上一张打出的牌的类型（神圣「若上一张是技能」判据）；null=本回合还没打过。 */
   lastCardType: CardType | null;
   /** 本场战斗奖励的敌人组标识（用于 reward 生成）。 */

--- a/apps/spire/src/persistence/migrate.ts
+++ b/apps/spire/src/persistence/migrate.ts
@@ -49,6 +49,7 @@ export function migrateLoadedState(raw: unknown): GameState {
     backfill(combat, "nextTurnStance", null); // 烈怒渐起——老档没有。
     backfill(combat, "doomedNextTurn", false); // 亵渎——老档没有。
     backfill(combat, "attacksThisTurn", 0);
+    backfill(combat, "cardsDiscardedThisTurn", 0); // 弃牌联动——老档没有。
     backfill(combat, "lastCardType", null);
     const enemies = Array.isArray(combat["enemies"]) ? combat["enemies"] : [];
     for (const entry of enemies) {

--- a/apps/spire/test/discard-synergy.test.ts
+++ b/apps/spire/test/discard-synergy.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat, playCard } from "../src/engine/combat/combat.js";
+import type { GameState } from "../src/engine/types.js";
+
+// 弃牌联动：声东击西（弃过牌给能量）/ 剖体斩（弃牌降费）。cardsDiscardedThisTurn 计数。
+
+function combat(): GameState {
+  const s = newRun({ runId: "disc", seed: 37, character: "silent" });
+  startCombat(s, "cultist");
+  s.hp = 300;
+  s.maxHp = 300;
+  s.combat!.enemies[0]!.hp = 300;
+  s.combat!.enemies[0]!.maxHp = 300;
+  return s;
+}
+
+describe("声东击西：弃过牌才回能量", () => {
+  it("本回合弃过牌 → 打出后净回 0 能量（花 2 得 2）", () => {
+    const s = combat();
+    s.combat!.cardsDiscardedThisTurn = 1;
+    s.combat!.hand = [{ uid: s.nextUid++, defId: "sneaky_strike", upgraded: false }];
+    s.combat!.energy = 3;
+    expect(playCard(s, 0, 0).ok).toBe(true);
+    expect(s.combat!.energy).toBe(3); // 3 - 2 + 2。
+  });
+
+  it("本回合未弃牌 → 不回能量", () => {
+    const s = combat();
+    s.combat!.cardsDiscardedThisTurn = 0;
+    s.combat!.hand = [{ uid: s.nextUid++, defId: "sneaky_strike", upgraded: false }];
+    s.combat!.energy = 3;
+    expect(playCard(s, 0, 0).ok).toBe(true);
+    expect(s.combat!.energy).toBe(1); // 3 - 2。
+  });
+});
+
+describe("剖体斩：弃牌降费", () => {
+  it("弃过 2 张 → 费用 3-2=1", () => {
+    const s = combat();
+    s.combat!.cardsDiscardedThisTurn = 2;
+    s.combat!.hand = [{ uid: s.nextUid++, defId: "eviscerate", upgraded: false }];
+    s.combat!.energy = 1; // 只够降费后的 1。
+    const before = s.combat!.enemies[0]!.hp;
+    expect(playCard(s, 0, 0).ok).toBe(true);
+    expect(s.combat!.energy).toBe(0);
+    expect(s.combat!.enemies[0]!.hp).toBe(before - 21); // 7×3。
+  });
+
+  it("未弃牌 → 原价 3，能量不足打不出", () => {
+    const s = combat();
+    s.combat!.cardsDiscardedThisTurn = 0;
+    s.combat!.hand = [{ uid: s.nextUid++, defId: "eviscerate", upgraded: false }];
+    s.combat!.energy = 2;
+    expect(playCard(s, 0, 0).ok).toBe(false);
+  });
+});
+
+describe("弃牌效果推进 cardsDiscardedThisTurn", () => {
+  it("卸货弃掉非攻击牌后计数增加", () => {
+    const s = combat();
+    s.combat!.cardsDiscardedThisTurn = 0;
+    s.combat!.hand = [
+      { uid: s.nextUid++, defId: "unload", upgraded: false }, // 卸货：弃所有非攻击
+      { uid: s.nextUid++, defId: "defend", upgraded: false },
+      { uid: s.nextUid++, defId: "defend", upgraded: false },
+    ];
+    s.combat!.energy = 9;
+    expect(playCard(s, 0, 0).ok).toBe(true);
+    // 两张 defend 被弃。
+    expect(s.combat!.cardsDiscardedThisTurn).toBe(2);
+  });
+});


### PR DESCRIPTION
cardsDiscardedThisTurn 计数 + costMinusDiscardThisTurn 降费 + gain_energy_if_discarded，2 张绿卡。四门禁过，spire 494 测试全绿，四角色 sim stuck=0。