### PR TITLE
feat(spire): 点穴 + 浩劫

### DIFF
--- a/apps/spire/src/engine/cards/cards.ts
+++ b/apps/spire/src/engine/cards/cards.ts
@@ -4861,6 +4861,42 @@ const CARD_LIST: CardDef[] = [
     upgradedDescription: "获得 4 点力量。消耗。",
   },
 
+  {
+    id: "pressure_points",
+    name: "点穴",
+    type: "attack",
+    rarity: "common",
+    color: "purple",
+    cost: 1,
+    targeted: true,
+    exhausts: false,
+    effects: [
+      { kind: "apply_power", power: "mark", amount: 8, on: "target" },
+      { kind: "drain_marked_enemies" },
+    ],
+    upgradedEffects: [
+      { kind: "apply_power", power: "mark", amount: 11, on: "target" },
+      { kind: "drain_marked_enemies" },
+    ],
+    description: "使目标获得 8 层标记。随后所有敌人损失 = 各自标记层数的生命。",
+    upgradedDescription: "使目标获得 11 层标记。随后所有敌人损失 = 各自标记层数的生命。",
+  },
+  {
+    id: "havoc",
+    name: "浩劫",
+    type: "skill",
+    rarity: "common",
+    color: "red",
+    cost: 1,
+    upgradedCost: 0,
+    targeted: false,
+    exhausts: false,
+    effects: [{ kind: "play_top_card_exhaust" }],
+    upgradedEffects: [{ kind: "play_top_card_exhaust" }],
+    description: "打出你抽牌堆顶的那张牌，随后将其消耗。",
+    upgradedDescription: "打出你抽牌堆顶的那张牌，随后将其消耗。",
+  },
+
   // —— 敌人塞进牌组的废牌 / 伤口（不可打出）——
   {
     id: "miracle",

--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -938,6 +938,37 @@ function applyEffect(
       // 终局：实际的结束回合在 playCard 收尾处检测本效果后触发，这里不做事。
       break;
     }
+    case "drain_marked_enemies": {
+      // 点穴：所有敌人损失 = 各自标记层数的生命（无视格挡）。
+      if (actor.side === "player") {
+        for (const enemy of combat.enemies) {
+          const marked = getPower(enemy.powers, "mark");
+          if (enemy.hp > 0 && marked > 0) {
+            enemy.hp = Math.max(0, enemy.hp - marked);
+          }
+        }
+      }
+      break;
+    }
+    case "play_top_card_exhaust": {
+      // 浩劫：打出抽牌堆顶的一张牌（若需目标则随机选存活敌人），随后消耗它。
+      if (actor.side === "player" && combat.drawPile.length > 0) {
+        const top = combat.drawPile.pop()!;
+        const topDef = getCardDef(top.defId);
+        let topTarget: number | null = null;
+        if (topDef.targeted) {
+          const living = combat.enemies
+            .map((enemy, index) => ({ enemy, index }))
+            .filter(entry => entry.enemy.hp > 0);
+          if (living.length > 0) {
+            topTarget = living[nextInt(state.rng, living.length)]!.index;
+          }
+        }
+        applyEffects(state, effectsOf(topDef, top.upgraded), { side: "player" }, topTarget, 0, top);
+        exhaustCard(state, top);
+      }
+      break;
+    }
     case "bonus_if_target_vulnerable": {
       // 飞踢：目标处于易伤时，获得能量并抽牌。
       if (actor.side === "player" && targetEnemyIndex !== null) {

--- a/apps/spire/src/engine/types.ts
+++ b/apps/spire/src/engine/types.ts
@@ -177,6 +177,8 @@ export type Effect =
   | { kind: "deal_damage_per_orb"; amount: number } // 场上每颗充能球对目标造成 amount 伤害（弹幕）
   | { kind: "deal_damage_per_enemy"; amount: number } // 对目标造成 amount×(存活敌人数) 伤害（保龄冲击）
   | { kind: "deal_damage_lesson"; amount: number } // 对目标造成 amount；若因此击杀，永久升级牌组中一张随机牌（研学有成）
+  | { kind: "drain_marked_enemies" } // 所有敌人损失 = 各自标记层数的生命（点穴）
+  | { kind: "play_top_card_exhaust" } // 打出抽牌堆顶的牌并消耗之（浩劫）
   | { kind: "end_turn" } // 打出结算后立即结束本回合（终局；在 playCard 收尾处检测）
   | { kind: "bonus_if_target_vulnerable"; energy: number; draw: number } // 若目标易伤：+energy 能量并抽 draw 张（飞踢）
   | { kind: "weaken_enemy_strength"; amount: number } // 使目标临时失去 amount 力量，其行动后归还（黑暗枷锁）

--- a/apps/spire/test/havoc.test.ts
+++ b/apps/spire/test/havoc.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat, playCard } from "../src/engine/combat/combat.js";
+import { getPower } from "../src/engine/powers/powers.js";
+import type { CardInstance, GameState } from "../src/engine/types.js";
+
+// 点穴（标记 + 全体按标记掉血）/ 浩劫（打出并消耗牌堆顶）。
+
+function combat(character: "watcher" | "ironclad"): GameState {
+  const s = newRun({ runId: "hv", seed: 55, character });
+  startCombat(s, "cultist");
+  s.hp = 300;
+  s.maxHp = 300;
+  s.combat!.enemies[0]!.hp = 300;
+  s.combat!.enemies[0]!.maxHp = 300;
+  return s;
+}
+
+describe("点穴：标记后全体按标记掉血", () => {
+  it("给目标 8 标记，随后其损失 8 生命（无视格挡）", () => {
+    const s = combat("watcher");
+    s.combat!.enemies[0]!.block = 100; // 掉血无视格挡
+    const before = s.combat!.enemies[0]!.hp;
+    const card: CardInstance = { uid: s.nextUid++, defId: "pressure_points", upgraded: false };
+    s.combat!.hand = [card];
+    s.combat!.energy = 9;
+    expect(playCard(s, 0, 0).ok).toBe(true);
+    expect(getPower(s.combat!.enemies[0]!.powers, "mark")).toBe(8);
+    expect(s.combat!.enemies[0]!.hp).toBe(before - 8);
+  });
+});
+
+describe("浩劫：打出并消耗抽牌堆顶", () => {
+  it("顶部是打击 → 打出造成伤害并消耗", () => {
+    const s = combat("ironclad");
+    s.combat!.enemies[0]!.block = 0;
+    s.combat!.drawPile = [{ uid: s.nextUid++, defId: "strike", upgraded: false }];
+    const before = s.combat!.enemies[0]!.hp;
+    const card: CardInstance = { uid: s.nextUid++, defId: "havoc", upgraded: false };
+    s.combat!.hand = [card];
+    s.combat!.energy = 9;
+    expect(playCard(s, 0, null).ok).toBe(true);
+    // 顶部的打击被打出（6 伤害）并消耗。
+    expect(s.combat!.enemies[0]!.hp).toBe(before - 6);
+    expect(s.combat!.exhaustPile.some(c => c.defId === "strike")).toBe(true);
+    // 浩劫自身进弃牌堆。
+    expect(s.combat!.discardPile.some(c => c.defId === "havoc")).toBe(true);
+  });
+
+  it("抽牌堆为空 → 无事发生", () => {
+    const s = combat("ironclad");
+    s.combat!.drawPile = [];
+    const card: CardInstance = { uid: s.nextUid++, defId: "havoc", upgraded: false };
+    s.combat!.hand = [card];
+    s.combat!.energy = 9;
+    expect(playCard(s, 0, null).ok).toBe(true);
+  });
+});


### PR DESCRIPTION
drain_marked_enemies（按标记掉血，复用 mark）+ play_top_card_exhaust（打出并消耗牌堆顶），2 张卡。四门禁过，spire 547 测试全绿，四角色 sim stuck=0。