### PR TITLE
fix(napcat): SSE 关停 teardown + agent 启动 seed 好友列表（#425）

### DIFF
--- a/apps/agent/src/agent/apps/qq/qq.app.ts
+++ b/apps/agent/src/agent/apps/qq/qq.app.ts
@@ -215,6 +215,25 @@ export class QqApp implements App, ForegroundInputSource {
           }
         }),
     );
+
+    // 好友列表 seed（issue #425）：napcat 拆成独立进程后只在好友列表**变化**时推
+    // friend_list_updated，agent 单独重启（napcat 不重启）后收不到已有列表 → 私聊会话列表空到
+    // 下一次列表变化 / 收到私聊。启动时主动拉一次 seed，让重启后私聊会话尽快可见。
+    // **fire-and-forget，不阻塞启动**：getFriendList 在 napcat 未就绪时会走 HTTP 超时，不该拖住
+    // agent 起服；seed 只 upsert 私聊会话、幂等无序，后台完成即可（期间来的私聊消息也会各自
+    // ensurePrivateConversation，不依赖 seed 先到）。拉不到就等下一次 friend_list_updated 回填。
+    void this.seedPrivateConversationsFromFriendList();
+  }
+
+  private async seedPrivateConversationsFromFriendList(): Promise<void> {
+    try {
+      const friends = await this.napcatGateway.getFriendList?.();
+      if (friends) {
+        this.handleNapcatEvent({ type: "napcat_friend_list_updated", data: { friends } });
+      }
+    } catch {
+      // 好友列表拉不到（napcat 未就绪等）就退化，等下一次 friend_list_updated 事件回填。
+    }
   }
 
   /**

--- a/apps/agent/test/agent/apps/qq/qq.app.test.ts
+++ b/apps/agent/test/agent/apps/qq/qq.app.test.ts
@@ -132,6 +132,26 @@ describe("QqApp", () => {
     expect("content" in content ? content.content : "").toContain("产品群");
   });
 
+  // issue #425：napcat 只在好友列表变化时推事件，agent 单独重启后收不到已有列表。启动时主动
+  // 拉一次 seed，让私聊会话重启后立刻可见（否则要等下次列表变化 / 收到私聊）。
+  it("seeds private conversations from the friend list on startup", async () => {
+    const napcatGateway = fakeGateway({
+      getFriendList: vi
+        .fn()
+        .mockResolvedValue([{ userId: "654321", nickname: "老王", remark: "王哥" }]),
+    });
+    const app = createApp(new FakeScheduler(), vi.fn(), { napcatGateway });
+    await app.onStartup();
+    // seed 是 fire-and-forget（不阻塞启动），waitFor 等后台拉取完成后断言。
+    await vi.waitFor(async () => {
+      const content = (await app.onFocus())[0];
+      const text = "content" in content ? content.content : "";
+      // 私聊会话现于列表：显示名取备注、id 为私聊会话 id。
+      expect(text).toContain("王哥");
+      expect(text).toContain("qq_private:654321");
+    });
+  });
+
   // napcat 拆成独立进程后（issue #347），QQ App 不再持有网关生命周期（WS 归 kagami-napcat，
   // 入站订阅 + 关停归 server-runtime）。原「owns the napcat gateway lifecycle」用例随之删除。
 

--- a/apps/napcat/src/app/napcat-runtime.ts
+++ b/apps/napcat/src/app/napcat-runtime.ts
@@ -70,6 +70,8 @@ export type NapcatRuntime = {
   port: number;
   /** 停 prune 定时器。 */
   stopPrune: () => void;
+  /** 结束所有活 SSE 连接（关停 teardown，避免 app.close 挂 keep-alive 长连接）。 */
+  closeSubscribers: () => void;
 };
 
 /**
@@ -160,5 +162,6 @@ export async function buildNapcatRuntime(): Promise<NapcatRuntime> {
     gateway,
     port: config.services.napcat.port,
     stopPrune: () => clearInterval(pruneTimer),
+    closeSubscribers: () => broadcaster.closeAll(),
   };
 }

--- a/apps/napcat/src/application/napcat-event-broadcaster.ts
+++ b/apps/napcat/src/application/napcat-event-broadcaster.ts
@@ -12,6 +12,8 @@ export type NapcatEventSubscriber = {
   deliver(outboxEvent: NapcatOutboxEvent): void;
   /** 心跳注释帧，用于对端半开检测。 */
   heartbeat(): void;
+  /** 关停时主动结束底层连接（end res），让 app.close() 不必等 keep-alive 长连接超时。 */
+  close(): void;
 };
 
 /**
@@ -39,6 +41,22 @@ export class NapcatEventBroadcaster {
   public remove(subscriber: NapcatEventSubscriber): void {
     this.subscribers.delete(subscriber);
     if (this.subscribers.size === 0 && this.heartbeatTimer !== null) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+  }
+
+  /**
+   * 关停时结束所有活连接：逐个 close（end res），清空订阅集、停心跳。没有这一步，hijack 的
+   * keep-alive SSE 长连接会让 `app.close()` 挂到强退超时（issue #425）。close 触发的 res "close"
+   * 事件还会各自回调 remove（幂等）。
+   */
+  public closeAll(): void {
+    for (const subscriber of [...this.subscribers]) {
+      this.safe(subscriber, () => subscriber.close());
+    }
+    this.subscribers.clear();
+    if (this.heartbeatTimer !== null) {
       clearInterval(this.heartbeatTimer);
       this.heartbeatTimer = null;
     }

--- a/apps/napcat/src/http/napcat-events.handler.ts
+++ b/apps/napcat/src/http/napcat-events.handler.ts
@@ -49,13 +49,18 @@ export class NapcatEventsHandler {
       const lastEventId = parseLastEventId(request);
       const subscriber = new NapcatSseSubscriber({
         write: chunk => res.write(chunk),
+        close: () => res.end(),
         outboxDao: this.outboxDao,
         lastEventId,
       });
 
       // 先 add：回放期间到达的实时事件先进订阅者缓冲，不会丢、也不会抢先推进游标。
       this.broadcaster.add(subscriber);
-      res.on("close", () => this.broadcaster.remove(subscriber));
+      // 客户端断连也置位 subscriber.closed（幂等），让在飞的 start() 回放停手、不写已关的 res。
+      res.on("close", () => {
+        subscriber.close();
+        this.broadcaster.remove(subscriber);
+      });
 
       try {
         await subscriber.start();
@@ -73,6 +78,8 @@ export class NapcatEventsHandler {
 
 export type NapcatSseSubscriberDeps = {
   write: (chunk: string) => void;
+  /** 结束底层连接（关停 teardown 用）。缺省为 no-op（单测里不必接真 res）。 */
+  close?: () => void;
   outboxDao: NapcatEventOutboxDao;
   lastEventId: number;
 };
@@ -84,18 +91,25 @@ export type NapcatSseSubscriberDeps = {
  */
 export class NapcatSseSubscriber implements NapcatEventSubscriber {
   private readonly write: (chunk: string) => void;
+  private readonly closeConnection: () => void;
   private readonly outboxDao: NapcatEventOutboxDao;
   private phase: "buffering" | "live" = "buffering";
   private readonly buffer: NapcatOutboxEvent[] = [];
   private lastWrittenSeq: number;
+  /** 连接已结束（socket close / 关停 teardown）。置位后所有写与在飞回放短路，避免写已 end 的 res。 */
+  private closed = false;
 
-  public constructor({ write, outboxDao, lastEventId }: NapcatSseSubscriberDeps) {
+  public constructor({ write, close, outboxDao, lastEventId }: NapcatSseSubscriberDeps) {
     this.write = write;
+    this.closeConnection = close ?? (() => {});
     this.outboxDao = outboxDao;
     this.lastWrittenSeq = lastEventId;
   }
 
   public deliver(outboxEvent: NapcatOutboxEvent): void {
+    if (this.closed) {
+      return;
+    }
     if (this.phase === "buffering") {
       this.buffer.push(outboxEvent);
       return;
@@ -104,7 +118,18 @@ export class NapcatSseSubscriber implements NapcatEventSubscriber {
   }
 
   public heartbeat(): void {
+    if (this.closed) {
+      return;
+    }
     this.write(": keepalive\n\n");
+  }
+
+  public close(): void {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    this.closeConnection();
   }
 
   /** 回放 outbox 缺口 → flush 缓冲 → 转实时。 */
@@ -116,7 +141,9 @@ export class NapcatSseSubscriber implements NapcatEventSubscriber {
     const requestedFrom = this.lastWrittenSeq;
     let cursor = requestedFrom;
     let gapChecked = false;
-    while (cursor < high) {
+    // 关停 teardown 可能在回放中途 close 连接：每批前检查，已关就停手，别对 end 掉的 res 再写
+    // （否则 ERR_STREAM_WRITE_AFTER_END）。writeIfNew 自身也短路，双保险。
+    while (cursor < high && !this.closed) {
       const batch = await this.outboxDao.listAfter(cursor, REPLAY_BATCH_SIZE);
       if (batch.length === 0) {
         break;
@@ -152,7 +179,7 @@ export class NapcatSseSubscriber implements NapcatEventSubscriber {
   }
 
   private writeIfNew(outboxEvent: NapcatOutboxEvent): void {
-    if (outboxEvent.seq <= this.lastWrittenSeq) {
+    if (this.closed || outboxEvent.seq <= this.lastWrittenSeq) {
       return;
     }
     this.write(serializeEventFrame(outboxEvent));

--- a/apps/napcat/src/index.ts
+++ b/apps/napcat/src/index.ts
@@ -14,8 +14,9 @@ runService({
       // 仅绑 127.0.0.1：只有 agent（出站 RPC + SSE 订阅）在同机 reach 它，绝不对外。
       bindHost: "127.0.0.1",
       port: runtime.port,
-      // 关停：先停网关（关 WS）与 prune，再关 DB。
-      beforeClose: [() => runtime.gateway.stop()],
+      // 关停：先结束活 SSE 连接（否则 keep-alive 长连接让 app.close 挂到强退超时，issue #425）+
+      // 停网关（关 WS），cleanup 再停 prune、关 DB。
+      beforeClose: [() => runtime.closeSubscribers(), () => runtime.gateway.stop()],
       cleanup: [() => runtime.stopPrune(), () => closeDb(runtime.database)],
       // WS 连接在 listen 之后建立：health 立即可用，NapCat 连接（可能重试）不阻塞启动。
       afterListen: () => {

--- a/apps/napcat/test/napcat-event-broadcaster.test.ts
+++ b/apps/napcat/test/napcat-event-broadcaster.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import type { NapcatAgentEvent, NapcatOutboxEvent } from "@kagami/napcat-api/event";
+import { initLoggerRuntime } from "@kagami/kernel/logger/runtime";
+import {
+  NapcatEventBroadcaster,
+  type NapcatEventSubscriber,
+} from "../src/application/napcat-event-broadcaster.js";
+
+// safe() 摘除失败订阅者时会 logger.warn；初始化一个空 sink 的 runtime，避免未初始化时抛。
+initLoggerRuntime({ sinks: [] });
+
+function outbox(seq: number): NapcatOutboxEvent {
+  const event: NapcatAgentEvent = { type: "napcat_friend_list_updated", data: { friends: [] } };
+  return { seq, event };
+}
+
+/** 记录各回调调用次数的假订阅者。 */
+function fakeSubscriber(): NapcatEventSubscriber & {
+  deliver: ReturnType<typeof vi.fn>;
+  heartbeat: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+} {
+  return { deliver: vi.fn(), heartbeat: vi.fn(), close: vi.fn() };
+}
+
+describe("NapcatEventBroadcaster", () => {
+  it("publish 扇出给所有活订阅者", () => {
+    const b = new NapcatEventBroadcaster();
+    const a = fakeSubscriber();
+    const c = fakeSubscriber();
+    b.add(a);
+    b.add(c);
+    b.publish(outbox(1));
+    expect(a.deliver).toHaveBeenCalledWith(outbox(1));
+    expect(c.deliver).toHaveBeenCalledWith(outbox(1));
+  });
+
+  it("deliver 抛错的订阅者被摘除，不影响其余", () => {
+    const b = new NapcatEventBroadcaster();
+    const bad = fakeSubscriber();
+    bad.deliver.mockImplementation(() => {
+      throw new Error("write EPIPE");
+    });
+    const good = fakeSubscriber();
+    b.add(bad);
+    b.add(good);
+    b.publish(outbox(1));
+    // bad 已被摘除：下一次 publish 不再调用它，good 照常收。
+    b.publish(outbox(2));
+    expect(bad.deliver).toHaveBeenCalledTimes(1);
+    expect(good.deliver).toHaveBeenCalledTimes(2);
+  });
+
+  it("closeAll 结束所有连接并清空订阅集（关停 teardown）", () => {
+    const b = new NapcatEventBroadcaster();
+    const a = fakeSubscriber();
+    const c = fakeSubscriber();
+    b.add(a);
+    b.add(c);
+    b.closeAll();
+    expect(a.close).toHaveBeenCalledTimes(1);
+    expect(c.close).toHaveBeenCalledTimes(1);
+    // 清空后再 publish 不会触达任何人。
+    b.publish(outbox(1));
+    expect(a.deliver).not.toHaveBeenCalled();
+    expect(c.deliver).not.toHaveBeenCalled();
+  });
+
+  it("closeAll 对 close 抛错的订阅者也稳健（逐个 safe 包裹）", () => {
+    const b = new NapcatEventBroadcaster();
+    const bad = fakeSubscriber();
+    bad.close.mockImplementation(() => {
+      throw new Error("already destroyed");
+    });
+    const good = fakeSubscriber();
+    b.add(bad);
+    b.add(good);
+    expect(() => b.closeAll()).not.toThrow();
+    expect(good.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/napcat/test/napcat-events-subscriber.test.ts
+++ b/apps/napcat/test/napcat-events-subscriber.test.ts
@@ -50,6 +50,27 @@ describe("NapcatSseSubscriber replay", () => {
     expect(writtenSeqs(chunks)).toEqual([3, 4]);
   });
 
+  it("close 后一切写短路（关停 teardown 不写已 end 的 res）", async () => {
+    const chunks: string[] = [];
+    let ended = false;
+    const sub = new NapcatSseSubscriber({
+      write: c => chunks.push(c),
+      close: () => {
+        ended = true;
+      },
+      outboxDao: new FakeOutboxDao([outbox(1), outbox(2)]),
+      lastEventId: 0,
+    });
+    await sub.start();
+    const before = chunks.length;
+    sub.close();
+    expect(ended).toBe(true);
+    // close 后 live 事件 / 心跳都不再写。
+    sub.deliver(outbox(3));
+    sub.heartbeat();
+    expect(chunks.length).toBe(before);
+  });
+
   it("高水位有界：回放只到 start 瞬间的 latestSeq，之后的实时事件走 buffer 不进回放", async () => {
     // 回放期间 deliver 进来的实时事件（seq 5、6）已在 dao 里（模拟持续入站），但快照 high=4，
     // 回放止于 4；5、6 经 buffer 补发。没有高水位就会一直 listAfter 追下去（review 发现的死循环）。


### PR DESCRIPTION
napcat 拆分上线（[#427](https://github.com/KisinTheFlame/kagami/pull/427)）后的两条健壮性修复，来自那次三方 opus + Codex review 的 follow-up 清单 [#425](https://github.com/KisinTheFlame/kagami/issues/425)。

## 修了什么

**1. SSE 关停 teardown**
napcat 的 SSE 端点用 `reply.hijack()` 裸 res + keep-alive，关停时从不 `res.end()` → `app.close()` 会等这条 agent 长连接结束，最坏挂满 10s 强退超时。现在：
- broadcaster 加 `closeAll()`：逐个结束活连接、清空订阅集、停心跳；napcat `index.ts` 的 `beforeClose` 先调它再停网关。
- 订阅者加 `closed` 标志：close 后所有写与**在飞的 `start()` 回放**都短路，避免对已 end 的 res 再写（`ERR_STREAM_WRITE_AFTER_END`）；客户端断连（res `close`）也置位，覆盖「回放中途断连」。

**2. agent 启动 seed 好友列表**
napcat 拆进程后只在好友列表**变化**时推 `friend_list_updated`。agent 单独重启（napcat 不重启）收不到已有列表 → 私聊会话列表空到下次变化/收到私聊。现在 `QqApp.onStartup` 主动 seed 一次好友列表。**fire-and-forget，真不阻塞启动**（getFriendList 在 napcat 未就绪时会走 HTTP 超时，不该拖住 agent 起服；seed 只 upsert 私聊会话、幂等无序，后台完成即可）。

## Review
Codex 跨模型对抗审查抓出两个真问题，都已修：
- write-after-end（关停/断连时在飞回放写已 end 的 res）→ closed 标志全链路短路。
- 好友 seed 注释称「不阻塞」实为 `await` → 改真后台 fire-and-forget。

## 测试
新增回归：broadcaster（扇出 / 失败摘除 / closeAll teardown / close 抛错稳健，**原零覆盖**）+ subscriber（close 后写短路）+ QqApp 好友 seed。全量 `build/typecheck/lint/format` 全绿，测试 1833 全过。

## 留在 #425 的
崩溃重放 messageId 幂等（at-least-once 固有权衡、窗口极小）、SSE 背压（单快消费方、理论风险）——不值得塞进这个干净 PR。

Part of #425, #347
