### PR TITLE
feat(spire): 补齐既有敌人组合遭遇（第二/三幕 8 组）

### DIFF
--- a/apps/spire/src/engine/enemies/enemies.ts
+++ b/apps/spire/src/engine/enemies/enemies.ts
@@ -1754,6 +1754,48 @@ const ENCOUNTERS: Record<string, EncounterDef> = {
   },
   // 奴隶主小队：工头 + 蓝/红奴隶主。
   slavers: { id: "slavers", enemies: ["taskmaster", "blue_slaver", "red_slaver"], isBoss: false },
+  // —— 第二幕组合遭遇（既有敌人拼装）——
+  cultist_and_chosen: {
+    id: "cultist_and_chosen",
+    enemies: ["cultist", "chosen"],
+    isBoss: false,
+  },
+  three_cultists: {
+    id: "three_cultists",
+    enemies: ["cultist", "cultist", "cultist"],
+    isBoss: false,
+  },
+  shelled_parasite_and_fungi: {
+    id: "shelled_parasite_and_fungi",
+    enemies: ["shelled_parasite", "fungi_beast"],
+    isBoss: false,
+  },
+  sentry_and_sphere: {
+    id: "sentry_and_sphere",
+    enemies: ["sentry", "spheric_guardian", "sentry"],
+    isBoss: false,
+  },
+  // —— 第三幕组合遭遇（几何体 shapes：爆破怪/斥力球/尖刺客 + 球卫/颚虫群）——
+  three_shapes: {
+    id: "three_shapes",
+    enemies: ["spiker", "exploder", "repulsor"],
+    isBoss: false,
+  },
+  four_shapes: {
+    id: "four_shapes",
+    enemies: ["spiker", "exploder", "repulsor", "exploder"],
+    isBoss: false,
+  },
+  sphere_and_two_shapes: {
+    id: "sphere_and_two_shapes",
+    enemies: ["exploder", "spheric_guardian", "repulsor"],
+    isBoss: false,
+  },
+  jaw_worm_horde: {
+    id: "jaw_worm_horde",
+    enemies: ["jaw_worm", "jaw_worm", "jaw_worm"],
+    isBoss: false,
+  },
   champ: { id: "champ", enemies: ["champ"], isBoss: true },
   bronze_automaton: { id: "bronze_automaton", enemies: ["bronze_automaton"], isBoss: true },
   the_collector: { id: "the_collector", enemies: ["the_collector"], isBoss: true },
@@ -1842,6 +1884,10 @@ const ACT2_STRONG_POOL: readonly WeightedEncounter[] = [
   { id: "snake_plant", weight: 1 },
   { id: "two_centurions", weight: 1 },
   { id: "spheric_guardian", weight: 1 },
+  { id: "cultist_and_chosen", weight: 1 },
+  { id: "three_cultists", weight: 1 },
+  { id: "shelled_parasite_and_fungi", weight: 1 },
+  { id: "sentry_and_sphere", weight: 1 },
 ];
 
 // —— 第三幕（超越）战斗池（切片）——
@@ -1859,6 +1905,10 @@ const ACT3_STRONG_POOL: readonly WeightedEncounter[] = [
   { id: "repulsor", weight: 1 },
   { id: "two_exploders", weight: 1 },
   { id: "two_orb_walkers", weight: 1 },
+  { id: "three_shapes", weight: 2 },
+  { id: "four_shapes", weight: 1 },
+  { id: "sphere_and_two_shapes", weight: 1 },
+  { id: "jaw_worm_horde", weight: 1 },
 ];
 
 function actWeakPool(act: number): readonly WeightedEncounter[] {

--- a/apps/spire/test/act2.test.ts
+++ b/apps/spire/test/act2.test.ts
@@ -29,6 +29,10 @@ describe("第二幕战斗池", () => {
     "chosen",
     "snecko",
     "centurion_mystic",
+    "cultist_and_chosen",
+    "three_cultists",
+    "shelled_parasite_and_fungi",
+    "sentry_and_sphere",
   ]);
 
   it("act=2 普通池只出第二幕怪", () => {

--- a/apps/spire/test/act3.test.ts
+++ b/apps/spire/test/act3.test.ts
@@ -42,6 +42,10 @@ describe("三幕", () => {
       "repulsor",
       "transient",
       "two_orb_walkers",
+      "three_shapes",
+      "four_shapes",
+      "sphere_and_two_shapes",
+      "jaw_worm_horde",
     ]);
     for (let seed = 0; seed < 40; seed += 1) {
       const rng = seedRng(seed);

--- a/apps/spire/test/encounters-extra.test.ts
+++ b/apps/spire/test/encounters-extra.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat } from "../src/engine/combat/combat.js";
+
+// PR3：新增的组合遭遇（既有敌人拼装）能正常起战、生成预期数量的敌人。
+
+const CASES: [string, number][] = [
+  ["cultist_and_chosen", 2],
+  ["three_cultists", 3],
+  ["shelled_parasite_and_fungi", 2],
+  ["sentry_and_sphere", 3],
+  ["three_shapes", 3],
+  ["four_shapes", 4],
+  ["sphere_and_two_shapes", 3],
+  ["jaw_worm_horde", 3],
+];
+
+describe("新增组合遭遇：起战与敌人数量", () => {
+  for (const [encounter, count] of CASES) {
+    it(`${encounter} → ${count} 个敌人，均有正血量`, () => {
+      const s = newRun({ runId: `enc-${encounter}`, seed: 1 });
+      startCombat(s, encounter);
+      expect(s.combat).not.toBeNull();
+      expect(s.combat!.enemies).toHaveLength(count);
+      for (const e of s.combat!.enemies) {
+        expect(e.hp).toBeGreaterThan(0);
+        expect(e.currentMove).toBeTruthy();
+      }
+    });
+  }
+});


### PR DESCRIPTION
## 背景
「杀戮尖塔向原版全面看齐」PR3。对照 `sts_lightspeed` `MonsterEncounters.h`（63 组），补齐可用**既有敌人**拼装的组合遭遇，充实二三幕战斗池。

## 改动
新增 8 组遭遇（全部复用已实现敌人，无新引擎逻辑）：
- **第二幕**（并入 STRONG 池）：`cultist_and_chosen` / `three_cultists` / `shelled_parasite_and_fungi` / `sentry_and_sphere`
- **第三幕**（并入 STRONG 池）：`three_shapes` / `four_shapes`（爆破怪·斥力球·尖刺客）/ `sphere_and_two_shapes` / `jaw_worm_horde`

act2/act3 池断言集同步扩充。

## 范围说明
需要**新敌人**的组合（`byrd` 拜鸟 / `mugger` 强盗 / `darkling` 暗影客 / `spire_growth` 尖塔幼体 / `maw` 巨口 / `writhing_mass` 蠕动之物）留待后续敌人批次——各自带独立 AI，属新敌人工作量，不在本纯数据 PR。

## 测试
新增 `test/encounters-extra.test.ts`（8 例）验证各组合起战、敌人数量与血量。spire **630 passed**；根级 build/typecheck/lint/format 全绿。