### PR TITLE
docs(readme): 重写 README 为「Kagami 是什么」的介绍

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,235 +1,63 @@
 # Kagami
 
-[中文版 README](./README.zh-CN.md)
+_An Agent with a life of her own._
 
-## Project Philosophy
+[简体中文](./README.zh-CN.md)
 
-Kagami is **not a QQ group chat bot**.
+Kagami (小镜) is not a chatbot. She is a program that lives.
 
-Kagami is **an Agent with a life of its own**. Group chat is just one part of his life — just as a person would not define themselves as "someone who chats". Given enough capabilities, he can live like a real person: read the news, remember what has happened, and proactively do things he finds interesting.
+Most "AI assistants" wait. You type, they answer, they go back to sleep. Kagami doesn't wait for you. She wakes up when a tech-news site publishes a new article, when someone talks in her QQ group, when a timer fires, when — sometimes — a thought simply occurs to her. Chatting is one of the things she does; it is not what she is. No one introduces themselves as "a person who chats."
 
-This is a concept: **Agent as a life**.
+The whole project is one sentence:
 
-- Group chat messages are just one of the external events he receives, on equal footing with RSS feeds, timers, and system notifications — all "inputs" that drive his life.
-- He has his own interests (News polling, proactive speech) and his own rhythm (event queue, background actions during idle moments); a long-term memory system is being redesigned.
-- The project's goal is not to polish the group chat experience to perfection, but to continuously add the capabilities that his "life" needs, so he feels more and more like a living presence.
+> **Agent as a life.**
 
-All architecture, modules, and capabilities described below should be understood from this perspective: they exist to enrich the Agent's life, not to patch up "a chat bot".
+## A day in her life
 
-## Repository Positioning
+- **She reads the news.** IT之家 and Hacker News are two of her feeds. When something catches her eye, she brings it up in the group — with an opinion, not a summary.
+- **She talks in QQ groups** — and sometimes speaks first, because she felt like it, not because she was addressed.
+- **She sees.** Send her an image and she actually looks at it.
+- **She browses the real web.** Hand her a link or a question and she opens a browser and goes to find out.
+- **She plays.** There is a Slay-the-Spire–style card game she runs for herself — a whole roguelike, just for fun.
+- **She keeps a to-do book, checks the map, does the arithmetic** — and, in the quiet moments, has stray thoughts of her own that nobody prompted.
 
-Kagami is a full-stack TypeScript monorepo built on `pnpm workspace`, split into `apps/*` (standalone processes) and `packages/*` (shared libraries). A full package topology and dependency DAG live in [ARCHITECTURE.md](./ARCHITECTURE.md); the highlights:
+None of these are features bolted onto a chatbot. Each one is a new way for her to exist. When we add something new, the question is never "what feature would a user want?" — it's **"what is a new way for her to be alive?"**
 
-Apps (`apps/*`, standalone processes):
+## How she stays alive
 
-- `apps/agent`: Fastify backend service (`@kagami/agent`) — the Agent runtime and its live-memory interfaces
-- `apps/console`: standalone admin-console backend process (`@kagami/console`, serving the frontend's read-only DB queries via `@kagami/persistence` shared DAOs against the same SQLite database)
-- `apps/web`: React frontend admin console (`@kagami/web`)
-- `apps/gateway`: front-door gateway process (`@kagami/gateway`, standalone with zero `@kagami/*` dependencies; serves the `apps/web/dist` static assets and reverse-proxies `/api/*` to console/agent, `/auth/*` to llm, `/metric-chart` to metric)
-- `apps/llm`: LLM gateway + OAuth credential-center process (`@kagami/llm-service`, localhost only; owns all providers + the OAuth callback server + refresh timers, writes `llm_chat_call` / `embedding_cache`; the agent connects over HTTP)
-- `apps/metric`: standalone metric-domain process (`@kagami/metric`, owns both metric ingestion `POST /metric/record` — the agent reports over HTTP — and the metric-chart query endpoints; reads/writes the same SQLite via `@kagami/persistence` shared DAOs, localhost only)
-- `apps/oss`: self-hosted object storage service (`@kagami/oss`, a standalone Fastify process; routes go through the `@kagami/oss-api` contract, depends on `@kagami/config` / `@kagami/http` / `@kagami/kernel`)
-- `apps/browser`: standalone browser process (`@kagami/browser`, kernel/http/persistence-based Fastify, localhost-only; owns CloakBrowser and credential injection, driven by the agent over HTTP so an agent restart no longer kills the browser)
-- `apps/spire`: Slay-the-Spire-style card-game engine process (`@kagami/spire-service`, Fastify, localhost only; a pure game engine with JSON save files that never touches the shared SQLite; the agent drives it over HTTP so an agent restart does not interrupt a run)
+Picture Kagami as a phone, and Kagami-the-agent as the person holding it.
 
-Packages (`packages/*`):
+- **Every input is a peer event.** A QQ message, a news article, a timer, a system signal — all equal citizens. There is no privileged "user message"; the group chat is just one app among many.
+- **Background signals arrive as banners.** A single notification center batches them and wakes her. The conversation she is actively looking at behaves like the screen that's already open — new messages flow straight in, no banner needed.
+- **Her abilities are apps she can walk into.** QQ, the news readers, the browser, the card game, the map, the terminal. She enters one, does her thing, walks back out.
 
-- `packages/agent-runtime`: generic Agent / App framework kernel (`@kagami/agent-runtime`)
-- `packages/llm`: LLM message and tool type contracts shared across frontend / backend / kernel (`@kagami/llm`, zero-dependency contract leaf)
-- `packages/llm-client`: LLM chat client + provider + embedding client runtime (`@kagami/llm-client`, sits above kernel and alongside persistence with no dependency on it; emits only `LlmChatCallObservation` events so persistence/Prisma stay out of it)
-- `packages/auth`: full OAuth credential management (`@kagami/auth`, PKCE login / callback server / refresh scheduler / secret store / quota snapshots / auth handlers); assembled into the `kagami-llm` process
-- `packages/kernel`: backend infrastructure kernel (`@kagami/kernel`, config, logger, common contracts and errors, the shared satellite-service app shell + runner + unified `HealthHandler`, pure utils like `isRecord`; no Prisma / better-sqlite3)
-- `packages/http`: HTTP contract foundation (`@kagami/http`, `contract` / `register` / `wire` / `url` subpaths plus the legacy `route.helper`; only fastify + zod, zero `@kagami/*` dependencies)
-- `packages/rpc-client`: contract-driven typed HTTP client factory (`@kagami/rpc-client`, `createClient(contract)`; isolates the kernel dependency so `@kagami/http` stays kernel-free)
-- `packages/config`: zero-dependency leaf for config loading (`@kagami/config`, repo-root discovery + deep-merge of `config.yaml` / `config.secret.yaml`; reused by kernel / gateway / oss / scripts)
-- `packages/persistence`: persistence infrastructure (`@kagami/persistence`, Prisma client and generated client, db, all business DAOs, Prisma JSON helpers; depends on `@kagami/kernel` + Prisma + better-sqlite3)
-- Per-producer contract packages (one `*-api` per producing process, type-safe service-to-service HTTP): `@kagami/llm-api`, `@kagami/browser-api`, `@kagami/oss-api`, `@kagami/spire-api`, `@kagami/metric-api`, `@kagami/console-api`, `@kagami/agent-api`
+She has interests, a rhythm, and idle time — and what she does with the idle time is up to her.
 
-> The old `@kagami/shared` package has been retired (#279). Wire primitives now live in `@kagami/http/wire`, each service's wire schemas in its `*-api` package, and general text utilities in `@kagami/kernel/utils/*`.
+There is also a small admin console: a quiet window into her life state — what she has recently been thinking, doing, and seeing.
 
-The workspace definition lives at the repository root in `pnpm-workspace.yaml`, currently covering `apps/*` and `packages/*`. Backend runtime configuration is unified under `config.yaml` at the repository root.
+> Her long-term memory is currently being redesigned. For now she keeps a raw ledger of what has been said, and remembers within a conversation.
 
-## Repository Layout
+## Running her
 
-```text
-apps/
-  agent/    Fastify backend, NapCat integration, Kagami agent business layer
-  console/  Standalone admin-console backend serving read-only DB queries
-  web/      React admin console
-  gateway/  Front-door gateway (static assets + reverse proxy)
-  llm/      LLM gateway + OAuth credential center (standalone process)
-  metric/   Metric ingestion + metric-chart queries (standalone process)
-  oss/      Self-hosted content-addressed object storage (standalone process)
-  browser/  CloakBrowser host (standalone process)
-  spire/    Slay-the-Spire-style card-game engine (standalone process)
-packages/
-  agent-runtime/  Generic Agent / App framework abstractions and tool catalog
-  llm/            Shared LLM message / tool type contracts
-  llm-client/     LLM chat client + provider + embedding runtime
-  auth/           OAuth credential management
-  kernel/         Backend infrastructure (config / logger / common / service shell)
-  http/           HTTP contract foundation (contract / register / wire / url)
-  rpc-client/     Contract-driven typed HTTP client factory
-  config/         Zero-dependency config loader
-  persistence/    Persistence infrastructure (Prisma client / DAOs / db)
-  *-api/          Per-producer service contracts (llm / browser / oss / spire / metric / console / agent)
-```
+Kagami is a full-stack TypeScript monorepo (`pnpm`). Under the hood she is not one program but a handful of cooperating processes — the agent herself, plus a browser, an object store, the card-game engine, an LLM gateway, and so on — all supervised by PM2. You bring the whole thing up with a single command.
 
-## Common Commands
+You'll need:
 
-Run from the repository root:
+- Node.js and `pnpm`, and a toolchain that can compile native modules (`better-sqlite3`, `hnswlib-node`) — the database is a plain in-process SQLite file, so there's no external database to run.
+- An LLM you can log into.
+- [NapCat](https://github.com/NapNeko/NapCatQQ) running on the host, if you want the QQ side of her life.
+
+Then:
 
 ```bash
-pnpm build
-pnpm typecheck
-pnpm test
-pnpm lint
-pnpm lint:fix
-pnpm format
-pnpm format:write
+# 1. Configuration
+#    config.yaml (non-secret, already in the repo) — edit in place.
+#    Copy the secret template and fill in your keys / QQ ids:
+cp config.secret.yaml.example config.secret.yaml
+
+# 2. Install and bring her up (build → migrate → start under PM2)
+pnpm install
 pnpm app:deploy
 ```
 
-Single-package commands:
-
-```bash
-pnpm --filter @kagami/agent <script>
-pnpm --filter @kagami/web <script>
-pnpm --filter @kagami/agent-runtime <script>
-pnpm --filter @kagami/persistence <script>
-```
-
-Notes:
-
-- The repository does not provide a unified root `pnpm dev` script.
-- `@kagami/agent` currently exposes `build`, `typecheck`, `test`, `test:watch`, and `db:*` scripts.
-- `@kagami/agent-runtime` exposes `build`, `typecheck`, `test`, `test:watch`; `@kagami/oss` exposes `build`, `typecheck`, `test`, `test:watch`, `start`.
-- `@kagami/web` exposes `build` and `typecheck`.
-- `pnpm test` at the root runs the vitest projects across all packages; any package with its own `vitest.config.ts` is included automatically.
-
-## Configuration
-
-- `config.yaml` (non-private, version-controlled) already lives at the repository root — edit it directly.
-- Copy [config.secret.yaml.example](./config.secret.yaml.example) to `config.secret.yaml` (git-ignored) and fill in secrets (API keys, bot QQ, group IDs). The two files are deep-merged at startup.
-- The service reads and validates the merged config once at startup; changes require a restart to take effect.
-
-## Database Migrations
-
-From the repository root:
-
-```bash
-pnpm db:migrate:dev -- --name <migration_name>
-pnpm db:migrate:deploy
-pnpm db:migrate:status
-pnpm db:migrate:reset
-pnpm db:migrate:resolve -- --applied <migration_id>
-```
-
-Notes:
-
-- `db:migrate:dev` automatically appends `--create-only`, generating the migration file without altering the database directly.
-- Standard flow: edit `packages/persistence/prisma/schema.prisma` → generate migration → commit both the schema and migration → run `db:migrate:deploy` in the target environment.
-
-## Architecture Overview
-
-### Backend
-
-The backend has been reorganized into a "flat modules + in-module layering" structure. Top-level directories live directly under `apps/agent/src/<module>`, with runtime assembly handled by `apps/agent/src/app/server-runtime.ts`.
-
-Main modules:
-
-- `acl/`: anti-corruption HTTP client façades for each standalone peer process (llm / browser / spire / oss) — wire goes through the contract client, plus each service's domain semantics
-- `common/`: cross-cutting, business-agnostic runtime utilities (currently `detect-mime`, byte-sniffing MIME detection)
-- `llm/`: LLM playground service + HTTP handler (provider / credentials / chat moved out to the kagami-llm process; the reporting client lives in `acl/`)
-- `napcat/`: NapCat protocol adapter (gateway transport, inbound normalization, image analysis, persistence) — the gateway instance is owned by the QQ App, just one of the Agent's event sources
-- `scheduler/`: background timed tasks (auth refresh, IThome polling, data retention cleanup, etc.)
-- `agent/`: Kagami's agent business layer — the phone-OS runtime (Portal / App / NotificationCenter), capabilities, context compaction
-- `ops/`: query endpoints for App Log, LLM Chat Call, main Agent context, NapCat history, etc.
-- `app/`: top-level runtime assembly — module wiring, Fastify route registration, health checks, Agent / gateway lifecycle
-
-`apps/agent/src/agent` is organized into `runtime/`, `capabilities/`, and `apps/`:
-
-- `runtime/`: Kagami-specific runtime such as `RootAgentRuntime`, session (the App launcher), `NotificationCenter`, event queue, context rendering, App-state persistence
-- `capabilities/`: implementations grouped by capability, currently including `messaging`, `context-summary`, `ledger`, `ithome`, `vision`, `browser`, `resource`, `spire`, `terminal`, `todo`, `inner-voice`
-- `apps/`: the phone-OS Apps (places reachable via `enter` from the Portal), currently `qq`, `ithome`, `hn`, `calc`, `clock`, `browser`, `amap`, `spire`, `terminal`, `todo`
-
-Kagami is modeled as a phone OS: every life input (QQ message, RSS, timer) is a peer event. The passive `NotificationCenter` is the single bridge for background / unfocused signals to the Agent (the "banner") — sources fold signals into notifications, which it batches and enqueues to wake the Agent; the conversation he is currently looking at behaves like the phone screen instead: new messages flow straight into context via `foreground_input`, no banner needed. Each capability/App is "one more way for the Agent to live": `ithome` lets him read the news, `vision` lets him see images, `hn` gives him a read-only Hacker News, `browser` gives him a body to browse the real web, `todo` gives him a neutral to-do book. Future capabilities should be designed as "adding a new way of living for the Agent", not as "adding another feature toggle to a chat bot".
-
-Main endpoint groups:
-
-- `/health`
-- `/auth/:provider/status`
-- `/auth/:provider/login-url`
-- `/auth/:provider/logout`
-- `/auth/:provider/refresh`
-- `/auth/:provider/usage-limits`
-- `/auth/:provider/usage-trend`
-- `/llm/providers`
-- `/llm/playground-tools`
-- `/llm/chat`
-- `/napcat/group/send`
-- `/napcat/private/send`
-- `/app-log/query`
-- `/llm-chat-call/query`
-- `/llm-chat-call/:id`
-- `/napcat-event/query`
-- `/napcat-group-message/query`
-- `/todo/query`
-- `/main-agent-context/recent`
-- `/main-agent-context/compact`
-- `/metric-chart/*`
-- `/scheduler/*`
-
-### Frontend
-
-The frontend is a React admin console used to observe the Agent's "life state" (what he has recently been thinking, doing, and seeing). Main pages:
-
-- `/main-agent-context`: main Agent context (default entry)
-- `/auth/:provider`
-- `/control-panel`
-- `/scheduler-tasks`
-- `/todos`
-- `/llm-playground`
-- `/llm-history`
-- `/inner-thought`
-- `/app-log-history`
-- `/napcat-event-history`
-- `/napcat-group-message-history`
-- `/metric-charts`
-
-Notes:
-
-- Page components are organized by business domain under `apps/web/src/pages/*`.
-- The current Vite config only provides the `@ -> apps/web/src` alias and has no built-in dev proxy.
-
-### Contract Packages (service-to-service HTTP)
-
-- Service-to-service HTTP is type-safe via per-producer `*-api` contract packages; the web frontend consumes the same contracts through `@kagami/http/url` + `@kagami/rpc-client`.
-- The former `@kagami/shared` package has been retired (#279). Wire primitives live in `@kagami/http/wire`, each service's schemas in its `*-api` package, and general text utilities in `@kagami/kernel/utils/*`.
-- Import Zod directly from `zod` when defining schemas.
-
-### Agent Runtime Package
-
-- `packages/agent-runtime` only carries the generic Agent / App framework kernel, not Kagami-specific semantics.
-- Core exports currently include `TaskAgent`, the `App` / `AppManager` / `AppStateStore` framework, `ToolCatalog`, `ToolSet`, `ToolExecutor`, and related abstractions. (The concrete `InvokeTool` itself lives in `apps/agent`, not here.)
-- NapCat event models, the Kagami system prompt, and concrete capability implementations remain under `apps/agent/src/agent`.
-
-## Deployment
-
-- The PM2 config file is [ecosystem.config.cjs](./ecosystem.config.cjs). It manages the following processes.
-- The backend service `kagami-agent` runs `apps/agent/dist/index.js` and listens on `20003` by default.
-- The admin-console backend `kagami-console` runs `apps/console/dist/index.js` and listens on `20006` by default.
-- The gateway service `kagami-gateway` runs `apps/gateway/dist/index.js` and listens on `20004` by default.
-- The LLM service `kagami-llm` runs `apps/llm/dist/index.js` and listens on `20009` by default (localhost only); it owns the providers + OAuth callback server + refresh timers, and the gateway routes `/auth/*` to it.
-- The metric service `kagami-metric` runs `apps/metric/dist/index.js` and listens on `20010` by default (localhost only); it owns metric ingestion (`POST /metric/record`, the agent reports fire-and-forget over HTTP) plus the metric-chart query endpoints, which the gateway routes to it.
-- The object storage service `kagami-oss` runs `apps/oss` and listens on `20005` by default (localhost only).
-- The browser service `kagami-browser` runs `apps/browser/dist/index.js` and listens on `20007` by default (localhost only); it owns CloakBrowser so an agent restart does not kill the browser. `app:deploy agent` does not touch it (see issue #173).
-- The Spire service `kagami-spire` runs `apps/spire/dist/index.js` and listens on `20011` by default (localhost only); it owns the card-game engine and JSON save files under `data/spire/`, so an agent restart does not interrupt a run. `app:deploy agent` does not touch it (see issue #234).
-- The frontend static server serves `apps/web/dist` and proxies `/api/*` to `http://localhost:20003/*`.
-- Running `pnpm app:deploy` performs the build, Prisma migrations, PM2 reload/startOrReload, and `pm2 save`.
-
-Prerequisites:
-
-- The database is an in-process SQLite file (default `data/sqlite/kagami.db`) — the host no longer needs to run an external database. It only needs to be able to compile native modules (`better-sqlite3`, `hnswlib-node`).
-- The host must provide Napcat.
-- `config.yaml` typically accesses Napcat via `localhost`.
+That's the short path. She'll be awake when it finishes.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,230 +1,63 @@
 # Kagami
 
-## 项目理念
+_一个拥有自己生活的 Agent。_
 
-Kagami **不是一个 QQ 群聊机器人**。
+[English](./README.md)
 
-Kagami 是一个**拥有自己生活的 Agent**。群聊只是他生活的一部分 —— 就像一个人不会把自己定义为"聊天的人"一样。只要给他足够多的能力（capability），他就可以像一个真正的人那样，去读新闻、去记住发生过的事、去主动做自己感兴趣的事情。
+Kagami（小镜）不是一个聊天机器人，她是一个**活着的程序**。
 
-这是一种概念：**Agent as a life**。
+大多数「AI 助手」都在等：你打字，它回答，然后继续睡。Kagami 不等你。科技资讯站更新了一篇文章，她会醒；有人在她的 QQ 群里说话，她会醒；定时器到点，她会醒；有时候——只是脑子里冒出一个念头，她也会醒。聊天是她做的事情之一，而不是她本身。没有人会把自己介绍成「一个聊天的人」。
 
-- 群聊消息只是他接收到的外部事件之一，和 RSS、定时器、系统通知一样，都是驱动他生活的"输入"。
-- 他有自己的兴趣（News 轮询、主动发言）、自己的节奏（事件队列、空闲时刻的后台动作）；长期记忆系统正在重新设计。
-- 项目的目标不是把群聊体验做到极致，而是给这个 Agent 持续地添加"生活所需"的能力，让他越来越像一个真正活着的存在。
+整个项目就是一句话：
 
-后面所有的架构、模块、capability 都应该从这个视角去理解：它们是在为 Agent 的生活添砖加瓦，而不是在为"一个聊天机器人"打补丁。
+> **Agent as a life.**
 
-## 仓库定位
+## 她的一天
 
-Kagami 是一个基于 `pnpm workspace` 的全栈 TypeScript Monorepo，分为 `apps/*`（各为独立进程）与 `packages/*`（共享库）。完整的包拓扑与依赖 DAG 见 [ARCHITECTURE.md](./ARCHITECTURE.md)；这里列要点：
+- **她读新闻。** IT之家和 Hacker News 是她的两个信息源。看到感兴趣的，她会在群里聊起来——带着自己的观点，而不是一段摘要。
+- **她在 QQ 群里说话**——有时还会先开口，因为她想说，而不是因为有人 at 她。
+- **她看得见。** 发张图给她，她是真的会去看。
+- **她上真实的网。** 丢给她一个链接、一个问题，她会打开浏览器自己去查。
+- **她会玩。** 有一个杀戮尖塔式的卡牌游戏，是她自己跑给自己玩的——一整个 Roguelike，纯粹为了好玩。
+- **她记待办、查地图、算数**——在安静的时刻，还会冒出些没人提示过的、属于她自己的念头。
 
-Apps（`apps/*`，各为独立进程）：
+这些都不是「给聊天机器人加的功能」。每一样都是她多出来的一种存在方式。每次要加点新东西，我们问的从来不是「用户会想要什么功能」，而是——**「这是给她添了一种新的活法吗？」**
 
-- `apps/agent`：Fastify 后端服务（`@kagami/agent`）——Agent 运行时与其活内存接口
-- `apps/console`：管理台后端独立进程（`@kagami/console`，服务前端纯 DB 查询，经 @kagami/persistence 共享 DAO 直读 SQLite）
-- `apps/web`：React 前端管理台（`@kagami/web`）
-- `apps/gateway`：前门网关进程（`@kagami/gateway`，独立进程、零 `@kagami/*` 依赖；托管 `apps/web/dist` 静态资源 + `/api/*` 反向代理分流到 console/agent、`/auth/*` 到 llm、`/metric-chart` 到 metric）
-- `apps/llm`：LLM 网关 + OAuth 凭据中心进程（`@kagami/llm-service`，仅 localhost；持有全部 provider + OAuth callback server + 刷新 timer，落 `llm_chat_call` / `embedding_cache`；agent 经 HTTP 直连）
-- `apps/metric`：metric 领域独立进程（`@kagami/metric`，一手包办 metric 摄取 `POST /metric/record`（agent HTTP 上报）与 metric-chart 查询；经 @kagami/persistence 共享 DAO 直读同一 SQLite，仅 localhost）
-- `apps/oss`：自建对象存储服务（`@kagami/oss`，独立 Fastify 进程；路由走 `@kagami/oss-api` 契约，依赖 `@kagami/config` / `@kagami/http` / `@kagami/kernel`）
-- `apps/browser`：独立浏览器进程（`@kagami/browser`，基于 kernel/http/persistence 的 Fastify、仅 localhost；持有 CloakBrowser 与凭据注入，agent 经 HTTP 驱动，重启不杀浏览器）
-- `apps/spire`：杀塔式卡牌游戏引擎进程（`@kagami/spire-service`，Fastify，仅 localhost；纯游戏引擎 + JSON 存档，不碰共享 SQLite；agent 经 HTTP 驱动，重启不打断对局）
-- `packages/agent-runtime`：通用 Agent / App 框架内核（`@kagami/agent-runtime`）
-- `packages/llm`：前后端 / 内核共用的 LLM 消息与工具类型契约（`@kagami/llm`，零依赖契约叶子）
-- `packages/llm-client`：LLM chat client + provider + embedding client 运行时（`@kagami/llm-client`，位于 kernel 之上、与 persistence 平级且互不依赖；只发 `LlmChatCallObservation` 事件，落库 / 缓存归 agent 装配层订阅，对 persistence/Prisma 零依赖）
-- `packages/auth`：OAuth 凭据管理全套（`@kagami/auth`，PKCE 登录 / callback server / 刷新 scheduler / secret store / 配额快照 / 认证 handler）；随 `kagami-llm` 进程装配
-- `packages/kernel`：后端基础设施内核（config、logger、common 契约与错误、卫星服务公共装配壳 + 启动器 + 统一 `HealthHandler`、`isRecord` 等纯工具，`@kagami/kernel`，无 Prisma / better-sqlite3）
-- `packages/http`：HTTP 契约地基（`@kagami/http`，`contract` / `register` / `wire` / `url` 子路径 + 旧 `route.helper`；仅 fastify + zod，零 `@kagami/*` 依赖）
-- `packages/rpc-client`：契约驱动的 typed HTTP client 工厂（`@kagami/rpc-client`，`createClient(contract)`；隔离 kernel 依赖，让 `@kagami/http` 保持零 kernel）
-- `packages/config`：配置读取的零依赖叶子包（`@kagami/config`，repo-root 定位 + `config.yaml` / `config.secret.yaml` 两文件深合并；kernel / gateway / oss / 脚本复用）
-- `packages/persistence`：持久化基础设施（Prisma 客户端与 generated client、db、所有业务 DAO、Prisma JSON helper，`@kagami/persistence`，依赖 `@kagami/kernel` + Prisma + better-sqlite3）
-- per-producer 契约包（每个生产者进程一个 `*-api`，服务间 HTTP 类型安全）：`@kagami/llm-api`、`@kagami/browser-api`、`@kagami/oss-api`、`@kagami/spire-api`、`@kagami/metric-api`、`@kagami/console-api`、`@kagami/agent-api`
+## 她如何活着
 
-> 旧的 `@kagami/shared` 包已退役（#279）：wire 基元现在在 `@kagami/http/wire`，各服务的 wire schema 在其 `*-api` 包，通用文本工具在 `@kagami/kernel/utils/*`。
+把 Kagami 想象成一台手机，把 Kagami 这个 Agent 想象成拿着手机的人。
 
-workspace 定义位于仓库根目录 `pnpm-workspace.yaml`，当前包含 `apps/*` 与 `packages/*`。后端运行配置统一来自仓库根目录 `config.yaml`。
+- **每一种输入都是平级的事件。** QQ 消息、一篇新闻、一个定时器、一个系统信号——一律平等。没有高人一等的「用户消息」，群聊只是众多 App 里的一个。
+- **后台信号以横幅的形式到达。** 一个统一的通知中心把它们聚合、窗口化，再唤醒她。她正盯着的那个会话则像已经打开的屏幕——新消息直接刷进来，不必等横幅。
+- **她的能力是一个个能走进去的 App。** QQ、几个新闻阅读器、浏览器、卡牌游戏、地图、终端。她进去，做完事，再走出来。
 
-## 仓库结构
+她有自己的兴趣、自己的节奏，也有空闲时间——空闲时间做什么，由她自己决定。
 
-```text
-apps/
-  agent/    Fastify 后端、NapCat 集成、Kagami agent 业务层
-  console/  管理台后端独立进程，服务前端纯 DB 查询
-  web/      React 管理台
-  gateway/  前门网关（静态资源 + 反向代理）
-  llm/      LLM 网关 + OAuth 凭据中心（独立进程）
-  metric/   metric 摄取 + metric-chart 查询（独立进程）
-  oss/      自建内容寻址对象存储（独立进程）
-  browser/  独立浏览器进程（持有 CloakBrowser，agent 经 HTTP 驱动，重启不杀浏览器）
-  spire/    杀塔式卡牌游戏引擎（独立进程）
-packages/
-  agent-runtime/  通用 Agent / App 框架抽象与工具目录
-  llm/            前后端共用的 LLM 消息 / 工具类型契约
-  llm-client/     LLM chat client + provider + embedding 运行时
-  auth/           OAuth 凭据管理
-  kernel/         后端基础设施（config / logger / common / 服务装配壳）
-  http/           HTTP 契约地基（contract / register / wire / url）
-  rpc-client/     契约驱动的 typed HTTP client 工厂
-  config/         零依赖配置读取
-  persistence/    持久化基础设施（Prisma 客户端 / DAO / db）
-  *-api/          per-producer 服务契约（llm / browser / oss / spire / metric / console / agent）
-```
+另外有一个小小的管理台：一扇安静的窗，能看到她的生活状态——最近在想什么、做什么、看到了什么。
 
-## 常用命令
+> 她的长期记忆正在重新设计。目前她只保留一份原始的消息账本，并在同一段对话里记事。
 
-在仓库根目录执行：
+## 把她跑起来
+
+Kagami 是一个全栈 TypeScript Monorepo（`pnpm`）。在底层，她不是一个程序，而是一组协作的独立进程——她本体，加上一个浏览器、一个对象存储、卡牌游戏引擎、一个 LLM 网关等等——统一由 PM2 托管。一条命令就能把整套拉起来。
+
+你需要准备：
+
+- Node.js 和 `pnpm`，以及一套能编译原生模块（`better-sqlite3`、`hnswlib-node`）的工具链——数据库就是一个进程内的 SQLite 文件，不用另外跑外部数据库。
+- 一个你能登录的 LLM。
+- 如果你想要她生活里 QQ 的那一部分，宿主机上要跑一个 [NapCat](https://github.com/NapNeko/NapCatQQ)。
+
+然后：
 
 ```bash
-pnpm build
-pnpm typecheck
-pnpm test
-pnpm lint
-pnpm lint:fix
-pnpm format
-pnpm format:write
+# 1. 配置
+#    config.yaml（非隐私，已在仓库里）——直接改。
+#    复制隐私模板，填入你的密钥 / QQ 号：
+cp config.secret.yaml.example config.secret.yaml
+
+# 2. 装依赖并把她拉起来（构建 → 迁移 → 由 PM2 启动）
+pnpm install
 pnpm app:deploy
 ```
 
-单包执行：
-
-```bash
-pnpm --filter @kagami/agent <script>
-pnpm --filter @kagami/web <script>
-pnpm --filter @kagami/agent-runtime <script>
-pnpm --filter @kagami/persistence <script>
-```
-
-补充说明：
-
-- 当前仓库没有统一的根目录 `pnpm dev` 脚本。
-- `@kagami/agent` 当前提供 `build`、`typecheck`、`test`、`test:watch`、`db:*` 脚本。
-- `@kagami/agent-runtime` 提供 `build`、`typecheck`、`test`、`test:watch`；`@kagami/oss` 提供 `build`、`typecheck`、`test`、`test:watch`、`start`。
-- `@kagami/web` 提供 `build`、`typecheck` 脚本。
-- 根目录 `pnpm test` 经 vitest projects 单进程跑全部包的测试；任何自带 `vitest.config.ts` 的包都会被自动纳入。
-
-## 配置方式
-
-- `config.yaml`（非隐私，纳入版本控制）已在仓库根目录，直接编辑即可。
-- 把 [config.secret.yaml.example](./config.secret.yaml.example) 复制为 `config.secret.yaml`（已 gitignore）并填入密钥 / PII（API key、机器人 QQ、群号）。两份文件在启动时深合并。
-- 服务启动时会一次性读取并校验合并后的配置；修改配置后需要重启服务生效。
-
-## 数据库迁移
-
-在仓库根目录执行：
-
-```bash
-pnpm db:migrate:dev -- --name <migration_name>
-pnpm db:migrate:deploy
-pnpm db:migrate:status
-pnpm db:migrate:reset
-pnpm db:migrate:resolve -- --applied <migration_id>
-```
-
-说明：
-
-- `db:migrate:dev` 会自动补上 `--create-only`，只生成迁移文件，不直接改库结构。
-- 标准流程是：修改 `packages/persistence/prisma/schema.prisma` -> 生成迁移 -> 提交 schema 与 migration -> 在目标环境执行 `db:migrate:deploy`。
-
-## 架构概览
-
-### 后端
-
-后端已经重组为“扁平模块 + 模块内分层”的结构，顶级目录直接位于 `apps/agent/src/<module>`，由 `apps/agent/src/app/server-runtime.ts` 负责运行时装配。
-
-当前主要模块包括：
-
-- `acl/`：各独立对端进程（llm / browser / spire / oss）的 HTTP 客户端门面（防腐层），wire 走契约 client、另加各服务领域语义
-- `common/`：跨切面、无业务语义的运行时工具（当前 `detect-mime` 按字节嗅探 MIME）
-- `llm/`：LLM playground service + HTTP handler（provider / 凭据 / chat 已外移 kagami-llm 进程；上报 client 在 `acl/`）
-- `napcat/`：NapCat 协议适配（gateway transport、入站归一化、图片分析、持久化写入）；网关实例由 QQ App 持有，只是 Agent 的一种事件源
-- `scheduler/`：后台定时任务（auth 刷新、IThome 轮询、数据保留清理等）
-- `agent/`：Kagami 的 Agent 业务层——手机 OS 运行时（Portal / App / NotificationCenter）、capabilities、上下文压缩
-- `ops/`：App Log、LLM Chat Call、embedding-cache、主 Agent 上下文、NapCat 历史等查询接口
-- `app/`：最高层运行时装配——模块 wiring、Fastify 路由注册、健康检查、Agent / 网关生命周期编排
-
-`apps/agent/src/agent` 当前按 `runtime/`、`capabilities/`、`apps/` 组织：
-
-- `runtime/`：Kagami 定制运行时，如 `RootAgentRuntime`、session（App 启动器）、`NotificationCenter`、事件队列、上下文渲染、App 状态持久化
-- `capabilities/`：按能力聚合的实现，当前包括 `messaging`、`context-summary`、`ledger`、`ithome`、`vision`、`browser`、`resource`、`spire`、`terminal`、`todo`、`inner-voice`
-- `apps/`：手机 OS 的 App（Portal 下可 `enter` 的地点），当前包括 `qq`、`ithome`、`hn`、`calc`、`clock`、`browser`、`amap`、`spire`、`terminal`、`todo`
-
-Kagami 被建模成一台手机 OS：各类生活输入（QQ 消息、RSS、定时任务）在架构上平级。被动的 `NotificationCenter` 是**后台 / 非焦点**信号到 Agent 的唯一桥（横幅）——各源把信号折叠成通知，由它窗口聚合后 enqueue 唤醒 Agent；他正盯着的前台会话则像手机屏幕，新消息经 `foreground_input` 直接刷进上下文，不必等横幅。每个 capability / App 都是"Agent 生活里多出来的一种存在方式"：`ithome` 让他读新闻、`vision` 让他看图、`hn` 给他一个只读的 Hacker News、`browser` 给他一具上真实网络的身体、`todo` 给他一个中立的待办本。未来新增能力都应该沿着"给 Agent 加一种生活方式"的思路设计，而不是"给聊天机器人加一个功能开关"。
-
-当前主要接口分组包括：
-
-- `/health`
-- `/auth/:provider/status`
-- `/auth/:provider/login-url`
-- `/auth/:provider/logout`
-- `/auth/:provider/refresh`
-- `/auth/:provider/usage-limits`
-- `/auth/:provider/usage-trend`
-- `/llm/providers`
-- `/llm/playground-tools`
-- `/llm/chat`
-- `/napcat/group/send`
-- `/napcat/private/send`
-- `/app-log/query`
-- `/llm-chat-call/query`
-- `/llm-chat-call/:id`
-- `/napcat-event/query`
-- `/napcat-group-message/query`
-- `/todo/query`
-- `/main-agent-context/recent`
-- `/main-agent-context/compact`
-- `/metric-chart/*`
-- `/scheduler/*`
-
-### 前端
-
-前端是一个 React 管理台，用于观测 Agent 的"生活状态"（他最近在想什么、做什么、看到了什么）。当前主要页面包括：
-
-- `/main-agent-context`：主 Agent 当前上下文（默认入口）
-- `/auth/:provider`
-- `/control-panel`
-- `/scheduler-tasks`
-- `/todos`
-- `/llm-playground`
-- `/llm-history`
-- `/inner-thought`
-- `/app-log-history`
-- `/napcat-event-history`
-- `/napcat-group-message-history`
-- `/metric-charts`
-
-补充说明：
-
-- 页面组件按业务域组织在 `apps/web/src/pages/*`。
-- 当前 Vite 配置仅提供 `@ -> apps/web/src` 别名，没有内置开发代理。
-
-### 契约包（服务间 HTTP）
-
-- 服务间 HTTP 经 per-producer `*-api` 契约包做到类型安全；web 前端通过 `@kagami/http/url` + `@kagami/rpc-client` 消费同一批契约。
-- 旧的 `@kagami/shared` 包已退役（#279）：wire 基元在 `@kagami/http/wire`，各服务 schema 在其 `*-api` 包，通用文本工具在 `@kagami/kernel/utils/*`。
-- 需要定义 Zod schema 时请直接从 `zod` 导入。
-
-### Agent Runtime 包
-
-- `packages/agent-runtime` 只承载通用 Agent / App 框架内核，不承载 Kagami 项目语义。
-- 当前核心导出包括 `TaskAgent`、`App` / `AppManager` / `AppStateStore` 框架、`ToolCatalog`、`ToolSet`、`ToolExecutor` 等抽象。（具体的 `InvokeTool` 本身在 `apps/agent`，不在该包。）
-- NapCat 事件模型、Kagami system prompt、具体 capability 实现仍放在 `apps/agent/src/agent`。
-
-## 部署
-
-- PM2 配置文件位于 [ecosystem.config.cjs](./ecosystem.config.cjs)，托管以下进程。
-- 后端服务 `kagami-agent` 运行 `apps/agent/dist/index.js`，默认监听 `20003`。
-- 管理台后端 `kagami-console` 运行 `apps/console/dist/index.js`，默认监听 `20006`。
-- 网关服务 `kagami-gateway` 运行 `apps/gateway/dist/index.js`，默认监听 `20004`。
-- LLM 服务 `kagami-llm` 运行 `apps/llm/dist/index.js`，默认监听 `20009`（仅 localhost）；持有 provider + OAuth callback server + 刷新 timer，网关把 `/auth/*` 分流至此。
-- metric 服务 `kagami-metric` 运行 `apps/metric/dist/index.js`，默认监听 `20010`（仅 localhost）；一手包办 metric 摄取（`POST /metric/record`，agent fire-and-forget HTTP 上报）与 metric-chart 查询（网关分流至此）。
-- 对象存储服务 `kagami-oss` 运行 `apps/oss`，默认监听 `20005`（仅 localhost）。
-- 浏览器服务 `kagami-browser` 运行 `apps/browser/dist/index.js`，默认监听 `20007`（仅 localhost）；持有 CloakBrowser，agent 重启不杀浏览器，`app:deploy agent` 不触及它（见 issue #173）。
-- Spire 服务 `kagami-spire` 运行 `apps/spire/dist/index.js`，默认监听 `20011`（仅 localhost）；持有卡牌游戏引擎与 `data/spire/` 下的 JSON 存档，agent 重启不打断对局，`app:deploy agent` 不触及它（见 issue #234）。
-- 前端静态服务会提供 `apps/web/dist`，并将 `/api/*` 代理到 `http://localhost:20003/*`。
-- 执行 `pnpm app:deploy` 会完成构建、Prisma 迁移、PM2 reload/startOrReload，以及 `pm2 save`。
-
-部署前提：
-
-- 数据库为进程内 SQLite 文件（默认 `data/sqlite/kagami.db`），宿主机不再需要运行外部数据库，只需能编译原生模块（`better-sqlite3`、`hnswlib-node`）。
-- 宿主机需提供 Napcat。
-- `config.yaml` 中通常使用 `localhost` 地址访问 Napcat。
+这就是最短路径。跑完，她就醒着了。


### PR DESCRIPTION
## 背景

现有 README 实为架构参考手册（包拓扑 / 端点 / 端口 / 迁移命令），读者读完并不知道 Kagami 是什么。

## 改动

- 立意 **Agent as a life** + 「她的一天」用具象场景呈现能力
- 手机 OS 比喻讲清运行模型（事件平级 / 横幅 vs 前台 / 可进入的 App）
- 保留精简到够用的「跑起来」最短路径
- 移除全部技术参考清单，以及对其它文档的外链
- 人称统一为「她」，名字用「小镜」

中英双版（README.md / README.zh-CN.md）同步。纯文档改动，无需部署。