### PR TITLE
chore(scheduler): 收紧 llm_chat_call 保留期至 24 小时

### DIFF
--- a/apps/agent/src/scheduler/tasks/data-retention/retention-tasks.ts
+++ b/apps/agent/src/scheduler/tasks/data-retention/retention-tasks.ts
@@ -68,7 +68,7 @@ export const RETENTION_TASKS: readonly RetentionSpec[] = [
   {
     displayName: "llm_chat_call",
     field: "createdAt",
-    days: 3,
+    days: 1,
     offsetMinutes: 5,
     getDelegate: db => db.llmChatCall,
   },


### PR DESCRIPTION
## 背景

SQLite 库膨胀到 44GB，排查发现 99% 空间来自 `llm_chat_call.native_request_payload`：该列把发给 provider 的原生请求体整包落库，内含上下文里累积的 ~200 张 base64 图片（截图/QQ图），每轮随全量历史重复序列化，平均约 **31MB/行**。已手动清空该表 + VACUUM，库从 44GB 降到 473MB。

## 改动

将数据保留清单里 `llm_chat_call` 的保留窗口从 `days: 3` 收紧到 `days: 1`（只保留最近 24 小时），减小该表峰值占用。

- 单行改动，仅 [retention-tasks.ts](apps/agent/src/scheduler/tasks/data-retention/retention-tasks.ts)。
- 保留清单按设计是纯代码常量，不涉及 config.yaml / schema 同步。
- 分块删除机制（每批 5000 行、批间让路）不变，不会一次性大删拖垮 agent。

## 验证

build / typecheck / lint(0 error) / format 全绿。

## 备注

这是最简治理，止住继续膨胀。根因（native payload 内联 base64）后续可另做「落库前剥离 base64」根治。