### PR TITLE
feat(spire): 扩展遗物钩子总线（onEquip/onLoseHp）+ 通用普通遗物批次

### DIFF
--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -22,7 +22,7 @@ import {
   getPower,
   removePower,
 } from "../powers/powers.js";
-import { getRelicDef, hasRelic } from "../relics/relics.js";
+import { getRelicDef, hasRelic, THE_BOOT_MIN_DAMAGE } from "../relics/relics.js";
 import type { RelicDef } from "../relics/relics.js";
 import { getPotionDef } from "../potions/potions.js";
 
@@ -321,6 +321,9 @@ function triggerRelicCombatEnd(state: GameState): void {
 }
 function triggerRelicTurnStart(state: GameState): void {
   fireRelicsCollectingEmits(state, (hooks, self, emit) => hooks.onTurnStart?.(state, self, emit));
+}
+function triggerRelicLoseHp(state: GameState): void {
+  fireRelicsCollectingEmits(state, (hooks, self, emit) => hooks.onLoseHp?.(state, self, emit));
 }
 function triggerRelicTurnEnd(state: GameState): void {
   fireRelicsCollectingEmits(state, (hooks, self, emit) => hooks.onTurnEnd?.(state, self, emit));
@@ -2242,6 +2245,10 @@ function dealDamageToEnemy(
   if (getPower(enemy.powers, "intangible") > 0) {
     dmg = Math.min(dmg, 1);
   }
+  // 战靴：一次无格挡攻击伤害为 1~4 时，改为造成 5（对齐 StS 只在有正伤害时生效）。
+  if (dmg >= 1 && dmg <= 4 && hasRelic(state, "the_boot")) {
+    dmg = THE_BOOT_MIN_DAMAGE;
+  }
   // 守卫者模式切换：进攻姿态下累计受到的伤害达阈值即切姿态（issue #234 C10）。
   if (enemy.stance === "offensive" && enemy.modeShiftThreshold !== null) {
     enemy.modeShiftAccum += dmg;
@@ -2335,6 +2342,7 @@ function dealDamageToPlayer(
   if (afterBlock > 0) {
     state.hp = Math.max(0, state.hp - afterBlock);
     combat.timesLostHpThisCombat += 1; // 血债血偿按本场失血次数降费。
+    triggerRelicLoseHp(state); // 失血遗物钩子（百年谜题首次失血抽牌）。
   }
   // 镀甲：受到穿透格挡的攻击伤害时 -1 层。
   if (afterBlock > 0 && getPower(combat.playerPowers, "plated_armor") > 0) {

--- a/apps/spire/src/engine/relics/relics.ts
+++ b/apps/spire/src/engine/relics/relics.ts
@@ -1,5 +1,7 @@
 import type { CardType, CharacterId, Effect, GameState, RelicState } from "../types.js";
 import { addPower } from "../powers/powers.js";
+import { getCardDef } from "../cards/cards.js";
+import { nextInt } from "../rng.js";
 
 // === 遗物系统 ===
 //
@@ -28,6 +30,10 @@ export type RelicHooks = {
   onTurnStart?: (state: GameState, self: RelicState, emit: Emit) => void;
   onTurnEnd?: (state: GameState, self: RelicState, emit: Emit) => void;
   onCardPlayed?: (state: GameState, self: RelicState, cardType: CardType, emit: Emit) => void;
+  /** 获得该遗物时结算一次（草莓 +最大生命、药水腰带 +药水槽、磨刀石/战争彩绘升级牌）。局外，无 emit。 */
+  onEquip?: (state: GameState, self: RelicState) => void;
+  /** 玩家受到穿透格挡的伤害（失血）后结算（百年谜题首次失血抽牌）。可 emit 战斗 Effect。 */
+  onLoseHp?: (state: GameState, self: RelicState, emit: Emit) => void;
 };
 
 /** 计数型遗物：自增 self.counter，达到 every 则归零并返回 true（触发效果）。 */
@@ -56,9 +62,26 @@ const ANCHOR_BLOCK = 10;
 const LANTERN_ENERGY = 1;
 const VAJRA_STRENGTH = 1;
 const MARBLES_VULNERABLE = 1;
+const STRAWBERRY_MAX_HP = 7;
+const AKABEKO_VIGOR = 8;
+const PUZZLE_DRAW = 3;
+const PREPARATION_DRAW = 2;
+export const THE_BOOT_MIN_DAMAGE = 5; // 战靴：无格挡攻击伤害 ≤4 时改为的下限值。
 
 function healPlayer(state: GameState, amount: number): void {
   state.hp = Math.min(state.maxHp, state.hp + amount);
+}
+
+/** 随机升级牌组中 count 张未升级的指定类型牌（磨刀石=攻击、战争彩绘=技能）。 */
+function upgradeRandomCardsOfType(state: GameState, type: CardType, count: number): void {
+  const candidates = state.deck.filter(
+    card => !card.upgraded && getCardDef(card.defId).type === type,
+  );
+  for (let n = 0; n < count && candidates.length > 0; n += 1) {
+    const idx = nextInt(state.rng, candidates.length);
+    candidates[idx]!.upgraded = true;
+    candidates.splice(idx, 1);
+  }
 }
 
 const RELIC_LIST: RelicDef[] = [
@@ -484,7 +507,103 @@ const RELIC_LIST: RelicDef[] = [
       },
     },
   },
+  // —— 通用普通遗物批次（借新增的 onEquip / onLoseHp 钩子）——
+  {
+    id: "strawberry",
+    name: "草莓",
+    rarity: "common",
+    description: "获得时，最大生命 +7。",
+    hooks: {
+      onEquip: state => {
+        state.maxHp += STRAWBERRY_MAX_HP;
+        state.hp += STRAWBERRY_MAX_HP;
+      },
+    },
+  },
+  {
+    id: "potion_belt",
+    name: "药水腰带",
+    rarity: "common",
+    description: "获得时，额外增加 2 个药水槽。",
+    hooks: {
+      onEquip: state => {
+        state.potions.push(null, null);
+      },
+    },
+  },
+  {
+    id: "whetstone",
+    name: "磨刀石",
+    rarity: "common",
+    description: "获得时，随机升级 2 张攻击牌。",
+    hooks: {
+      onEquip: state => upgradeRandomCardsOfType(state, "attack", 2),
+    },
+  },
+  {
+    id: "war_paint",
+    name: "战争彩绘",
+    rarity: "common",
+    description: "获得时，随机升级 2 张技能牌。",
+    hooks: {
+      onEquip: state => upgradeRandomCardsOfType(state, "skill", 2),
+    },
+  },
+  {
+    id: "akabeko",
+    name: "赤红牛铃",
+    rarity: "common",
+    description: "每场战斗你的第一张攻击牌额外造成 8 点伤害。",
+    hooks: {
+      onCombatStart: state => {
+        if (state.combat) {
+          addPower(state.combat.playerPowers, "vigor", AKABEKO_VIGOR);
+        }
+      },
+    },
+  },
+  {
+    id: "bag_of_preparation",
+    name: "行囊",
+    rarity: "common",
+    description: "每场战斗第一回合额外抽 2 张牌。",
+    hooks: {
+      onCombatStart: (_state, _self, emit) => emit({ kind: "draw", amount: PREPARATION_DRAW }),
+    },
+  },
+  {
+    id: "centennial_puzzle",
+    name: "百年谜题",
+    rarity: "common",
+    description: "每场战斗中第一次失去生命时，抽 3 张牌。",
+    hooks: {
+      onCombatStart: (_state, self) => {
+        self.counter = 0;
+      },
+      onLoseHp: (_state, self, emit) => {
+        if (self.counter === 0) {
+          self.counter = 1;
+          emit({ kind: "draw", amount: PUZZLE_DRAW });
+        }
+      },
+    },
+  },
+  {
+    id: "the_boot",
+    name: "战靴",
+    // 伤害下限修正在 combat.ts 的 dealDamageToEnemy 里按 hasRelic 处理（不走钩子）。
+    rarity: "common",
+    description: "当你的一次无格挡攻击伤害为 4 或更低时，改为造成 5 点。",
+    hooks: {},
+  },
 ];
+
+/** 获得一件遗物：入列 + 结算 onEquip（草莓 +最大生命等一次性效果）。日志由调用方按情景补。 */
+export function grantRelic(state: GameState, id: string): void {
+  const self: RelicState = { id, counter: 0 };
+  state.relics.push(self);
+  getRelicDef(id).hooks.onEquip?.(state, self);
+}
 
 const RELIC_MAP: ReadonlyMap<string, RelicDef> = new Map(
   RELIC_LIST.map(relic => [relic.id, relic]),

--- a/apps/spire/src/engine/run/run.ts
+++ b/apps/spire/src/engine/run/run.ts
@@ -2,7 +2,7 @@ import type { GameState, MapNode, MapNodeType } from "../types.js";
 import { cardPoolOf, getCardDef, costOf } from "../cards/cards.js";
 import { getCharacterConfig } from "../characters/characters.js";
 import { pickBossEncounter, pickEliteEncounter, pickNormalEncounter } from "../enemies/enemies.js";
-import { rewardRelicPool, getRelicDef, hasRelic } from "../relics/relics.js";
+import { rewardRelicPool, getRelicDef, hasRelic, grantRelic } from "../relics/relics.js";
 import {
   BASE_POTION_DROP_CHANCE,
   POTION_DROP_POOL,
@@ -131,7 +131,7 @@ function grantTreasure(state: GameState): void {
   const available = rewardRelicPool(state.character).filter(id => !hasRelic(state, id));
   if (available.length > 0) {
     const id = available[nextInt(state.rng, available.length)]!;
-    state.relics.push({ id, counter: 0 });
+    grantRelic(state, id);
     state.log.push(`你打开宝箱，获得遗物「${getRelicDef(id).name}」。`);
     return;
   }
@@ -350,7 +350,7 @@ function buyShopItem(
     state.deck.push({ uid: state.nextUid++, defId: item.defId, upgraded: false });
     state.log.push(`你买下了牌「${getCardDef(item.defId).name}」。`);
   } else if (item.kind === "relic") {
-    state.relics.push({ id: item.id, counter: 0 });
+    grantRelic(state, item.id);
     state.log.push(`你买下了遗物「${getRelicDef(item.id).name}」。`);
   } else {
     state.potions[state.potions.indexOf(null)] = item.id;

--- a/apps/spire/test/relics-batch2.test.ts
+++ b/apps/spire/test/relics-batch2.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat, playCard } from "../src/engine/combat/combat.js";
+import { grantRelic, getRelicDef } from "../src/engine/relics/relics.js";
+import { getPower } from "../src/engine/powers/powers.js";
+import { getCardDef } from "../src/engine/cards/cards.js";
+import type { Effect, GameState } from "../src/engine/types.js";
+
+// PR6：遗物钩子总线扩展（onEquip / onLoseHp）+ 通用普通遗物批次。
+
+function run(): GameState {
+  return newRun({ runId: "r6", seed: 4, character: "ironclad" });
+}
+
+describe("onEquip 一次性效果", () => {
+  it("草莓：最大生命 +7", () => {
+    const s = run();
+    const maxHp = s.maxHp;
+    grantRelic(s, "strawberry");
+    expect(s.maxHp).toBe(maxHp + 7);
+    expect(s.hp).toBe(maxHp + 7);
+  });
+
+  it("药水腰带：+2 药水槽", () => {
+    const s = run();
+    const slots = s.potions.length;
+    grantRelic(s, "potion_belt");
+    expect(s.potions.length).toBe(slots + 2);
+  });
+
+  it("磨刀石：升级 2 张攻击牌", () => {
+    const s = run();
+    grantRelic(s, "whetstone");
+    const upgradedAttacks = s.deck.filter(
+      c => c.upgraded && getCardDef(c.defId).type === "attack",
+    ).length;
+    expect(upgradedAttacks).toBe(2);
+  });
+
+  it("战争彩绘：升级 2 张技能牌", () => {
+    const s = run();
+    grantRelic(s, "war_paint");
+    const upgradedSkills = s.deck.filter(
+      c => c.upgraded && getCardDef(c.defId).type === "skill",
+    ).length;
+    expect(upgradedSkills).toBe(2);
+  });
+});
+
+describe("战斗开始钩子", () => {
+  it("赤红牛铃：战斗开始给活力 8，第一张攻击 +8 伤害", () => {
+    const s = run();
+    grantRelic(s, "akabeko");
+    startCombat(s, "cultist");
+    expect(getPower(s.combat!.playerPowers, "vigor")).toBe(8);
+    const before = s.combat!.enemies[0]!.hp;
+    s.combat!.hand = [{ uid: s.nextUid++, defId: "strike", upgraded: false }];
+    s.combat!.energy = 3;
+    expect(playCard(s, 0, 0).ok).toBe(true);
+    expect(before - s.combat!.enemies[0]!.hp).toBe(6 + 8);
+  });
+
+  it("行囊：第一回合多抽 2 张（起手 7 张）", () => {
+    const s = run();
+    grantRelic(s, "bag_of_preparation");
+    startCombat(s, "cultist");
+    expect(s.combat!.hand).toHaveLength(7);
+  });
+});
+
+describe("战靴：无格挡攻击伤害 ≤4 改为 5", () => {
+  it("飞刀 4 伤 → 5 伤", () => {
+    const s = run();
+    grantRelic(s, "the_boot");
+    startCombat(s, "cultist");
+    const before = s.combat!.enemies[0]!.hp;
+    s.combat!.hand = [{ uid: s.nextUid++, defId: "shiv", upgraded: false }];
+    s.combat!.energy = 3;
+    expect(playCard(s, 0, 0).ok).toBe(true);
+    expect(before - s.combat!.enemies[0]!.hp).toBe(5);
+  });
+});
+
+describe("百年谜题：每场首次失血抽 3（onLoseHp 钩子）", () => {
+  it("首次失血 emit 抽 3，之后不再触发", () => {
+    const s = run();
+    const self = { id: "centennial_puzzle", counter: 0 };
+    const hooks = getRelicDef("centennial_puzzle").hooks;
+    hooks.onCombatStart?.(s, self, () => {});
+    const emitted: Effect[] = [];
+    hooks.onLoseHp?.(s, self, e => emitted.push(e));
+    hooks.onLoseHp?.(s, self, e => emitted.push(e)); // 第二次不应再抽
+    expect(emitted).toEqual([{ kind: "draw", amount: 3 }]);
+  });
+});


### PR DESCRIPTION
## 背景
PR6（原 A0）。遗物钩子总线此前有 onCombatStart/End、onTurnStart/End、onCardPlayed(+counter+emit)。本 PR 补两个最常用的缺失触发点，并落一批通用普通遗物验证。

## 改动
**钩子总线扩展**
- `onEquip(state, self)`：获得遗物时结算一次（局外，无 emit）。新增 `grantRelic()` 统一入列 + 触发 onEquip，宝箱 / 商店购买两处 relic 入列都改走它。
- `onLoseHp(state, self, emit)`：玩家受穿透格挡伤害（失血）后结算，可 emit 战斗 Effect；接在 `dealDamageToPlayer` 失血处。

**8 件通用普通遗物**
| 遗物 | 钩子 | 效果 |
|---|---|---|
| 草莓 strawberry | onEquip | 最大生命 +7 |
| 药水腰带 potion_belt | onEquip | +2 药水槽 |
| 磨刀石 whetstone | onEquip | 随机升级 2 攻击 |
| 战争彩绘 war_paint | onEquip | 随机升级 2 技能 |
| 赤红牛铃 akabeko | onCombatStart | 首张攻击 +8（活力 8） |
| 行囊 bag_of_preparation | onCombatStart | 首回合多抽 2 |
| 百年谜题 centennial_puzzle | onLoseHp | 每场首次失血抽 3 |
| 战靴 the_boot | （dealDamageToEnemy 特判） | 无格挡攻击伤害 ≤4 改为 5 |

均自动并入通用奖励/商店遗物池（按 rarity=common）。

## 测试
`test/relics-batch2.test.ts`（8 例）覆盖各 onEquip / onCombatStart 效果、战靴伤害下限、百年谜题 onLoseHp 一次性。spire **639 passed**；根级 build/typecheck/lint/format 全绿。