### PR TITLE
fix(napcat): SSE 背压保护（#425）

### DIFF
--- a/apps/napcat/src/http/napcat-events.handler.ts
+++ b/apps/napcat/src/http/napcat-events.handler.ts
@@ -13,6 +13,9 @@ const logger = new AppLogger({ source: "napcat.events-handler" });
 /** 单次回放的批大小（避免一口气把超长缺口全查进内存）。 */
 const REPLAY_BATCH_SIZE = 500;
 
+/** SSE 背压宽限期：res.write 背压后等 drain 这么久，还不 drain 就销毁连接（消费方视为真死/半开）。 */
+const SSE_BACKPRESSURE_GRACE_MS = 15_000;
+
 type NapcatEventsHandlerDeps = {
   broadcaster: NapcatEventBroadcaster;
   outboxDao: NapcatEventOutboxDao;
@@ -46,9 +49,15 @@ export class NapcatEventsHandler {
         "X-Accel-Buffering": "no",
       });
 
+      const write = createBackpressureAwareWrite(res, SSE_BACKPRESSURE_GRACE_MS, () => {
+        logger.warn("SSE 背压超时，销毁连接等 agent 重连回放", {
+          event: "napcat.sse.backpressure_timeout",
+        });
+      });
+
       const lastEventId = parseLastEventId(request);
       const subscriber = new NapcatSseSubscriber({
-        write: chunk => res.write(chunk),
+        write,
         close: () => res.end(),
         outboxDao: this.outboxDao,
         lastEventId,
@@ -185,6 +194,48 @@ export class NapcatSseSubscriber implements NapcatEventSubscriber {
     this.write(serializeEventFrame(outboxEvent));
     this.lastWrittenSeq = outboxEvent.seq;
   }
+}
+
+/** 背压写所需的 res 最小面（便于单测注入假 res）。 */
+type BackpressureWritable = {
+  write(chunk: string): boolean;
+  once(event: "close", listener: () => void): void;
+  destroy(): void;
+};
+
+/**
+ * 背压感知的写入（issue #425）：`res.write` 返回 false = 内核发送缓冲已满、消费方跟不上。慢/半死
+ * 消费方若一直不 drain，无脑续写会让 napcat 内存无界增长。
+ *
+ * 对策：一旦背压就**停止后续写**（硬约束内存——不再往缓冲堆新帧），挂宽限期后 destroy 连接。
+ * agent 侧看门狗会重连、带 Last-Event-ID 从 outbox 回放缺口（**agent 自己的持久游标**才是回放起点，
+ * outbox 是 durability 事实源，故停写期间的帧一条不丢）。destroy 后 `dead` 短路一切写，杜绝写已毁
+ * 的 res（write-after-destroy）。客户端先断连（res close）则清 timer，不留悬挂定时器 / 虚假日志。
+ * onTimeout 在 destroy 前回调（记日志用）。正常快消费方永不触发。
+ */
+export function createBackpressureAwareWrite(
+  res: BackpressureWritable,
+  graceMs: number,
+  onTimeout?: () => void,
+): (chunk: string) => void {
+  let dead = false;
+  return (chunk: string): void => {
+    if (dead) {
+      return;
+    }
+    if (res.write(chunk)) {
+      return;
+    }
+    // 触发背压：这一帧 Node 已缓冲（不丢），但立刻停写后续帧。宽限期给已缓冲数据一点 flush 时间，
+    // 到期 destroy —— agent 重连回放。若客户端在宽限期内先断连，清掉 timer 即可。
+    dead = true;
+    const timer = setTimeout(() => {
+      onTimeout?.();
+      res.destroy();
+    }, graceMs);
+    timer.unref?.();
+    res.once("close", () => clearTimeout(timer));
+  };
 }
 
 /**

--- a/apps/napcat/test/napcat-events-subscriber.test.ts
+++ b/apps/napcat/test/napcat-events-subscriber.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import type { NapcatAgentEvent, NapcatOutboxEvent } from "@kagami/napcat-api/event";
-import { NapcatSseSubscriber } from "../src/http/napcat-events.handler.js";
+import {
+  NapcatSseSubscriber,
+  createBackpressureAwareWrite,
+} from "../src/http/napcat-events.handler.js";
 import type { NapcatEventOutboxDao } from "../src/infra/napcat-event-outbox.dao.js";
 import { initLoggerRuntime } from "@kagami/kernel/logger/runtime";
 import type { LogEvent, LogSink } from "@kagami/kernel/logger/types";
@@ -131,5 +134,54 @@ describe("NapcatSseSubscriber replay", () => {
     const gap = logs.find(l => l.metadata?.event === "napcat.events.replay_gap");
     expect(gap).toBeDefined();
     expect(gap?.metadata?.lostCount).toBe(4); // 3,4,5,6
+  });
+});
+
+describe("createBackpressureAwareWrite", () => {
+  it("write 不背压（返回 true）时永不销毁连接", () => {
+    vi.useFakeTimers();
+    const res = { write: vi.fn().mockReturnValue(true), once: vi.fn(), destroy: vi.fn() };
+    const write = createBackpressureAwareWrite(res, 15_000);
+    write("frame");
+    write("frame2");
+    vi.advanceTimersByTime(20_000);
+    expect(res.destroy).not.toHaveBeenCalled();
+    expect(res.write).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  it("背压后停写后续帧 + 宽限期到销毁连接（等 agent 重连回放）", () => {
+    vi.useFakeTimers();
+    const res = { write: vi.fn().mockReturnValue(false), once: vi.fn(), destroy: vi.fn() };
+    const onTimeout = vi.fn();
+    const write = createBackpressureAwareWrite(res, 15_000, onTimeout);
+    write("frame"); // 触发背压：这帧写了（Node 缓冲），dead 置位
+    write("frame2"); // dead 后不再 res.write（硬约束内存）
+    expect(res.write).toHaveBeenCalledTimes(1);
+    expect(res.destroy).not.toHaveBeenCalled(); // 宽限期内先不动
+    vi.advanceTimersByTime(15_000);
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+    expect(res.destroy).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
+  it("客户端在宽限期内先断连（res close）→ 清 timer，不再 destroy / 无虚假日志", () => {
+    vi.useFakeTimers();
+    let closeCb: () => void = () => {};
+    const res = {
+      write: vi.fn().mockReturnValue(false),
+      once: vi.fn((_event: "close", cb: () => void) => {
+        closeCb = cb;
+      }),
+      destroy: vi.fn(),
+    };
+    const onTimeout = vi.fn();
+    const write = createBackpressureAwareWrite(res, 15_000, onTimeout);
+    write("frame"); // 背压，挂 timer
+    closeCb(); // 客户端断连
+    vi.advanceTimersByTime(20_000);
+    expect(onTimeout).not.toHaveBeenCalled();
+    expect(res.destroy).not.toHaveBeenCalled();
+    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
napcat 拆分 follow-up [#425](https://github.com/KisinTheFlame/kagami/issues/425) 的 SSE 背压保护。

## 问题
napcat 的 SSE 端点向 agent 推流。`res.write` 返回 false = 内核发送缓冲满、消费方跟不上。慢 / 半死消费方一直不 drain 时，无脑续写会让 napcat 内存无界增长。

## 修法
`createBackpressureAwareWrite`：一旦背压就**停止写后续帧**（硬约束内存，不再往缓冲堆），挂宽限期后 `res.destroy()` 连接——agent 侧看门狗会重连、带 `Last-Event-ID` 从**自己的持久游标**从 outbox 回放缺口。outbox 是 durability 事实源，所以停写期间的帧一条不丢；内存随连接销毁释放。`dead` 标志短路一切写，杜绝写已毁的 res；客户端先断连（res `close`）则清 timer，不留悬挂定时器 / 虚假日志。正常快消费方永不触发。

## Review
Codex 跨模型对抗**两轮**把实现打磨到位：先前版本背压期仍照写（`res.write` 在 `||` 左边总被调）+ destroy 后写已毁 res，都已修（停写 + `dead` 短路）。

## 测试
背压 helper：不背压不销毁 / 背压后停写 + 超时销毁 / 客户端断连清 timer。全量 build/typecheck/lint/format 全绿，测试 1839 全过。

## 关于 #425 的第 4 条（崩溃重放幂等）
**没做，PR 只收背压**。详见 PR 讨论——这条经两轮 Codex 对抗确认无法干净修复（QqApp 未读状态优雅关停粒度持久化 vs SSE 游标逐条持久化，粒度不匹配；真崩溃 exportState 根本不跑），是 at-least-once 的固有权衡，且症状罕见 + 自愈 + 未读本就近似。是否接受为 tradeoff、还是投入更大重构，待与维护者确认。

Part of #425
