### PR TITLE
feat(spire): 降费家族（力场/血债血偿）

### DIFF
--- a/apps/spire/src/engine/cards/cards.ts
+++ b/apps/spire/src/engine/cards/cards.ts
@@ -4499,6 +4499,38 @@ const CARD_LIST: CardDef[] = [
     upgradedDescription: "造成 12 点伤害。本回合你每打出一张牌，目标损失 5 点生命。",
   },
 
+  {
+    id: "force_field",
+    name: "力场",
+    type: "skill",
+    rarity: "uncommon",
+    color: "blue",
+    cost: 4,
+    costMinusPowersPlayedThisCombat: true,
+    targeted: false,
+    exhausts: false,
+    effects: [{ kind: "gain_block", amount: 12 }],
+    upgradedEffects: [{ kind: "gain_block", amount: 16 }],
+    description: "本场战斗每打出一张能力牌，本牌费用 -1。获得 12 点格挡。",
+    upgradedDescription: "本场战斗每打出一张能力牌，本牌费用 -1。获得 16 点格挡。",
+  },
+  {
+    id: "blood_for_blood",
+    name: "血债血偿",
+    type: "attack",
+    rarity: "uncommon",
+    color: "red",
+    cost: 4,
+    upgradedCost: 3,
+    costMinusHpLossCountThisCombat: true,
+    targeted: true,
+    exhausts: false,
+    effects: [{ kind: "deal_damage", amount: 18 }],
+    upgradedEffects: [{ kind: "deal_damage", amount: 22 }],
+    description: "本场战斗你每失血一次，本牌费用 -1。造成 18 点伤害。",
+    upgradedDescription: "本场战斗你每失血一次，本牌费用 -1。造成 22 点伤害。",
+  },
+
   // —— 敌人塞进牌组的废牌 / 伤口（不可打出）——
   {
     id: "miracle",

--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -189,6 +189,8 @@ export function startCombat(state: GameState, encounterId: string): void {
     cardsPlayedThisTurn: 0,
     mantraGainedThisCombat: 0,
     frostChanneledThisCombat: 0,
+    powersPlayedThisCombat: 0,
+    timesLostHpThisCombat: 0,
     lastCardType: null,
     encounterId,
     isBoss: encounter.isBoss,
@@ -1611,7 +1613,10 @@ function dealDamageToPlayer(
     addPower(combat.playerPowers, "buffer", -1);
     afterBlock = 0;
   }
-  state.hp = Math.max(0, state.hp - afterBlock);
+  if (afterBlock > 0) {
+    state.hp = Math.max(0, state.hp - afterBlock);
+    combat.timesLostHpThisCombat += 1; // 血债血偿按本场失血次数降费。
+  }
   // 镀甲：受到穿透格挡的攻击伤害时 -1 层。
   if (afterBlock > 0 && getPower(combat.playerPowers, "plated_armor") > 0) {
     addPower(combat.playerPowers, "plated_armor", -1);
@@ -1827,10 +1832,18 @@ export function playCard(
   }
   // 腐化：技能牌费用变 0（打出后消耗，见下方入堆处理）。
   const corrupted = def.type === "skill" && getPower(combat.playerPowers, "corruption") > 0;
-  // 剖体斩：费用按本回合已弃牌数下调（下限 0）。
-  const discountedRawCost = def.costMinusDiscardThisTurn
-    ? Math.max(0, rawCost - combat.cardsDiscardedThisTurn)
-    : rawCost;
+  // 动态降费：剖体斩按本回合弃牌数、力场按本场能力牌数、血债血偿按本场失血次数（下限 0）。
+  let costReduction = 0;
+  if (def.costMinusDiscardThisTurn) {
+    costReduction += combat.cardsDiscardedThisTurn;
+  }
+  if (def.costMinusPowersPlayedThisCombat) {
+    costReduction += combat.powersPlayedThisCombat;
+  }
+  if (def.costMinusHpLossCountThisCombat) {
+    costReduction += combat.timesLostHpThisCombat;
+  }
+  const discountedRawCost = Math.max(0, rawCost - costReduction);
   // 回身步：下一张攻击牌费用视为 0（打出后消耗一层）。
   const freeAttack = def.type === "attack" && getPower(combat.playerPowers, "free_attack") > 0;
   // costZero（疯狂使其免费）或腐化时费用视为 0。
@@ -1907,6 +1920,7 @@ export function playCard(
   }
   if (def.type === "power") {
     // 能力牌打出后离场（效果转为常驻 power），不入任何牌堆，本场不再抽到。
+    combat.powersPlayedThisCombat += 1; // 力场按本场打出的能力牌数降费。
   } else if (def.exhausts || corrupted) {
     // 腐化下技能牌也消耗。
     exhaustCard(state, instance);

--- a/apps/spire/src/engine/types.ts
+++ b/apps/spire/src/engine/types.ts
@@ -241,6 +241,10 @@ export type CardDef = {
   innate?: boolean;
   /** 打出时费用按本回合已弃牌数下调（下限 0）（剖体斩）。 */
   costMinusDiscardThisTurn?: boolean;
+  /** 打出时费用按本场已打出的能力牌数下调（下限 0）（力场）。 */
+  costMinusPowersPlayedThisCombat?: boolean;
+  /** 打出时费用按本场失血次数下调（下限 0）（血债血偿）。 */
+  costMinusHpLossCountThisCombat?: boolean;
   /** 需要选择一个敌人目标（攻击类多为 true；AoE / 自身增益为 false）。 */
   targeted: boolean;
   /** 打出后进入消耗堆而非弃牌堆。 */
@@ -387,6 +391,10 @@ export type CombatState = {
   mantraGainedThisCombat: number;
   /** 本场战斗累计充能的冰霜球数（暴风雪按此结算；整场不清零）。 */
   frostChanneledThisCombat: number;
+  /** 本场战斗累计打出的能力牌数（力场按此降费；整场不清零）。 */
+  powersPlayedThisCombat: number;
+  /** 本场战斗玩家失血的次数（血债血偿按此降费；整场不清零）。 */
+  timesLostHpThisCombat: number;
   /** 上一张打出的牌的类型（神圣「若上一张是技能」判据）；null=本回合还没打过。 */
   lastCardType: CardType | null;
   /** 本场战斗奖励的敌人组标识（用于 reward 生成）。 */

--- a/apps/spire/src/persistence/migrate.ts
+++ b/apps/spire/src/persistence/migrate.ts
@@ -53,6 +53,8 @@ export function migrateLoadedState(raw: unknown): GameState {
     backfill(combat, "cardsPlayedThisTurn", 0); // 出牌计数——老档没有。
     backfill(combat, "mantraGainedThisCombat", 0); // 璀璨光辉——老档没有。
     backfill(combat, "frostChanneledThisCombat", 0); // 暴风雪——老档没有。
+    backfill(combat, "powersPlayedThisCombat", 0); // 力场——老档没有。
+    backfill(combat, "timesLostHpThisCombat", 0); // 血债血偿——老档没有。
     backfill(combat, "lastCardType", null);
     const enemies = Array.isArray(combat["enemies"]) ? combat["enemies"] : [];
     for (const entry of enemies) {

--- a/apps/spire/test/cost-scale.test.ts
+++ b/apps/spire/test/cost-scale.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat, playCard, endTurn } from "../src/engine/combat/combat.js";
+import type { GameState } from "../src/engine/types.js";
+
+// 降费家族：力场（每能力牌 -1）/ 血债血偿（每失血 -1）。
+
+function combat(character: "defect" | "ironclad"): GameState {
+  const s = newRun({ runId: "cs", seed: 44, character });
+  startCombat(s, "cultist");
+  s.hp = 300;
+  s.maxHp = 300;
+  s.combat!.enemies[0]!.hp = 300;
+  s.combat!.enemies[0]!.maxHp = 300;
+  return s;
+}
+
+describe("力场：按本场能力牌数降费", () => {
+  it("已打出 2 张能力牌 → 力场费用 4-2=2", () => {
+    const s = combat("defect");
+    s.combat!.powersPlayedThisCombat = 2;
+    s.combat!.hand = [{ uid: s.nextUid++, defId: "force_field", upgraded: false }];
+    s.combat!.playerBlock = 0;
+    s.combat!.energy = 2; // 恰好够降费后的 2。
+    expect(playCard(s, 0, null).ok).toBe(true);
+    expect(s.combat!.energy).toBe(0);
+    expect(s.combat!.playerBlock).toBe(12);
+  });
+
+  it("打出能力牌会推进计数（力场本身是技能不计）", () => {
+    const s = combat("defect");
+    s.combat!.powersPlayedThisCombat = 0;
+    // 力场本身是技能，不推进计数。
+    s.combat!.hand = [{ uid: s.nextUid++, defId: "force_field", upgraded: false }];
+    s.combat!.energy = 9;
+    expect(playCard(s, 0, null).ok).toBe(true);
+    expect(s.combat!.powersPlayedThisCombat).toBe(0);
+    // 打出一张能力牌（碎片整理）才推进计数。
+    s.combat!.hand = [{ uid: s.nextUid++, defId: "defragment", upgraded: false }];
+    s.combat!.energy = 9;
+    expect(playCard(s, 0, null).ok).toBe(true);
+    expect(s.combat!.powersPlayedThisCombat).toBe(1);
+  });
+});
+
+describe("血债血偿：按本场失血次数降费", () => {
+  it("已失血 2 次 → 费用 4-2=2", () => {
+    const s = combat("ironclad");
+    s.combat!.timesLostHpThisCombat = 2;
+    s.combat!.hand = [{ uid: s.nextUid++, defId: "blood_for_blood", upgraded: false }];
+    s.combat!.energy = 2;
+    const before = s.combat!.enemies[0]!.hp;
+    expect(playCard(s, 0, 0).ok).toBe(true);
+    expect(s.combat!.energy).toBe(0);
+    expect(s.combat!.enemies[0]!.hp).toBe(before - 18);
+  });
+
+  it("受击穿透失血会推进计数", () => {
+    const s = combat("ironclad");
+    s.combat!.timesLostHpThisCombat = 0;
+    s.combat!.playerBlock = 0; // 无格挡，邪教徒黑暗强击必穿透。
+    s.combat!.hand = [];
+    s.combat!.enemies[0]!.currentMove = "dark_strike"; // 强制敌人本回合攻击。
+    const hpBefore = s.hp;
+    endTurn(s);
+    // 玩家被打掉血 → 计数 +1。
+    expect(s.hp).toBeLessThan(hpBefore);
+    expect(s.combat!.timesLostHpThisCombat).toBe(1);
+  });
+});


### PR DESCRIPTION
powersPlayedThisCombat + timesLostHpThisCombat 两个整场计数 + 泛化可叠加动态降费，2 张卡。四门禁过，spire 518 测试全绿，四角色 sim stuck=0。