### PR TITLE
fix(spire): 回合开始击杀残敌时结算胜利，消除模拟器 stuck 死锁

### DIFF
--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -3289,6 +3289,12 @@ export function endTurn(state: GameState): void {
   for (let n = 0; n < creativeAi; n += 1) {
     addCards(state, WHITE_NOISE_POOL[nextInt(state.rng, WHITE_NOISE_POOL.length)]!, "hand", 1);
   }
+  // 回合开始的抽牌触发效果（火焰吐息随抽到状态牌 AoE、混沌打出牌、荆棘反弹等）可能打死最后的
+  // 敌人；此时必须结算胜利，否则会留在「全灭却仍在战斗」的死局里（无合法出牌目标）。
+  resolveCombatIfEnded(state);
+  if (state.combat === null || state.screen !== "combat") {
+    return;
+  }
   state.log.push(`第 ${combat.turn} 回合开始。`);
 }
 

--- a/apps/spire/test/turn-start-victory.test.ts
+++ b/apps/spire/test/turn-start-victory.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { newRun, applyAction } from "../src/engine/engine.js";
+import { startCombat } from "../src/engine/combat/combat.js";
+import type { GameState } from "../src/engine/types.js";
+
+// 回归：回合开始的抽牌触发效果（火焰吐息随抽到状态牌 AoE）打死最后的敌人时，
+// 必须结算胜利，而不是留在「全灭却仍在战斗」的死局（模拟器 9/1000 stuck 的根因）。
+
+describe("回合开始击杀 → 立即结算胜利（不卡死）", () => {
+  it("火焰吐息随抽到眩晕 AoE 打死残敌，战斗结束", () => {
+    const s: GameState = newRun({ runId: "tsv", seed: 1, character: "ironclad" });
+    startCombat(s, "cultist");
+    const combat = s.combat!;
+    // 玩家带火焰吐息 6：每抽到状态/诅咒牌，对全体造成 6。
+    combat.playerPowers = [{ id: "fire_breathing", amount: 6 }];
+    // 残敌 5 血；抽牌堆塞满眩晕（状态牌），回合开始抽到即触发 AoE。
+    combat.enemies[0]!.hp = 5;
+    combat.hand = [];
+    combat.drawPile = Array.from({ length: 5 }, () => ({
+      uid: s.nextUid++,
+      defId: "dazed",
+      upgraded: false,
+    }));
+    s.version = 1;
+    applyAction(s, { type: "end_turn" });
+    // 敌人被回合开始的 AoE 打死 → 战斗应已结算（combat 清空 + 离开 combat 屏），而非卡死。
+    expect(s.combat).toBeNull();
+    expect(s.screen).not.toBe("combat");
+  });
+});


### PR DESCRIPTION
## 背景
PR5。模拟器 1000 局有 9 局 `stuck`（4000 步跑满仍未结束）。

## 根因
`endTurn` 的「新玩家回合开始」序列会抽牌，而抽牌可触发 AoE：**火焰吐息**（每抽到一张状态/诅咒牌对全体 6 伤害）、混沌、荆棘反弹等。这些可能打死**最后的敌人**——但抽牌之后 `endTurn` 没有再做胜负判定，于是进入「敌人全灭（hp=0）却仍停在 combat 屏」的死局：没有存活目标，任何攻击牌都被 `playCard` 拒绝，贪心策略反复出同一张牌，卡死到 4000 步。

诊断：9 个 stuck 种子全部是此形态，典型是三哨卫战（哨卫的电击往手里塞眩晕，玩家攒了火焰吐息）。

## 修复
在 `endTurn` 回合开始序列末尾补一次 `resolveCombatIfEnded(state)`；若已结算则直接返回，不再打印「回合开始」。

模拟器 `stuck`：**9 → 0**（这 9 局改为正常判负）。

## 测试
新增 `test/turn-start-victory.test.ts`：构造火焰吐息 6 + 残敌 5 血 + 抽牌堆满眩晕，`end_turn` 后战斗应结算（combat 清空、离开 combat 屏）。spire **631 passed**；根级 build/typecheck/lint/format 全绿。