### PR TITLE
feat(spire): 飞踢 + 黑暗枷锁

### DIFF
--- a/apps/agent/src/agent/capabilities/spire/render/spire-screen.ts
+++ b/apps/agent/src/agent/capabilities/spire/render/spire-screen.ts
@@ -81,6 +81,7 @@ const POWER_LABELS: Record<string, string> = {
   well_laid_plans: "深谋远虑",
   mark: "标记",
   envenom: "淬毒",
+  shackled: "枷锁",
 };
 
 const ORB_LABELS: Record<string, string> = {

--- a/apps/spire/src/engine/cards/cards.ts
+++ b/apps/spire/src/engine/cards/cards.ts
@@ -4597,6 +4597,41 @@ const CARD_LIST: CardDef[] = [
     upgradedDescription: "你的攻击每造成一次穿透格挡的伤害，给该敌人施加 1 层中毒。",
   },
 
+  {
+    id: "dropkick",
+    name: "飞踢",
+    type: "attack",
+    rarity: "uncommon",
+    color: "red",
+    cost: 1,
+    targeted: true,
+    exhausts: false,
+    effects: [
+      { kind: "deal_damage", amount: 5 },
+      { kind: "bonus_if_target_vulnerable", energy: 1, draw: 1 },
+    ],
+    upgradedEffects: [
+      { kind: "deal_damage", amount: 8 },
+      { kind: "bonus_if_target_vulnerable", energy: 1, draw: 1 },
+    ],
+    description: "造成 5 点伤害。若目标处于易伤，获得 1 点能量并抽 1 张牌。",
+    upgradedDescription: "造成 8 点伤害。若目标处于易伤，获得 1 点能量并抽 1 张牌。",
+  },
+  {
+    id: "dark_shackles",
+    name: "黑暗枷锁",
+    type: "skill",
+    rarity: "uncommon",
+    color: "colorless",
+    cost: 0,
+    targeted: true,
+    exhausts: true,
+    effects: [{ kind: "weaken_enemy_strength", amount: 9 }],
+    upgradedEffects: [{ kind: "weaken_enemy_strength", amount: 15 }],
+    description: "本回合内，使目标失去 9 点力量（其行动过后归还）。消耗。",
+    upgradedDescription: "本回合内，使目标失去 15 点力量（其行动过后归还）。消耗。",
+  },
+
   // —— 敌人塞进牌组的废牌 / 伤口（不可打出）——
   {
     id: "miracle",

--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -904,6 +904,27 @@ function applyEffect(
       }
       break;
     }
+    case "bonus_if_target_vulnerable": {
+      // 飞踢：目标处于易伤时，获得能量并抽牌。
+      if (actor.side === "player" && targetEnemyIndex !== null) {
+        if (getPower(combat.enemies[targetEnemyIndex]!.powers, "vulnerable") > 0) {
+          combat.energy += effect.energy;
+          drawCards(state, effect.draw);
+        }
+      }
+      break;
+    }
+    case "weaken_enemy_strength": {
+      // 黑暗枷锁：目标临时失去力量，记入枷锁，待其行动过后归还。
+      if (actor.side === "player" && targetEnemyIndex !== null) {
+        const enemy = combat.enemies[targetEnemyIndex]!;
+        if (enemy.hp > 0) {
+          addPower(enemy.powers, "strength", -effect.amount);
+          addPower(enemy.powers, "shackled", effect.amount);
+        }
+      }
+      break;
+    }
     case "deal_damage_plus_mantra_gained": {
       // 璀璨光辉：对目标造成 base + 本场累计法力。
       if (actor.side === "player" && targetEnemyIndex !== null) {
@@ -2215,6 +2236,14 @@ export function endTurn(state: GameState): void {
   combat.attacksThisTurn = 0;
   combat.cardsDiscardedThisTurn = 0;
   combat.cardsPlayedThisTurn = 0;
+  // 黑暗枷锁：敌人被临时削弱的力量在其行动过后（新玩家回合开始）归还，清除枷锁。
+  for (const enemy of combat.enemies) {
+    const shackled = getPower(enemy.powers, "shackled");
+    if (shackled > 0) {
+      addPower(enemy.powers, "strength", shackled);
+      removePower(enemy.powers, "shackled");
+    }
+  }
   // 亵渎：预约的死亡在新回合兑现。
   if (combat.doomedNextTurn) {
     state.hp = 0;

--- a/apps/spire/src/engine/types.ts
+++ b/apps/spire/src/engine/types.ts
@@ -83,7 +83,8 @@ export type PowerId =
   | "choked" // 扼喉：本回合玩家每打出一张牌，此敌人损失 = 层数的生命（玩家回合末清除，静默）
   | "well_laid_plans" // 深谋远虑：回合结束可额外保留至多 = 层数张牌（静默）
   | "mark" // 标记：玩家每次攻击此敌人，获得 = 层数的格挡（观者·以手言心，敌人身上）
-  | "envenom"; // 淬毒：玩家攻击造成穿透格挡的伤害时，给该敌人施加 = 层数的中毒（静默）
+  | "envenom" // 淬毒：玩家攻击造成穿透格挡的伤害时，给该敌人施加 = 层数的中毒（静默）
+  | "shackled"; // 枷锁：此敌人被临时削弱的力量，将在其行动过后归还（内部记账，黑暗枷锁）
 
 /** 玩家出牌 / 敌人出招共用的效果原语。target 相对「行动者」解析。 */
 export type Effect =
@@ -168,6 +169,8 @@ export type Effect =
   | { kind: "multiply_target_poison"; factor: number } // 将目标当前中毒层数乘以 factor（催化剂）
   | { kind: "deal_damage_per_orb"; amount: number } // 场上每颗充能球对目标造成 amount 伤害（弹幕）
   | { kind: "deal_damage_per_enemy"; amount: number } // 对目标造成 amount×(存活敌人数) 伤害（保龄冲击）
+  | { kind: "bonus_if_target_vulnerable"; energy: number; draw: number } // 若目标易伤：+energy 能量并抽 draw 张（飞踢）
+  | { kind: "weaken_enemy_strength"; amount: number } // 使目标临时失去 amount 力量，其行动后归还（黑暗枷锁）
   | { kind: "deal_damage_plus_mantra_gained"; base: number } // 对目标造成 base + 本场累计法力（璀璨光辉）
   | { kind: "deal_damage_all_per_frost_channeled"; per: number } // 对所有敌人造成 per×本场充能冰霜数（暴风雪）
   // —— 下回合预约 / 弃牌 / 随机毒 / 抽到指定张数 ——

--- a/apps/spire/test/conditional2.test.ts
+++ b/apps/spire/test/conditional2.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat, playCard, endTurn } from "../src/engine/combat/combat.js";
+import { getPower } from "../src/engine/powers/powers.js";
+import type { CardInstance, GameState } from "../src/engine/types.js";
+
+// 飞踢（易伤则回能量+抽牌）/ 黑暗枷锁（临时削力，行动后归还）。
+
+function combat(character: "ironclad"): GameState {
+  const s = newRun({ runId: "c2", seed: 47, character });
+  startCombat(s, "cultist");
+  s.hp = 300;
+  s.maxHp = 300;
+  s.combat!.enemies[0]!.hp = 300;
+  s.combat!.enemies[0]!.maxHp = 300;
+  return s;
+}
+
+function play(s: GameState, defId: string, target: number | null): void {
+  const card: CardInstance = { uid: s.nextUid++, defId, upgraded: false };
+  s.combat!.hand = [card];
+  s.combat!.energy = 9;
+  expect(playCard(s, 0, target).ok).toBe(true);
+}
+
+describe("飞踢：目标易伤时回能量并抽牌", () => {
+  it("目标易伤 → +1 能量、抽 1", () => {
+    const s = combat("ironclad");
+    s.combat!.enemies[0]!.powers = [{ id: "vulnerable", amount: 2 }];
+    s.combat!.drawPile = [{ uid: s.nextUid++, defId: "strike", upgraded: false }];
+    const card: CardInstance = { uid: s.nextUid++, defId: "dropkick", upgraded: false };
+    s.combat!.hand = [card];
+    s.combat!.energy = 3;
+    expect(playCard(s, 0, 0).ok).toBe(true);
+    // 花 1 费 + 易伤回 1 → 能量净不变（3）。
+    expect(s.combat!.energy).toBe(3);
+    expect(s.combat!.hand.filter(c => c.defId === "strike")).toHaveLength(1);
+  });
+
+  it("目标不易伤 → 无额外收益", () => {
+    const s = combat("ironclad");
+    s.combat!.enemies[0]!.powers = [];
+    const card: CardInstance = { uid: s.nextUid++, defId: "dropkick", upgraded: false };
+    s.combat!.hand = [card];
+    s.combat!.energy = 3;
+    expect(playCard(s, 0, 0).ok).toBe(true);
+    expect(s.combat!.energy).toBe(2); // 只花 1 费。
+  });
+});
+
+describe("黑暗枷锁：临时削力，敌人行动后归还", () => {
+  it("削 9 力量并记入枷锁；新回合归还", () => {
+    const s = combat("ironclad");
+    s.combat!.enemies[0]!.powers = [{ id: "strength", amount: 5 }];
+    play(s, "dark_shackles", 0);
+    expect(getPower(s.combat!.enemies[0]!.powers, "strength")).toBe(-4); // 5 - 9
+    expect(getPower(s.combat!.enemies[0]!.powers, "shackled")).toBe(9);
+    s.combat!.hand = [];
+    s.combat!.enemies[0]!.currentMove = "dark_strike"; // 敌人本回合以被削状态行动
+    endTurn(s);
+    // 新回合开始：力量归还，枷锁清除。
+    expect(getPower(s.combat!.enemies[0]!.powers, "strength")).toBe(5);
+    expect(getPower(s.combat!.enemies[0]!.powers, "shackled")).toBe(0);
+  });
+});


### PR DESCRIPTION
bonus_if_target_vulnerable + weaken_enemy_strength(shackled归还) 两效果，2 张卡。四门禁过，spire 528 测试全绿，四角色 sim stuck=0。