### PR TITLE
feat(spire): 掌控现实 + 研学有成

### DIFF
--- a/apps/agent/src/agent/capabilities/spire/render/spire-screen.ts
+++ b/apps/agent/src/agent/capabilities/spire/render/spire-screen.ts
@@ -86,6 +86,7 @@ const POWER_LABELS: Record<string, string> = {
   establishment: "既定事实",
   study: "研习",
   omega: "奥米加",
+  master_reality: "掌控现实",
 };
 
 const ORB_LABELS: Record<string, string> = {

--- a/apps/spire/src/engine/cards/cards.ts
+++ b/apps/spire/src/engine/cards/cards.ts
@@ -4737,6 +4737,35 @@ const CARD_LIST: CardDef[] = [
     upgradedDescription: "每个回合结束时，对所有敌人造成 50 点伤害。",
   },
 
+  {
+    id: "master_reality",
+    name: "掌控现实",
+    type: "power",
+    rarity: "rare",
+    color: "purple",
+    cost: 1,
+    targeted: false,
+    exhausts: false,
+    effects: [{ kind: "apply_power", power: "master_reality", amount: 1, on: "self" }],
+    upgradedEffects: [{ kind: "apply_power", power: "master_reality", amount: 1, on: "self" }],
+    description: "本场战斗中，你生成的牌进入牌堆时立即升级。",
+    upgradedDescription: "本场战斗中，你生成的牌进入牌堆时立即升级。",
+  },
+  {
+    id: "lesson_learned",
+    name: "研学有成",
+    type: "attack",
+    rarity: "uncommon",
+    color: "purple",
+    cost: 2,
+    targeted: true,
+    exhausts: true,
+    effects: [{ kind: "deal_damage_lesson", amount: 10 }],
+    upgradedEffects: [{ kind: "deal_damage_lesson", amount: 13 }],
+    description: "造成 10 点伤害。若因此击杀目标，永久升级你牌组中一张随机牌。消耗。",
+    upgradedDescription: "造成 13 点伤害。若因此击杀目标，永久升级你牌组中一张随机牌。消耗。",
+  },
+
   // —— 敌人塞进牌组的废牌 / 伤口（不可打出）——
   {
     id: "miracle",

--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -920,6 +920,20 @@ function applyEffect(
       }
       break;
     }
+    case "deal_damage_lesson": {
+      // 研学有成：造成伤害；若因此击杀目标，永久升级牌组中一张随机未升级牌。
+      if (actor.side === "player" && targetEnemyIndex !== null) {
+        const wasAlive = combat.enemies[targetEnemyIndex]!.hp > 0;
+        dealDamageToEnemy(state, targetEnemyIndex, effect.amount, powers);
+        if (wasAlive && combat.enemies[targetEnemyIndex]!.hp <= 0) {
+          const upgradable = state.deck.filter(card => !card.upgraded);
+          if (upgradable.length > 0) {
+            upgradable[nextInt(state.rng, upgradable.length)]!.upgraded = true;
+          }
+        }
+      }
+      break;
+    }
     case "bonus_if_target_vulnerable": {
       // 飞踢：目标处于易伤时，获得能量并抽牌。
       if (actor.side === "player" && targetEnemyIndex !== null) {
@@ -1520,8 +1534,10 @@ function addCards(
   count: number,
 ): void {
   const combat = state.combat!;
+  // 掌控现实：战斗中生成的牌进场即升级。
+  const created = getPower(combat.playerPowers, "master_reality") > 0;
   for (let i = 0; i < count; i += 1) {
-    const instance: CardInstance = { uid: state.nextUid++, defId: cardId, upgraded: false };
+    const instance: CardInstance = { uid: state.nextUid++, defId: cardId, upgraded: created };
     if (pile === "hand") {
       if (combat.hand.length >= MAX_HAND_SIZE) {
         combat.discardPile.push(instance);

--- a/apps/spire/src/engine/types.ts
+++ b/apps/spire/src/engine/types.ts
@@ -88,7 +88,8 @@ export type PowerId =
   | "sadistic_nature" // 虐念：玩家每给敌人施加一个减益，对其造成 = 层数的伤害（静默）
   | "establishment" // 既定事实：每当一张牌被保留，其费用永久 -层数（观者）
   | "study" // 研习：每个玩家回合结束，将 = 层数张「洞悉」加入抽牌堆（观者）
-  | "omega"; // 奥米加：每个玩家回合结束，对所有敌人造成 50×层数 的伤害（观者）
+  | "omega" // 奥米加：每个玩家回合结束，对所有敌人造成 50×层数 的伤害（观者）
+  | "master_reality"; // 掌控现实：战斗中生成的牌进场即升级（观者）
 
 /** 玩家出牌 / 敌人出招共用的效果原语。target 相对「行动者」解析。 */
 export type Effect =
@@ -173,6 +174,7 @@ export type Effect =
   | { kind: "multiply_target_poison"; factor: number } // 将目标当前中毒层数乘以 factor（催化剂）
   | { kind: "deal_damage_per_orb"; amount: number } // 场上每颗充能球对目标造成 amount 伤害（弹幕）
   | { kind: "deal_damage_per_enemy"; amount: number } // 对目标造成 amount×(存活敌人数) 伤害（保龄冲击）
+  | { kind: "deal_damage_lesson"; amount: number } // 对目标造成 amount；若因此击杀，永久升级牌组中一张随机牌（研学有成）
   | { kind: "bonus_if_target_vulnerable"; energy: number; draw: number } // 若目标易伤：+energy 能量并抽 draw 张（飞踢）
   | { kind: "weaken_enemy_strength"; amount: number } // 使目标临时失去 amount 力量，其行动后归还（黑暗枷锁）
   | { kind: "deal_damage_plus_mantra_gained"; base: number } // 对目标造成 base + 本场累计法力（璀璨光辉）

--- a/apps/spire/test/mastery.test.ts
+++ b/apps/spire/test/mastery.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat, playCard } from "../src/engine/combat/combat.js";
+import { getPower } from "../src/engine/powers/powers.js";
+import type { CardInstance, GameState } from "../src/engine/types.js";
+
+// 掌控现实（生成牌即升级）/ 研学有成（击杀则升级牌组一张）。
+
+function combat(): GameState {
+  const s = newRun({ runId: "mr", seed: 51, character: "watcher" });
+  startCombat(s, "cultist");
+  s.hp = 300;
+  s.maxHp = 300;
+  s.combat!.enemies[0]!.hp = 300;
+  s.combat!.enemies[0]!.maxHp = 300;
+  return s;
+}
+
+describe("掌控现实：生成的牌进场即升级", () => {
+  it("挂上后洗入的洞悉是升级版", () => {
+    const s = combat();
+    s.combat!.hand = [{ uid: s.nextUid++, defId: "master_reality", upgraded: false }];
+    s.combat!.energy = 9;
+    expect(playCard(s, 0, null).ok).toBe(true);
+    expect(getPower(s.combat!.playerPowers, "master_reality")).toBe(1);
+    // 用「阿尔法」生成贝塔（走 addCards）；掌控现实下贝塔应进场即升级。
+    s.combat!.hand = [{ uid: s.nextUid++, defId: "alpha", upgraded: false }];
+    s.combat!.drawPile = [];
+    s.combat!.energy = 9;
+    expect(playCard(s, 0, null).ok).toBe(true);
+    const beta = s.combat!.drawPile.find(c => c.defId === "beta");
+    expect(beta?.upgraded).toBe(true);
+  });
+});
+
+describe("研学有成：击杀则升级牌组一张", () => {
+  it("击杀敌人后牌组多一张升级牌", () => {
+    const s = combat();
+    // 保证牌组里有未升级牌。
+    const upgradedBefore = s.deck.filter(c => c.upgraded).length;
+    s.combat!.enemies[0]!.hp = 5;
+    s.combat!.enemies[0]!.block = 0;
+    const card: CardInstance = { uid: s.nextUid++, defId: "lesson_learned", upgraded: false };
+    s.combat!.hand = [card];
+    s.combat!.energy = 9;
+    expect(playCard(s, 0, 0).ok).toBe(true);
+    // 唯一敌人被击杀 → 战斗结束（combat 归 null）；牌组升级持久留在 state.deck。
+    expect(s.deck.filter(c => c.upgraded).length).toBe(upgradedBefore + 1);
+  });
+
+  it("未击杀则不升级牌组", () => {
+    const s = combat();
+    const upgradedBefore = s.deck.filter(c => c.upgraded).length;
+    s.combat!.enemies[0]!.hp = 100;
+    const card: CardInstance = { uid: s.nextUid++, defId: "lesson_learned", upgraded: false };
+    s.combat!.hand = [card];
+    s.combat!.energy = 9;
+    expect(playCard(s, 0, 0).ok).toBe(true);
+    expect(s.deck.filter(c => c.upgraded).length).toBe(upgradedBefore);
+  });
+});


### PR DESCRIPTION
master_reality（生成牌升级）+ deal_damage_lesson（击杀升级牌组），2 张紫卡。四门禁过，spire 538 测试全绿，四角色 sim stuck=0。