### PR TITLE
feat(oss): 管理台新增 OSS 对象只读浏览 tab（列表 + 预览 + 存储统计）

### DIFF
--- a/apps/gateway/src/config.ts
+++ b/apps/gateway/src/config.ts
@@ -14,6 +14,8 @@ export interface GatewayConfig {
   llmTarget: URL;
   /** metric 上游基址，由 services.metric.host/port 拼出（metric-chart 查询走它）。 */
   metricTarget: URL;
+  /** oss 上游基址，由 services.oss.host/port 拼出（管理台只读对象浏览 /oss-object 走它）。 */
+  ossTarget: URL;
   /** 静态资源目录：仓库根下的 apps/web/dist。 */
   distDir: string;
 }
@@ -30,6 +32,7 @@ interface RawConfig {
     gateway?: RawServiceEndpoint;
     llm?: RawServiceEndpoint;
     metric?: RawServiceEndpoint;
+    oss?: RawServiceEndpoint;
   };
 }
 
@@ -60,6 +63,7 @@ export function loadGatewayConfig(): GatewayConfig {
     consoleTarget: resolveEndpoint(services?.console, "console"),
     llmTarget: resolveEndpoint(services?.llm, "llm"),
     metricTarget: resolveEndpoint(services?.metric, "metric"),
+    ossTarget: resolveEndpoint(services?.oss, "oss"),
     distDir: path.join(repoRoot, "apps/web/dist"),
   };
 }

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -16,6 +16,7 @@ const apiTarget = config.agentTarget;
 const consoleTarget = config.consoleTarget;
 const llmTarget = config.llmTarget;
 const metricTarget = config.metricTarget;
+const ossTarget = config.ossTarget;
 // 这些前缀的 /api 请求路由到 console 进程（管理台后端，纯 DB 查询）；其余仍到 server（agent）。
 const CONSOLE_PATH_PREFIXES = [
   "/app-log",
@@ -29,6 +30,9 @@ const CONSOLE_PATH_PREFIXES = [
 const LLM_PATH_PREFIXES = ["/auth"];
 // metric-chart 查询走独立的 metric 进程（@kagami/metric）；摄取端点 /metric/* 不经网关（agent 直连）。
 const METRIC_PATH_PREFIXES = ["/metric-chart"];
+// 管理台对象浏览器只读面路由到 kagami-oss 进程。仅 /oss-object（列表 / 统计 / 预览字节）过网关；
+// 写操作前缀 /objects（put/delete）刻意不在此，浏览器经网关够不到 OSS 的任何写路由。
+const OSS_PATH_PREFIXES = ["/oss-object"];
 const HASHED_ASSET_NAME_PATTERN = /(?:^|[-.])[a-z0-9]{8,}(?=\.)/i;
 // 上游响应超时：等待上游返回响应头的上限。命中即回 504，避免上游卡死 / 半开时前端连接
 // 永久悬挂、socket 句柄泄漏。只约束"拿到响应头"这一段——响应头一到就清除，故不会打断
@@ -151,6 +155,10 @@ function selectUpstreamTarget(upstreamPath: string): URL {
 
   if (matchesAnyPrefix(upstreamPath, CONSOLE_PATH_PREFIXES)) {
     return consoleTarget;
+  }
+
+  if (matchesAnyPrefix(upstreamPath, OSS_PATH_PREFIXES)) {
+    return ossTarget;
   }
 
   return apiTarget;

--- a/apps/oss/src/http/server.ts
+++ b/apps/oss/src/http/server.ts
@@ -4,13 +4,14 @@ import type { FastifyInstance } from "fastify";
 import {
   registerBinaryEnvelopeRoute,
   registerBinaryRawRoute,
+  registerJsonRoute,
   useRawBodyPassthrough,
 } from "@kagami/http/register";
-import { ossApiContract } from "@kagami/oss-api/contract";
+import { getOssObjectContent, ossApiContract, ossConsoleContract } from "@kagami/oss-api/contract";
 import { AppLogger } from "@kagami/kernel/logger/logger";
 import { createServiceApp, type ServiceErrorHandler } from "@kagami/kernel/http/service-app";
 import { HealthHandler } from "@kagami/kernel/http/health.handler";
-import { PayloadTooLargeError } from "../store/object-store.js";
+import { formatObjectKey, PayloadTooLargeError } from "../store/object-store.js";
 import type { ObjectStore } from "../store/object-store.js";
 
 const logger = new AppLogger({ source: "oss-http" });
@@ -97,6 +98,39 @@ function registerOssRoutes(app: FastifyInstance, store: ObjectStore, maxBodyByte
 
   registerBinaryRawRoute(app, ossApiContract.deleteObject, async ({ params, raw }) => {
     await handleDelete(raw, store, params.key);
+  });
+
+  // === 控制台只读面（管理台对象浏览器）===
+
+  registerJsonRoute(app, ossConsoleContract.queryObjects, ({ input }) => {
+    const { items, total } = store.list(input);
+    return {
+      pagination: { page: input.page, pageSize: input.pageSize, total },
+      items: items.map(row => ({
+        key: formatObjectKey(row.id),
+        mime: row.mime,
+        size: row.size,
+        sha256: row.sha256,
+        refcount: row.refcount,
+        createdAt: new Date(row.createdAt).toISOString(),
+      })),
+    };
+  });
+
+  registerJsonRoute(app, ossConsoleContract.getStats, () => {
+    const s = store.stats();
+    return {
+      objectCount: s.objectCount,
+      blobCount: s.blobCount,
+      physicalBytes: s.physicalBytes,
+      logicalBytes: s.logicalBytes,
+      dedupSavedBytes: s.logicalBytes - s.physicalBytes,
+    };
+  });
+
+  // 预览 / 下载：字节透传，复用 getObject 的流式管道与安全头（nosniff + attachment）。
+  registerBinaryRawRoute(app, getOssObjectContent, async ({ params, raw }) => {
+    await handleGet(raw, store, params.key);
   });
 }
 

--- a/apps/oss/src/store/object-store.ts
+++ b/apps/oss/src/store/object-store.ts
@@ -85,6 +85,31 @@ interface DeleteOutcome {
   orphanSha256: string | null;
 }
 
+/** 控制台对象浏览的列表行（object ⋈ blob，size/refcount 取自权威的 blob 行）。 */
+export interface ObjectListRow {
+  /** object 表自增 id；对外 key = `res-<id>`（映射在 HTTP 层完成）。 */
+  id: number;
+  mime: string;
+  size: number;
+  sha256: string;
+  refcount: number;
+  /** Unix ms（object.created_at）。 */
+  createdAt: number;
+}
+
+export interface ObjectListPage {
+  items: ObjectListRow[];
+  total: number;
+}
+
+/** 存储统计。dedupSavedBytes 由 HTTP 层用 logical-physical 算出，此处只回原始聚合。 */
+export interface StorageStats {
+  objectCount: number;
+  blobCount: number;
+  physicalBytes: number;
+  logicalBytes: number;
+}
+
 export class ObjectStore {
   private readonly db: Database.Database;
   private readonly blobDir: string;
@@ -240,6 +265,68 @@ export class ObjectStore {
     return { mime: row.mime, size: blob?.size ?? 0, sha256: row.sha256 };
   }
 
+  /**
+   * 控制台只读：分页列出对象（object ⋈ blob），按 id 倒序（最新在前）。可选 mime 精确过滤。
+   * 读不走 writeLock（与 get/head 一致，读并发安全）。size/refcount 取自权威 blob 行。
+   */
+  public list({
+    page,
+    pageSize,
+    mime,
+  }: {
+    page: number;
+    pageSize: number;
+    mime?: string;
+  }): ObjectListPage {
+    const offset = (page - 1) * pageSize;
+    const total = mime
+      ? (
+          this.db.prepare(`SELECT COUNT(*) AS c FROM object WHERE mime = ?`).get(mime) as {
+            c: number;
+          }
+        ).c
+      : (this.db.prepare(`SELECT COUNT(*) AS c FROM object`).get() as { c: number }).c;
+
+    const selectSql = `
+      SELECT o.id AS id, o.mime AS mime, o.created_at AS createdAt,
+             b.size AS size, b.sha256 AS sha256, b.refcount AS refcount
+      FROM object o JOIN blob b ON b.sha256 = o.sha256
+      ${mime ? "WHERE o.mime = ?" : ""}
+      ORDER BY o.id DESC
+      LIMIT ? OFFSET ?
+    `;
+    const items = (
+      mime
+        ? this.db.prepare(selectSql).all(mime, pageSize, offset)
+        : this.db.prepare(selectSql).all(pageSize, offset)
+    ) as ObjectListRow[];
+
+    return { items, total };
+  }
+
+  /**
+   * 控制台只读：存储统计。全表聚合（COUNT + SUM(int)，无 json_extract，成本远低于会撞网关超时的
+   * 大表 json 聚合）；当前规模下远小于 gateway 30s 超时。读不走 writeLock。
+   */
+  public stats(): StorageStats {
+    const objectCount = (this.db.prepare(`SELECT COUNT(*) AS c FROM object`).get() as { c: number })
+      .c;
+    const blobCount = (this.db.prepare(`SELECT COUNT(*) AS c FROM blob`).get() as { c: number }).c;
+    const physicalBytes = (
+      this.db.prepare(`SELECT COALESCE(SUM(size), 0) AS s FROM blob`).get() as { s: number }
+    ).s;
+    const logicalBytes = (
+      this.db
+        .prepare(
+          `SELECT COALESCE(SUM(b.size), 0) AS s
+           FROM object o JOIN blob b ON b.sha256 = o.sha256`,
+        )
+        .get() as { s: number }
+    ).s;
+
+    return { objectCount, blobCount, physicalBytes, logicalBytes };
+  }
+
   public async delete(key: string): Promise<boolean> {
     const id = parseKey(key);
     if (id === null) {
@@ -361,6 +448,11 @@ export class ObjectStore {
       });
     }
   }
+}
+
+/** 由 object id 拼出对外 key（`res-<id>`）。与 {@link parseKey} 共享同一前缀，单一事实源。 */
+export function formatObjectKey(id: number): string {
+  return `${KEY_PREFIX}${id}`;
 }
 
 /** 解析对外 key：`res-<正整数>` → id；前缀不对 / 非正整数 / 越界 → null（视作无映射）。 */

--- a/apps/oss/test/object-store.test.ts
+++ b/apps/oss/test/object-store.test.ts
@@ -316,3 +316,70 @@ describe("ObjectStore", () => {
     expect(await countTmpFiles()).toBe(0);
   });
 });
+
+describe("ObjectStore 控制台只读面（list / stats）", () => {
+  it("list：按 id 倒序分页 + total", async () => {
+    const a = await putBuffer(Buffer.from("obj-a"), "text/plain");
+    const b = await putBuffer(Buffer.from("obj-b"), "image/png");
+    const c = await putBuffer(Buffer.from("obj-c"), "text/plain");
+
+    const page1 = store.list({ page: 1, pageSize: 2 });
+    expect(page1.total).toBe(3);
+    expect(page1.items.map(row => row.id)).toEqual([parseId(c.key), parseId(b.key)]);
+
+    const page2 = store.list({ page: 2, pageSize: 2 });
+    expect(page2.items.map(row => row.id)).toEqual([parseId(a.key)]);
+  });
+
+  it("list：mime 精确过滤", async () => {
+    await putBuffer(Buffer.from("t1"), "text/plain");
+    await putBuffer(Buffer.from("i1"), "image/png");
+
+    const onlyPng = store.list({ page: 1, pageSize: 20, mime: "image/png" });
+    expect(onlyPng.total).toBe(1);
+    expect(onlyPng.items).toHaveLength(1);
+    expect(onlyPng.items[0]!.mime).toBe("image/png");
+  });
+
+  it("list 行携带 size/sha256/refcount（去重共享内容 refcount>1）", async () => {
+    const bytes = Buffer.from("dup content");
+    await putBuffer(bytes, "text/plain");
+    await putBuffer(bytes, "text/plain");
+
+    const { items } = store.list({ page: 1, pageSize: 20 });
+    expect(items).toHaveLength(2);
+    for (const row of items) {
+      expect(row.size).toBe(bytes.length);
+      expect(row.sha256).toBe(sha256(bytes));
+      expect(row.refcount).toBe(2);
+    }
+  });
+
+  it("stats：去重场景 objectCount/blobCount/物理/名义/节省口径", async () => {
+    const dup = Buffer.from("same-bytes");
+    await putBuffer(dup, "text/plain"); // object#1 → blob X（refcount→1）
+    await putBuffer(dup, "text/plain"); // object#2 → blob X（refcount→2，不新增物理文件）
+    const uniq = Buffer.from("unique-bytes-xyz");
+    await putBuffer(uniq, "image/png"); // object#3 → blob Y
+
+    const s = store.stats();
+    expect(s.objectCount).toBe(3);
+    expect(s.blobCount).toBe(2);
+    expect(s.physicalBytes).toBe(dup.length + uniq.length);
+    expect(s.logicalBytes).toBe(dup.length * 2 + uniq.length);
+    expect(s.logicalBytes - s.physicalBytes).toBe(dup.length);
+  });
+
+  it("stats：空库全 0", () => {
+    expect(store.stats()).toEqual({
+      objectCount: 0,
+      blobCount: 0,
+      physicalBytes: 0,
+      logicalBytes: 0,
+    });
+  });
+});
+
+function parseId(key: string): number {
+  return Number(key.slice("res-".length));
+}

--- a/apps/oss/test/server.test.ts
+++ b/apps/oss/test/server.test.ts
@@ -161,3 +161,89 @@ describe("OSS HTTP server (streaming)", () => {
     expect(typeof body.timestamp).toBe("string");
   });
 });
+
+describe("OSS HTTP 控制台只读面（/oss-object）", () => {
+  async function putObject(bytes: Buffer, mime: string): Promise<string> {
+    const res = await fetch(`${baseUrl}/objects`, {
+      method: "POST",
+      headers: { "content-type": mime },
+      body: new Uint8Array(bytes),
+    });
+    const { key } = (await res.json()) as { key: string };
+    return key;
+  }
+
+  it("GET /oss-object/query → 分页 JSON + 倒序 + ISO 时间", async () => {
+    await putObject(Buffer.from("a"), "text/plain");
+    const k2 = await putObject(Buffer.from("b"), "image/png");
+
+    const res = await fetch(`${baseUrl}/oss-object/query?page=1&pageSize=1`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      pagination: { page: number; pageSize: number; total: number };
+      items: Array<{
+        key: string;
+        mime: string;
+        size: number;
+        refcount: number;
+        createdAt: string;
+      }>;
+    };
+    expect(body.pagination.total).toBe(2);
+    expect(body.items).toHaveLength(1);
+    expect(body.items[0]!.key).toBe(k2); // 最新的先出
+    expect(body.items[0]!.mime).toBe("image/png");
+    expect(body.items[0]!.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("GET /oss-object/query?mime= → 精确过滤", async () => {
+    await putObject(Buffer.from("t"), "text/plain");
+    await putObject(Buffer.from("i"), "image/png");
+
+    const res = await fetch(`${baseUrl}/oss-object/query?mime=${encodeURIComponent("image/png")}`);
+    const body = (await res.json()) as {
+      pagination: { total: number };
+      items: Array<{ mime: string }>;
+    };
+    expect(body.pagination.total).toBe(1);
+    expect(body.items.every(item => item.mime === "image/png")).toBe(true);
+  });
+
+  it("GET /oss-object/stats → 去重口径", async () => {
+    const dup = Buffer.from("dup-bytes");
+    await putObject(dup, "text/plain");
+    await putObject(dup, "text/plain");
+    const uniq = randomBytes(100);
+    await putObject(uniq, "application/octet-stream");
+
+    const res = await fetch(`${baseUrl}/oss-object/stats`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      objectCount: number;
+      blobCount: number;
+      physicalBytes: number;
+      logicalBytes: number;
+      dedupSavedBytes: number;
+    };
+    expect(body.objectCount).toBe(3);
+    expect(body.blobCount).toBe(2);
+    expect(body.physicalBytes).toBe(dup.length + uniq.length);
+    expect(body.logicalBytes).toBe(dup.length * 2 + uniq.length);
+    expect(body.dedupSavedBytes).toBe(dup.length);
+  });
+
+  it("GET /oss-object/:key/content → 原字节 + nosniff + attachment（复用 getObject）", async () => {
+    const bytes = randomBytes(256);
+    const key = await putObject(bytes, "image/png");
+
+    const res = await fetch(`${baseUrl}/oss-object/${key}/content`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("image/png");
+    expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(res.headers.get("content-disposition")).toBe("attachment");
+    expect(new Uint8Array(await res.arrayBuffer())).toEqual(new Uint8Array(bytes));
+
+    const missing = await fetch(`${baseUrl}/oss-object/res-999/content`);
+    expect(missing.status).toBe(404);
+  });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
     "@kagami/http": "workspace:*",
     "@kagami/llm-api": "workspace:*",
     "@kagami/metric-api": "workspace:*",
+    "@kagami/oss-api": "workspace:*",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -58,6 +58,11 @@ const TodosPage = lazy(() =>
     default: module.TodosPage,
   })),
 );
+const OssObjectsPage = lazy(() =>
+  import("@/pages/oss-objects/OssObjectsPage").then(module => ({
+    default: module.OssObjectsPage,
+  })),
+);
 
 function App() {
   return (
@@ -78,6 +83,7 @@ function App() {
           <Route path="/napcat-group-message-history" element={<NapcatGroupMessageHistoryPage />} />
           <Route path="/metric-charts" element={<MetricChartsPage />} />
           <Route path="/todos" element={<TodosPage />} />
+          <Route path="/oss-objects" element={<OssObjectsPage />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/apps/web/src/components/layout/navigation.ts
+++ b/apps/web/src/components/layout/navigation.ts
@@ -5,6 +5,7 @@ import {
   CalendarClock,
   FileText,
   FlaskConical,
+  HardDrive,
   History,
   type LucideIcon,
   KeyRound,
@@ -39,6 +40,7 @@ export const navItems: readonly NavItem[] = [
   { to: "/app-log-history", label: "应用日志", icon: FileText },
   { to: "/napcat-event-history", label: "NapCat 事件", icon: Webhook },
   { to: "/napcat-group-message-history", label: "QQ 消息", icon: MessagesSquare },
+  { to: "/oss-objects", label: "OSS 对象", icon: HardDrive },
 ];
 
 export function getPageTitle(pathname: string): string {

--- a/apps/web/src/lib/format.ts
+++ b/apps/web/src/lib/format.ts
@@ -17,6 +17,23 @@ export function formatDateTime(value: string): string {
   return new Date(value).toLocaleString("zh-CN", DATE_TIME_FORMAT_OPTIONS);
 }
 
+const BYTE_UNITS = ["B", "KB", "MB", "GB", "TB", "PB"] as const;
+
+/**
+ * 把字节数格式化为人类可读（1024 进制，保留至多 2 位小数，去掉尾随 0）。
+ * 负数 / 非有限值一律回退成 `0 B`。用于 OSS 对象大小与存储统计展示。
+ */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return "0 B";
+  }
+
+  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), BYTE_UNITS.length - 1);
+  const value = bytes / 1024 ** exponent;
+  const rounded = Math.round(value * 100) / 100;
+  return `${rounded} ${BYTE_UNITS[exponent]}`;
+}
+
 /**
  * 与 {@link formatDateTime} 同样的展示格式，但容忍 null/undefined/非法时间：
  * 这些情况返回 `fallback`（默认 `"—"`）。

--- a/apps/web/src/lib/query.ts
+++ b/apps/web/src/lib/query.ts
@@ -46,6 +46,10 @@ export const queryKeys = {
   todo: {
     historyList: (params: QueryParams) => ["todo", "list", params] as const,
   },
+  ossObject: {
+    historyList: (params: QueryParams) => ["oss-object", "list", params] as const,
+    stats: () => ["oss-object", "stats"] as const,
+  },
   metricChart: {
     root: () => ["metric-chart"] as const,
     list: () => ["metric-chart", "list"] as const,

--- a/apps/web/src/pages/oss-objects/OssObjectDetailPanel.tsx
+++ b/apps/web/src/pages/oss-objects/OssObjectDetailPanel.tsx
@@ -1,0 +1,36 @@
+import type { OssObjectSummary } from "@kagami/oss-api/oss-object";
+import { formatBytes, formatDateTime } from "@/lib/format";
+import { OssObjectPreview } from "./OssObjectPreview";
+
+export function OssObjectDetailPanel({ summary }: { summary: OssObjectSummary | null }) {
+  if (!summary) {
+    return (
+      <div className="flex h-full items-center justify-center p-6 text-sm text-muted-foreground">
+        选择左侧对象查看详情
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col gap-4 overflow-auto p-4">
+      <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
+        <dt className="text-muted-foreground">Key</dt>
+        <dd className="break-all font-mono">{summary.key}</dd>
+        <dt className="text-muted-foreground">类型</dt>
+        <dd className="break-all">{summary.mime}</dd>
+        <dt className="text-muted-foreground">大小</dt>
+        <dd>{formatBytes(summary.size)}</dd>
+        <dt className="text-muted-foreground">引用数</dt>
+        <dd>{summary.refcount}</dd>
+        <dt className="text-muted-foreground">sha256</dt>
+        <dd className="break-all font-mono text-xs">{summary.sha256}</dd>
+        <dt className="text-muted-foreground">创建时间</dt>
+        <dd>{formatDateTime(summary.createdAt)}</dd>
+      </dl>
+
+      <div className="min-h-0">
+        <OssObjectPreview objectKey={summary.key} mime={summary.mime} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/oss-objects/OssObjectPreview.tsx
+++ b/apps/web/src/pages/oss-objects/OssObjectPreview.tsx
@@ -1,0 +1,35 @@
+import { interpolatePath } from "@kagami/http/url";
+import { getOssObjectContent } from "@kagami/oss-api/contract";
+import { buildApiUrl } from "@/lib/api";
+
+/**
+ * 拼出对象字节透传 URL（经 gateway `/api/oss-object/:key/content` → kagami-oss）。路径取自契约
+ * （interpolatePath 单一事实源），再由 buildApiUrl 加 `/api` 基址。响应带 nosniff + attachment，
+ * `<img>` 子资源加载不受 attachment 影响、正常渲染；顶层导航才触发下载，杜绝存储型 XSS 内联执行。
+ */
+function ossObjectContentUrl(key: string): string {
+  return buildApiUrl(interpolatePath(getOssObjectContent.path, { key }));
+}
+
+export function OssObjectPreview({ objectKey, mime }: { objectKey: string; mime: string }) {
+  const url = ossObjectContentUrl(objectKey);
+
+  if (mime.startsWith("image/")) {
+    return (
+      <img
+        src={url}
+        alt={objectKey}
+        className="max-h-[420px] max-w-full rounded-none border object-contain"
+      />
+    );
+  }
+
+  return (
+    <div className="rounded-none border p-4 text-sm text-muted-foreground">
+      非图片类型（{mime}），无法内联预览。
+      <a href={url} download className="ml-1 text-foreground underline">
+        下载查看
+      </a>
+    </div>
+  );
+}

--- a/apps/web/src/pages/oss-objects/OssObjectsPage.tsx
+++ b/apps/web/src/pages/oss-objects/OssObjectsPage.tsx
@@ -1,0 +1,237 @@
+import type { OssObjectSummary } from "@kagami/oss-api/oss-object";
+import { type FormEvent, useMemo } from "react";
+import { HistoryListPageLayout } from "@/components/layout/HistoryListPageLayout";
+import { Button } from "@/components/ui/button";
+import { MobileSelectCard } from "@/components/ui/mobile-select-card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useHistoryListPageState } from "@/hooks/useHistoryListPageState";
+import { formatBytes, formatDateTime } from "@/lib/format";
+import { normalizeOptionalText, setIfNonEmpty } from "@/lib/search-params";
+import { cn } from "@/lib/utils";
+import { OssObjectDetailPanel } from "./OssObjectDetailPanel";
+import { OssStatsBanner } from "./OssStatsBanner";
+import { type OssObjectListFilters, useOssObjectList } from "./useOssObjectList";
+
+const PAGE_SIZE = 20;
+
+type FilterFormState = {
+  mime: string;
+};
+
+export function OssObjectsPage() {
+  const {
+    isMobile,
+    page,
+    filters,
+    formState,
+    setFormState,
+    selectedId,
+    showMobileDetail,
+    handleSelectItem,
+    handleBackToList,
+    submitFilters,
+    resetFilters,
+    goToPage,
+  } = useHistoryListPageState<OssObjectListFilters, FilterFormState, string>({
+    parseFilters,
+    toFormState,
+    buildSearchParams,
+    createEmptyFormState,
+    onSameParamsSubmit: () => {
+      void refetch();
+    },
+  });
+  const { data, isLoading, isFetching, isError, refetch } = useOssObjectList(
+    page,
+    PAGE_SIZE,
+    filters,
+  );
+  const isInitialLoading = isLoading && !data;
+  const total = data?.pagination.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+  const items = useMemo(() => data?.items ?? [], [data?.items]);
+  const selectedSummary = useMemo(
+    () => items.find(item => item.key === selectedId) ?? null,
+    [items, selectedId],
+  );
+
+  function handleFilterSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    submitFilters();
+  }
+
+  return (
+    <HistoryListPageLayout
+      filterForm={
+        <div className={cn("flex flex-col gap-3", showMobileDetail && "hidden")}>
+          <OssStatsBanner />
+          <form onSubmit={handleFilterSubmit} className="rounded-none border p-4">
+            <div className="flex flex-col gap-1 text-sm sm:flex-row sm:items-center sm:gap-3">
+              <span className="text-muted-foreground sm:w-24 sm:shrink-0 sm:text-right">类型</span>
+              <input
+                type="text"
+                aria-label="mime 类型"
+                placeholder="如 image/png，留空为全部"
+                value={formState.mime}
+                onChange={event => setFormState(prev => ({ ...prev, mime: event.target.value }))}
+                className="min-w-0 flex-1 rounded-none border bg-background px-3 py-1.5 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              />
+            </div>
+
+            <div className="mt-3 flex items-center gap-2">
+              <Button type="submit" size="sm">
+                查询
+              </Button>
+              <Button type="button" size="sm" variant="outline" onClick={resetFilters}>
+                重置
+              </Button>
+            </div>
+          </form>
+        </div>
+      }
+      desktopList={
+        <div className="min-h-0 flex-1 overflow-hidden rounded-none border">
+          <Table className="min-w-[680px] table-fixed">
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[190px]">时间</TableHead>
+                <TableHead className="w-[110px]">Key</TableHead>
+                <TableHead>类型</TableHead>
+                <TableHead className="w-[110px]">大小</TableHead>
+                <TableHead className="w-[80px]">引用</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {isInitialLoading ? (
+                <TableRow>
+                  <TableCell colSpan={5} className="h-24 text-center text-muted-foreground">
+                    加载中…
+                  </TableCell>
+                </TableRow>
+              ) : items.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={5} className="h-24 text-center text-muted-foreground">
+                    暂无数据
+                  </TableCell>
+                </TableRow>
+              ) : (
+                items.map(item => (
+                  <TableRow
+                    key={item.key}
+                    data-state={selectedId === item.key ? "selected" : undefined}
+                    className="cursor-pointer"
+                    onClick={() => handleSelectItem(item.key)}
+                  >
+                    <TableCell className="whitespace-nowrap text-sm text-muted-foreground">
+                      {formatDateTime(item.createdAt)}
+                    </TableCell>
+                    <TableCell className="truncate font-mono text-sm">{item.key}</TableCell>
+                    <TableCell className="truncate text-sm">{item.mime}</TableCell>
+                    <TableCell className="whitespace-nowrap text-sm">
+                      {formatBytes(item.size)}
+                    </TableCell>
+                    <TableCell className="whitespace-nowrap text-sm">{item.refcount}</TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      }
+      mobileList={
+        <div className="min-h-0 flex-1 overflow-auto">
+          {isInitialLoading ? (
+            <div className="flex h-24 items-center justify-center rounded-none border text-sm text-muted-foreground">
+              加载中…
+            </div>
+          ) : items.length === 0 ? (
+            <div className="flex h-24 items-center justify-center rounded-none border text-sm text-muted-foreground">
+              暂无数据
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {items.map(item => (
+                <OssObjectMobileCard
+                  key={item.key}
+                  item={item}
+                  isSelected={selectedId === item.key}
+                  onClick={() => handleSelectItem(item.key)}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      }
+      detailPanel={<OssObjectDetailPanel summary={selectedSummary} />}
+      detailTitle={selectedSummary ? selectedSummary.key : "OSS 对象详情"}
+      isMobile={isMobile}
+      showMobileDetail={showMobileDetail}
+      isError={isError}
+      page={page}
+      total={total}
+      totalPages={totalPages}
+      isPaginationDisabled={isFetching}
+      onPrevPage={() => goToPage(page - 1)}
+      onNextPage={() => goToPage(page + 1)}
+      onBackToList={handleBackToList}
+    />
+  );
+}
+
+function parseFilters(params: URLSearchParams): OssObjectListFilters {
+  return {
+    mime: normalizeOptionalText(params.get("mime")),
+  };
+}
+
+function toFormState(params: URLSearchParams): FilterFormState {
+  return {
+    mime: params.get("mime") ?? "",
+  };
+}
+
+function buildSearchParams(formState: FilterFormState): URLSearchParams {
+  const nextParams = new URLSearchParams();
+  setIfNonEmpty(nextParams, "mime", formState.mime);
+  return nextParams;
+}
+
+function createEmptyFormState(): FilterFormState {
+  return {
+    mime: "",
+  };
+}
+
+function OssObjectMobileCard({
+  item,
+  isSelected,
+  onClick,
+}: {
+  item: OssObjectSummary;
+  isSelected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <MobileSelectCard isSelected={isSelected} onClick={onClick}>
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="truncate font-mono text-sm font-semibold">{item.key}</p>
+          <p className="mt-1 truncate text-xs text-muted-foreground">{item.mime}</p>
+        </div>
+        <span className="shrink-0 text-xs text-muted-foreground">{formatBytes(item.size)}</span>
+      </div>
+
+      <div className="mt-3 flex items-center justify-between gap-3 text-xs text-muted-foreground">
+        <span>{formatDateTime(item.createdAt)}</span>
+        <span>引用 {item.refcount}</span>
+      </div>
+    </MobileSelectCard>
+  );
+}

--- a/apps/web/src/pages/oss-objects/OssStatsBanner.tsx
+++ b/apps/web/src/pages/oss-objects/OssStatsBanner.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from "react";
+import { formatBytes } from "@/lib/format";
+import { cn } from "@/lib/utils";
+import { useOssStats } from "./useOssStats";
+
+/**
+ * 存储统计条。DESIGN.md 配色铁律：90% 中性，饱和色只落在「活着 / 持久」的数据上——去重节省与物理
+ * 占用属持久存储数据，用 `text-story`（绿 · 记忆 / 持久数据）点睛，其余中性。
+ */
+export function OssStatsBanner() {
+  const { data, isLoading, isError } = useOssStats();
+
+  if (isError) {
+    return (
+      <div className="rounded-none border p-3 text-sm text-destructive">存储统计加载失败。</div>
+    );
+  }
+
+  const placeholder = isLoading || !data;
+
+  return (
+    <div className="grid grid-cols-2 gap-px rounded-none border bg-border sm:grid-cols-3 xl:grid-cols-5">
+      <StatCell label="对象数" value={placeholder ? "—" : String(data.objectCount)} />
+      <StatCell label="内容条目" value={placeholder ? "—" : String(data.blobCount)} />
+      <StatCell
+        label="物理占用"
+        value={placeholder ? "—" : formatBytes(data.physicalBytes)}
+        accent
+      />
+      <StatCell label="名义占用" value={placeholder ? "—" : formatBytes(data.logicalBytes)} />
+      <StatCell
+        label="去重节省"
+        value={placeholder ? "—" : formatBytes(data.dedupSavedBytes)}
+        accent
+      />
+    </div>
+  );
+}
+
+function StatCell({
+  label,
+  value,
+  accent = false,
+}: {
+  label: string;
+  value: ReactNode;
+  accent?: boolean;
+}) {
+  return (
+    <div className="flex flex-col gap-1 bg-card p-3">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      <span className={cn("text-lg font-semibold tabular-nums", accent && "text-story")}>
+        {value}
+      </span>
+    </div>
+  );
+}

--- a/apps/web/src/pages/oss-objects/useOssObjectList.ts
+++ b/apps/web/src/pages/oss-objects/useOssObjectList.ts
@@ -1,0 +1,32 @@
+import { contractUrl } from "@kagami/http/url";
+import { ossConsoleContract } from "@kagami/oss-api/contract";
+import {
+  type OssObjectListResponse,
+  OssObjectListResponseSchema,
+} from "@kagami/oss-api/oss-object";
+import { useQuery } from "@tanstack/react-query";
+import { createHistoryListQueryOptions, queryKeys } from "@/lib/query";
+
+export type OssObjectListFilters = {
+  mime?: string;
+};
+
+export function useOssObjectList(page: number, pageSize: number, filters: OssObjectListFilters) {
+  const params = {
+    page: String(page),
+    pageSize: String(pageSize),
+    mime: filters.mime,
+  } satisfies Record<string, string | undefined>;
+
+  return useQuery(
+    createHistoryListQueryOptions<
+      OssObjectListResponse,
+      ReturnType<typeof queryKeys.ossObject.historyList>
+    >({
+      queryKey: queryKeys.ossObject.historyList(params),
+      path: contractUrl(ossConsoleContract.queryObjects),
+      schema: OssObjectListResponseSchema,
+      params,
+    }),
+  );
+}

--- a/apps/web/src/pages/oss-objects/useOssStats.ts
+++ b/apps/web/src/pages/oss-objects/useOssStats.ts
@@ -1,0 +1,15 @@
+import { contractUrl } from "@kagami/http/url";
+import { ossConsoleContract } from "@kagami/oss-api/contract";
+import { type OssStatsResponse, OssStatsResponseSchema } from "@kagami/oss-api/oss-object";
+import { useQuery } from "@tanstack/react-query";
+import { createSchemaQueryOptions, queryKeys } from "@/lib/query";
+
+export function useOssStats() {
+  return useQuery(
+    createSchemaQueryOptions<OssStatsResponse, ReturnType<typeof queryKeys.ossObject.stats>>({
+      queryKey: queryKeys.ossObject.stats(),
+      path: contractUrl(ossConsoleContract.getStats),
+      schema: OssStatsResponseSchema,
+    }),
+  );
+}

--- a/apps/web/test/format.test.ts
+++ b/apps/web/test/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatDateTime, formatOptionalDateTime } from "@/lib/format";
+import { formatBytes, formatDateTime, formatOptionalDateTime } from "@/lib/format";
 
 describe("formatOptionalDateTime", () => {
   it("null / undefined / 空串 / 非法时间 → fallback（默认 —）", () => {
@@ -23,5 +23,22 @@ describe("formatOptionalDateTime", () => {
   it("与 formatDateTime 对同一合法输入输出一致", () => {
     const iso = "2026-07-02T04:30:00.000Z";
     expect(formatOptionalDateTime(iso)).toBe(formatDateTime(iso));
+  });
+});
+
+describe("formatBytes", () => {
+  it("0 / 负数 / 非有限 → 0 B", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(-5)).toBe("0 B");
+    expect(formatBytes(Number.NaN)).toBe("0 B");
+    expect(formatBytes(Number.POSITIVE_INFINITY)).toBe("0 B");
+  });
+
+  it("按 1024 进制选单位，去尾随 0", () => {
+    expect(formatBytes(512)).toBe("512 B");
+    expect(formatBytes(1024)).toBe("1 KB");
+    expect(formatBytes(1536)).toBe("1.5 KB");
+    expect(formatBytes(1024 * 1024)).toBe("1 MB");
+    expect(formatBytes(5 * 1024 * 1024 * 1024)).toBe("5 GB");
   });
 });

--- a/packages/oss-api/src/contract.ts
+++ b/packages/oss-api/src/contract.ts
@@ -1,5 +1,14 @@
-import { defineBinaryEnvelopeRoute, defineBinaryRawRoute } from "@kagami/http/contract";
+import {
+  defineBinaryEnvelopeRoute,
+  defineBinaryRawRoute,
+  defineJsonRoute,
+} from "@kagami/http/contract";
 import { z } from "zod";
+import {
+  OssObjectListQuerySchema,
+  OssObjectListResponseSchema,
+  OssStatsResponseSchema,
+} from "./oss-object.js";
 
 const KeyParams = z.object({ key: z.string().min(1) });
 
@@ -41,3 +50,33 @@ export const ossApiContract = {
     bytesIn: false,
   }),
 };
+
+/**
+ * 控制台只读面（管理台对象浏览器）：分页列表 + 存储统计，均为 JSON 契约。挂 `/oss-object` 前缀，
+ * 与写操作的 `/objects` 前缀物理隔离——gateway 只把 `/oss-object` 分流到 OSS，浏览器够不到写路由。
+ */
+export const ossConsoleContract = {
+  queryObjects: defineJsonRoute({
+    method: "GET",
+    path: "/oss-object/query",
+    input: OssObjectListQuerySchema,
+    output: OssObjectListResponseSchema,
+  }),
+  getStats: defineJsonRoute({
+    method: "GET",
+    path: "/oss-object/stats",
+    input: z.object({}),
+    output: OssStatsResponseSchema,
+  }),
+};
+
+/**
+ * 对象字节透传（预览 / 下载）：binary-raw 路由，浏览器直接以 `<img src>` / 下载消费，不进 typed
+ * client。复用现有 getObject 的流式管道与安全头（nosniff + attachment）。同挂 `/oss-object` 前缀。
+ */
+export const getOssObjectContent = defineBinaryRawRoute({
+  method: "GET",
+  path: "/oss-object/:key/content",
+  params: KeyParams,
+  bytesIn: false,
+});

--- a/packages/oss-api/src/oss-object.ts
+++ b/packages/oss-api/src/oss-object.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+import {
+  createPaginatedResponseSchema,
+  PaginationQuerySchema,
+  parseOptionalStringInput,
+} from "@kagami/http/wire";
+
+// === kagami-oss 的控制台只读面 wire schema（对象浏览 + 存储统计） ===
+//
+// OSS 是数据 owner，自己出这份只读 JSON 契约给管理台（web 经 gateway `/oss-object` 前缀消费），
+// Console 不代读 OSS 的私有 better-sqlite3 库。写操作（put/delete）仍只在二进制契约 ossApiContract
+// 里、不进 gateway 分流表，浏览器永远够不到。
+
+export const OssObjectListQuerySchema = PaginationQuerySchema.extend({
+  // 可选按 mime 精确过滤（如 image/png）。
+  mime: z.preprocess(parseOptionalStringInput, z.string().min(1).optional()),
+});
+
+export type OssObjectListQuery = z.infer<typeof OssObjectListQuerySchema>;
+
+export const OssObjectSummarySchema = z.object({
+  /** 对外 key，形如 `res-<id>`。 */
+  key: z.string().min(1),
+  mime: z.string().min(1),
+  /** 字节大小，取自去重后的 blob 行（权威）。 */
+  size: z.number().int().nonnegative(),
+  /** 内容哈希（内部去重键，此处仅作展示 / 排查用）。 */
+  sha256: z.string().min(1),
+  /** 多少个 object 共享此内容（refcount>1 即命中去重）。 */
+  refcount: z.number().int().positive(),
+  createdAt: z.string().datetime(),
+});
+
+export type OssObjectSummary = z.infer<typeof OssObjectSummarySchema>;
+
+export const OssObjectListResponseSchema = createPaginatedResponseSchema(OssObjectSummarySchema);
+
+export type OssObjectListResponse = z.infer<typeof OssObjectListResponseSchema>;
+
+export const OssStatsResponseSchema = z.object({
+  /** object 表行数（命名层，含去重后的重复引用）。 */
+  objectCount: z.number().int().nonnegative(),
+  /** blob 表行数（内容层，去重后的物理条目数）。 */
+  blobCount: z.number().int().nonnegative(),
+  /** SUM(blob.size)：去重后真实物理占用。 */
+  physicalBytes: z.number().int().nonnegative(),
+  /** SUM over objects 的 blob.size：不去重时的名义占用。 */
+  logicalBytes: z.number().int().nonnegative(),
+  /** logicalBytes - physicalBytes：内容寻址去重省下的字节。 */
+  dedupSavedBytes: z.number().int().nonnegative(),
+});
+
+export type OssStatsResponse = z.infer<typeof OssStatsResponseSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -496,6 +496,9 @@ importers:
       '@kagami/metric-api':
         specifier: workspace:*
         version: link:../../packages/metric-api
+      '@kagami/oss-api':
+        specifier: workspace:*
+        version: link:../../packages/oss-api
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)


### PR DESCRIPTION
Closes #438

## 做了什么

给管理台加一个只读 **OSS 对象浏览 tab**（`/oss-objects`）：分页列表 + 点开内联图片预览 + 顶部存储统计条。只读，无删除 / 上传。

## 架构

OSS 作为数据 owner 自出只读 JSON 面（`/oss-object` 前缀），前端经 gateway 直连；**Console 不代读 OSS 私有 better-sqlite3 库**（per-producer 契约模式 #230）。写操作 `/objects` 不进 gateway 分流表，浏览器物理够不到任何 OSS 写路由。

- **oss-api**: `ossConsoleContract`（`queryObjects` / `getStats`）+ `getOssObjectContent`（字节透传）
- **oss**: `ObjectStore.list()` / `stats()` 只读聚合（读不加写锁）；HTTP 注册 JSON 查询/统计 + 复用 `getObject` 的 `nosniff`+`attachment` 安全头做预览透传
- **gateway**: 新增 `ossTarget` + `/oss-object` 前缀分流
- **web**: OSS 对象浏览页（列表 + 详情内联预览 + 统计条，去重节省用绿色语义）、`formatBytes`、导航项与路由

## 验证

`pnpm build / typecheck / lint(0 error) / format` 全绿；`pnpm test` 1860 passed。新增测试：store list/stats 去重口径 + 空库、HTTP 三路由集成（含 nosniff+attachment + 缺失 404）、formatBytes 单测。

## 无 DB 迁移

OSS 表已存在，只加只读查询。上线走含前端的全量 `pnpm build` + 单服务 `app:deploy gateway` / `oss`（不重启 agent）。