### PR TITLE
fix(qq): 修复 open_conversation 拉历史缺 message_seq 报「消息undefined不存在」

### DIFF
--- a/apps/agent/src/agent/apps/qq/qq.app.ts
+++ b/apps/agent/src/agent/apps/qq/qq.app.ts
@@ -652,6 +652,20 @@ export class QqApp implements App, ForegroundInputSource {
     if (this.recentMessageLimit <= 0) {
       return [];
     }
+    // 拉历史失败不该让 open_conversation 整个硬失败：NapCat 抽风（如锚点消息缺失报
+    // 「消息...不存在」）时降级为「暂无最近消息」，会话照常打开、缓冲里的未读仍会兜底展示。
+    try {
+      return await this.fetchRecentFromNapcat(conversation);
+    } catch (error) {
+      logger.errorWithCause("Failed to fetch recent messages for conversation", error, {
+        event: "agent.qq.fetch_recent_failed",
+        conversationId: conversation.id,
+      });
+      return [];
+    }
+  }
+
+  private async fetchRecentFromNapcat(conversation: Conversation): Promise<ConversationMessage[]> {
     if (conversation.kind === "group") {
       const groupId = parseConversationGroupId(conversation.id);
       return groupId

--- a/apps/agent/src/napcat/application/napcat-gateway.impl.service.ts
+++ b/apps/agent/src/napcat/application/napcat-gateway.impl.service.ts
@@ -470,6 +470,9 @@ export class DefaultNapcatGatewayService implements NapcatGatewayService {
 
     const data = await this.transport.request("get_group_msg_history", {
       group_id: groupIdResult.data,
+      // message_seq=0 = 从最新一条往前取（OneBot/NapCat 约定）。缺省时 NapCat 会按
+      // undefined 去定位锚点消息、报「消息undefined不存在」，故必须显式给锚点。
+      message_seq: 0,
       count: countResult.data,
     });
 
@@ -516,11 +519,13 @@ export class DefaultNapcatGatewayService implements NapcatGatewayService {
     const params: Record<string, unknown> = {
       user_id: userIdResult.data,
       count: countResult.data,
+      // 同 get_group_msg_history：缺省 message_seq 会让 NapCat 按 undefined 查锚点报错，
+      // 未显式指定时以 0 = 从最新一条往前取。
+      message_seq:
+        typeof input.messageSeq === "number" && Number.isFinite(input.messageSeq)
+          ? Math.trunc(input.messageSeq)
+          : 0,
     };
-
-    if (typeof input.messageSeq === "number" && Number.isFinite(input.messageSeq)) {
-      params.message_seq = Math.trunc(input.messageSeq);
-    }
 
     const data = await this.transport.request("get_friend_msg_history", params);
     const historyResult = GroupMessageHistoryResponseSchema.safeParse(data ?? {});

--- a/apps/agent/test/agent/apps/qq/qq.app.test.ts
+++ b/apps/agent/test/agent/apps/qq/qq.app.test.ts
@@ -1054,7 +1054,7 @@ describe("QqApp 前台实时输入（issue #251）", () => {
     expect(input?.text).toContain("（更早 3 条未读未展示，其中有人 @ 你）");
   });
 
-  it("fetch 抛错：未读原封不动（消费只发生在成功路径）", async () => {
+  it("fetch 抛错：降级为空历史、会话照常打开、缓冲未读兜底展示（不硬失败）", async () => {
     const gateway = fakeGateway({
       getRecentGroupMessages: vi.fn().mockRejectedValue(new Error("napcat 挂了")),
     });
@@ -1067,11 +1067,11 @@ describe("QqApp 前台实时输入（issue #251）", () => {
       data: fgMessage("别丢我", { messageId: 91 }),
     });
 
-    await expect(app.openConversation("qq_group:1")).rejects.toThrow("napcat 挂了");
-
-    // 消息仍在：之后列表里未读还在（这里用退化补推间接验证——消息未被吞）。
-    const onFocusContent = (await app.onFocus())[0];
-    expect("content" in onFocusContent ? onFocusContent.content : "").toContain("未读 1");
+    // 拉历史失败不再让 open 硬抛错：降级为空历史，会话照常打开。空历史 + 有缓冲未读时走
+    // 「退化为直接展示缓冲」路径，消息不被静默吞——当场兜底展示，而非丢弃。
+    const opened = await app.openConversation("qq_group:1");
+    expect(opened.ok).toBe(true);
+    expect(opened.content).toContain("别丢我");
   });
 });
 

--- a/apps/agent/test/napcat/napcat-gateway.impl.service.test.ts
+++ b/apps/agent/test/napcat/napcat-gateway.impl.service.test.ts
@@ -977,6 +977,7 @@ describe("DefaultNapcatGatewayService", () => {
     expect(sentPayload.action).toBe("get_group_msg_history");
     expect(sentPayload.params).toEqual({
       group_id: "987654",
+      message_seq: 0,
       count: 2,
     });
 


### PR DESCRIPTION
## 问题

小镜调 `open_conversation` 打开一个**首次进入**的 QQ 会话时报错：

```
invoke 子工具 open_conversation 调用失败：消息undefined不存在。
```

## 根因

`open_conversation` → `enterConversation` → `fetchRecent` 会向 NapCat 发
`get_group_msg_history` / `get_friend_msg_history`，**只带 `group_id/user_id + count`，没带 `message_seq`**。NapCat 按缺省的 `message_seq`（JS `undefined`）去定位「从哪条消息往前取历史」的锚点，字符串插值成 `消息undefined不存在` 报错回来。这个 `BizError` 全链路没被 catch，被 InvokeTool 兜底成上面那句硬失败。

文案 `消息undefined不存在` 不是本仓库文案，是 NapCat 经 `response.wording` 回传，在 `transport.ts` 包成 BizError 抛出。

## 修复

**A（治本）** `getRecentGroupMessages` / `getRecentPrivateMessages` 显式带 `message_seq: 0`（OneBot/NapCat 约定 `0 = 从最新一条往前取`），给 NapCat 合法锚点。私聊路径保留「显式传入的 seq 优先」。

**B（兜底）** `fetchRecent` 拉历史失败不再让 `open_conversation` 整个硬抛错：拆出 `fetchRecentFromNapcat`，外层 try/catch 记 `agent.qq.fetch_recent_failed` 日志并降级返回 `[]`。会话照常打开，缓冲里的未读走既有「空历史 + 有缓冲 → 直接展示缓冲」路径兜底展示，不静默吞。

## 影响面

- 与 KV 缓存/稳定前缀无关（工具定义、system prompt、消息序列化全不动，纯 gateway 内部 WS 参数）。
- 触发范围只在 open_conversation 首次进入某会话（拉历史）；已进入过的会话走 `consumeUnreadTail`，不碰 NapCat。
- A 的正确性依赖 NapCat 当前版本把 `message_seq: 0` 当「最新」处理（主流约定）；B 保证即使 A 在某版本没生效，`open_conversation` 也不会再硬失败，最坏只是「暂无最近消息」。

## 测试

- `napcat-gateway.impl.service.test.ts`：群历史入参断言补 `message_seq: 0`。
- `qq.app.test.ts`：原「fetch 抛错 → open 抛错」测试改写为验证新降级语义（不抛错、会话打开、缓冲未读当场兜底展示）。
- `pnpm build / typecheck / lint / format` 全绿；`pnpm test` 287 文件 1831 用例全过。