### PR TITLE
feat(spire): 军备（补完标准卡池最后一张）

### DIFF
--- a/apps/spire/src/engine/cards/cards.ts
+++ b/apps/spire/src/engine/cards/cards.ts
@@ -5756,6 +5756,27 @@ const CARD_LIST: CardDef[] = [
     upgradedDescription: "充能 3 颗闪电球。此后你的闪电球伤害命中所有敌人。",
   },
 
+  {
+    id: "armaments",
+    name: "军备",
+    type: "skill",
+    rarity: "common",
+    color: "red",
+    cost: 1,
+    targeted: false,
+    exhausts: false,
+    effects: [
+      { kind: "gain_block", amount: 5 },
+      { kind: "upgrade_hand_cards", all: false },
+    ],
+    upgradedEffects: [
+      { kind: "gain_block", amount: 5 },
+      { kind: "upgrade_hand_cards", all: true },
+    ],
+    description: "获得 5 点格挡。升级你手牌中的一张牌，本场战斗内有效。",
+    upgradedDescription: "获得 5 点格挡。升级你手牌中的所有牌，本场战斗内有效。",
+  },
+
   // —— 敌人塞进牌组的废牌 / 伤口（不可打出）——
   {
     id: "miracle",

--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -1236,6 +1236,22 @@ function applyEffect(
       }
       break;
     }
+    case "upgrade_hand_cards": {
+      // 军备：升级手牌——all 则全部，否则升级一张未升级的牌（自动取第一张）。
+      if (actor.side === "player") {
+        if (effect.all) {
+          for (const card of combat.hand) {
+            card.upgraded = true;
+          }
+        } else {
+          const target = combat.hand.find(card => !card.upgraded);
+          if (target) {
+            target.upgraded = true;
+          }
+        }
+      }
+      break;
+    }
     case "schedule_bomb": {
       // 炸弹：预约在若干回合后对所有敌人造成伤害。
       if (actor.side === "player") {

--- a/apps/spire/src/engine/types.ts
+++ b/apps/spire/src/engine/types.ts
@@ -206,6 +206,7 @@ export type Effect =
   | { kind: "gain_random_potion" } // 获得一瓶随机药水（炼金）
   | { kind: "transmutation" } // X 费：将 X 张随机无色牌加入手牌，本场费用视为 0（嬗变）
   | { kind: "upgrade_all_cards" } // 本场剩余时间内升级你所有的牌（神化）
+  | { kind: "upgrade_hand_cards"; all: boolean } // 升级手牌：all=全部，否则升级一张（军备）
   | { kind: "schedule_bomb"; turns: number; damage: number } // turns 回合后对所有敌人造成 damage（炸弹）
   | { kind: "add_random_cards_to_draw"; pool: "skill" | "attack"; count: number } // 将 count 张随机牌洗入抽牌堆，费用视为 0（蜕变/变形）
   | { kind: "fission" } // 唤醒所有充能球，每唤醒一颗获得 1 能量并抽 1 张（裂变）

--- a/apps/spire/test/armaments.test.ts
+++ b/apps/spire/test/armaments.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat, playCard } from "../src/engine/combat/combat.js";
+import type { CardInstance, GameState } from "../src/engine/types.js";
+
+// 军备：格挡 + 升级手牌（base 一张 / upgraded 全部）。
+
+function combat(): GameState {
+  const s = newRun({ runId: "arm", seed: 63, character: "ironclad" });
+  startCombat(s, "cultist");
+  s.hp = 300;
+  s.maxHp = 300;
+  return s;
+}
+
+describe("军备：格挡并升级手牌", () => {
+  it("base 升级一张手牌", () => {
+    const s = combat();
+    s.combat!.playerBlock = 0;
+    const a: CardInstance = { uid: s.nextUid++, defId: "strike", upgraded: false };
+    const b: CardInstance = { uid: s.nextUid++, defId: "defend", upgraded: false };
+    s.combat!.hand = [{ uid: s.nextUid++, defId: "armaments", upgraded: false }, a, b];
+    s.combat!.energy = 9;
+    expect(playCard(s, 0, null).ok).toBe(true);
+    expect(s.combat!.playerBlock).toBe(5);
+    // 恰好升级一张（第一张未升级的 strike）。
+    expect([a.upgraded, b.upgraded].filter(Boolean)).toHaveLength(1);
+    expect(a.upgraded).toBe(true);
+  });
+
+  it("upgraded 升级手牌全部", () => {
+    const s = combat();
+    const a: CardInstance = { uid: s.nextUid++, defId: "strike", upgraded: false };
+    const b: CardInstance = { uid: s.nextUid++, defId: "defend", upgraded: false };
+    s.combat!.hand = [{ uid: s.nextUid++, defId: "armaments", upgraded: true }, a, b];
+    s.combat!.energy = 9;
+    expect(playCard(s, 0, null).ok).toBe(true);
+    expect(a.upgraded).toBe(true);
+    expect(b.upgraded).toBe(true);
+  });
+});


### PR DESCRIPTION
mega-sweep 复查后仅剩这一张标准卡（军备）。四门禁过，spire 605 测试全绿，四角色 sim stuck=0。补完即标准卡池全量。