### PR TITLE
feat(spire): 终局 + 连绵拳

### DIFF
--- a/apps/spire/src/engine/cards/cards.ts
+++ b/apps/spire/src/engine/cards/cards.ts
@@ -4766,6 +4766,35 @@ const CARD_LIST: CardDef[] = [
     upgradedDescription: "造成 13 点伤害。若因此击杀目标，永久升级你牌组中一张随机牌。消耗。",
   },
 
+  {
+    id: "conclude",
+    name: "终局",
+    type: "attack",
+    rarity: "uncommon",
+    color: "purple",
+    cost: 1,
+    targeted: false,
+    exhausts: false,
+    effects: [{ kind: "deal_damage_all", amount: 12 }, { kind: "end_turn" }],
+    upgradedEffects: [{ kind: "deal_damage_all", amount: 16 }, { kind: "end_turn" }],
+    description: "对所有敌人造成 12 点伤害。结束你的回合。",
+    upgradedDescription: "对所有敌人造成 16 点伤害。结束你的回合。",
+  },
+  {
+    id: "flurry_of_blows",
+    name: "连绵拳",
+    type: "attack",
+    rarity: "common",
+    color: "purple",
+    cost: 0,
+    targeted: true,
+    exhausts: false,
+    effects: [{ kind: "deal_damage", amount: 4 }],
+    upgradedEffects: [{ kind: "deal_damage", amount: 6 }],
+    description: "造成 4 点伤害。每当你切换姿态，将本牌从弃牌堆收回手牌。",
+    upgradedDescription: "造成 6 点伤害。每当你切换姿态，将本牌从弃牌堆收回手牌。",
+  },
+
   // —— 敌人塞进牌组的废牌 / 伤口（不可打出）——
   {
     id: "miracle",

--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -934,6 +934,10 @@ function applyEffect(
       }
       break;
     }
+    case "end_turn": {
+      // 终局：实际的结束回合在 playCard 收尾处检测本效果后触发，这里不做事。
+      break;
+    }
     case "bonus_if_target_vulnerable": {
       // 飞踢：目标处于易伤时，获得能量并抽牌。
       if (actor.side === "player" && targetEnemyIndex !== null) {
@@ -1746,6 +1750,12 @@ function enterStance(state: GameState, stance: PlayerStance): void {
       drawCards(state, rushdown);
     }
   }
+  // 连绵拳：每次姿态改变，将弃牌堆里的所有「连绵拳」收回手牌（手满则留在弃牌堆）。
+  for (let i = combat.discardPile.length - 1; i >= 0; i -= 1) {
+    if (combat.discardPile[i]!.defId === "flurry_of_blows" && combat.hand.length < MAX_HAND_SIZE) {
+      combat.hand.push(combat.discardPile.splice(i, 1)[0]!);
+    }
+  }
 }
 
 /** 累积法力：达到 10 层自动进入神性姿态（清空法力、+3 能量）。 */
@@ -2035,6 +2045,14 @@ export function playCard(
   if (state.combat !== null && state.hp <= 0) {
     state.screen = "gameover";
     state.log.push("你倒下了。");
+  }
+  // 终局：带「结束回合」效果的牌，打出结算后若战斗仍在进行则立即结束本回合。
+  if (
+    state.combat !== null &&
+    state.screen === "combat" &&
+    effectsOf(def, instance.upgraded).some(candidate => candidate.kind === "end_turn")
+  ) {
+    endTurn(state);
   }
   return { ok: true };
 }

--- a/apps/spire/src/engine/types.ts
+++ b/apps/spire/src/engine/types.ts
@@ -175,6 +175,7 @@ export type Effect =
   | { kind: "deal_damage_per_orb"; amount: number } // 场上每颗充能球对目标造成 amount 伤害（弹幕）
   | { kind: "deal_damage_per_enemy"; amount: number } // 对目标造成 amount×(存活敌人数) 伤害（保龄冲击）
   | { kind: "deal_damage_lesson"; amount: number } // 对目标造成 amount；若因此击杀，永久升级牌组中一张随机牌（研学有成）
+  | { kind: "end_turn" } // 打出结算后立即结束本回合（终局；在 playCard 收尾处检测）
   | { kind: "bonus_if_target_vulnerable"; energy: number; draw: number } // 若目标易伤：+energy 能量并抽 draw 张（飞踢）
   | { kind: "weaken_enemy_strength"; amount: number } // 使目标临时失去 amount 力量，其行动后归还（黑暗枷锁）
   | { kind: "deal_damage_plus_mantra_gained"; base: number } // 对目标造成 base + 本场累计法力（璀璨光辉）

--- a/apps/spire/test/stance2.test.ts
+++ b/apps/spire/test/stance2.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat, playCard } from "../src/engine/combat/combat.js";
+import type { CardInstance, GameState } from "../src/engine/types.js";
+
+// 终局（AoE + 结束回合）/ 连绵拳（切换姿态从弃牌堆收回）。
+
+function combat(): GameState {
+  const s = newRun({ runId: "s2", seed: 52, character: "watcher" });
+  startCombat(s, "cultist");
+  s.hp = 300;
+  s.maxHp = 300;
+  s.combat!.enemies[0]!.hp = 300;
+  s.combat!.enemies[0]!.maxHp = 300;
+  return s;
+}
+
+describe("终局：AoE 后立即结束回合", () => {
+  it("造成全体伤害并推进到下一回合", () => {
+    const s = combat();
+    s.combat!.enemies[0]!.block = 0;
+    const before = s.combat!.enemies[0]!.hp;
+    const turnBefore = s.combat!.turn;
+    const card: CardInstance = { uid: s.nextUid++, defId: "conclude", upgraded: false };
+    s.combat!.hand = [card];
+    s.combat!.energy = 9;
+    s.combat!.enemies[0]!.currentMove = "incantation";
+    expect(playCard(s, 0, null).ok).toBe(true);
+    // 全体 12 伤害。
+    expect(before - s.combat!.enemies[0]!.hp).toBeGreaterThanOrEqual(12);
+    // 回合已推进（结束回合触发了敌人回合 + 新回合）。
+    expect(s.combat!.turn).toBe(turnBefore + 1);
+  });
+});
+
+describe("连绵拳：切换姿态从弃牌堆收回", () => {
+  it("打出进弃牌堆，进入愤怒后收回手牌", () => {
+    const s = combat();
+    const card: CardInstance = { uid: s.nextUid++, defId: "flurry_of_blows", upgraded: false };
+    s.combat!.hand = [card];
+    s.combat!.energy = 9;
+    expect(playCard(s, 0, 0).ok).toBe(true);
+    // 0 费攻击进弃牌堆。
+    expect(s.combat!.discardPile.some(c => c.defId === "flurry_of_blows")).toBe(true);
+    expect(s.combat!.hand.some(c => c.defId === "flurry_of_blows")).toBe(false);
+    // 打出「喷发」进入愤怒姿态 → 连绵拳被收回手牌。
+    s.combat!.hand = [{ uid: s.nextUid++, defId: "eruption", upgraded: false }];
+    s.combat!.energy = 9;
+    expect(playCard(s, 0, 0).ok).toBe(true);
+    expect(s.combat!.playerStance).toBe("wrath");
+    expect(s.combat!.hand.some(c => c.defId === "flurry_of_blows")).toBe(true);
+    expect(s.combat!.discardPile.some(c => c.defId === "flurry_of_blows")).toBe(false);
+  });
+});


### PR DESCRIPTION
end_turn 效果（playCard 收尾触发）+ 连绵拳走 enterStance 钩子从弃牌堆收回，2 张紫卡。四门禁过，spire 540 测试全绿，四角色 sim stuck=0。