### PR TITLE
refactor: 收窄类型消除 8 个 no-unsafe-* lint 告警

### DIFF
--- a/apps/web/src/components/ui/chart.tsx
+++ b/apps/web/src/components/ui/chart.tsx
@@ -142,7 +142,8 @@ function ChartTooltipContent({
           .map((item, index) => {
             const key = `${nameKey || item.name || item.dataKey || "value"}`;
             const itemConfig = getPayloadConfigFromPayload(config, item, key);
-            const indicatorColor = color || item.payload.fill || item.color;
+            const itemFill = (item.payload as { fill?: string } | undefined)?.fill;
+            const indicatorColor = color || itemFill || item.color;
 
             return (
               <div
@@ -153,7 +154,7 @@ function ChartTooltipContent({
                 )}
               >
                 {formatter && item?.value !== undefined && item.name ? (
-                  formatter(item.value, item.name, item, index, item.payload)
+                  formatter(item.value, item.name, item, index, payload)
                 ) : (
                   <>
                     {itemConfig?.icon ? (
@@ -243,7 +244,7 @@ function ChartLegendContent({
 
           return (
             <div
-              key={item.value}
+              key={String(item.value)}
               className={cn(
                 "flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3 [&>svg]:text-muted-foreground",
               )}

--- a/packages/rpc-client/src/binary-client.ts
+++ b/packages/rpc-client/src/binary-client.ts
@@ -123,7 +123,7 @@ async function callBinaryEnvelope(
   }
 
   if (!response.ok) {
-    const body = await response.json().catch(() => null);
+    const body: unknown = await response.json().catch(() => null);
     const decoded = ctx.decodeError(response.status, body);
     if (decoded) {
       throw decoded;

--- a/packages/rpc-client/src/client.ts
+++ b/packages/rpc-client/src/client.ts
@@ -149,7 +149,7 @@ async function callJsonRoute(
   }
 
   if (!response.ok) {
-    const body = await response.json().catch(() => null);
+    const body: unknown = await response.json().catch(() => null);
     const decoded = ctx.decodeError(response.status, body);
     if (decoded) {
       throw decoded;


### PR DESCRIPTION
## 背景

`/health` 体检发现 `pnpm lint` 有 8 个 `@typescript-eslint/no-unsafe-*` 告警（0 error，不阻塞构建）。本 PR 全部清掉，lint 归零。按项目约定不用 `eslint-disable` 压制，改代码让规则自然满足。

## 改动（3 文件，纯类型收窄，无运行时行为变化）

| 文件 | 原因 | 改法 |
|---|---|---|
| `rpc-client/src/client.ts` `binary-client.ts` | `response.json()` 返回 `any` | `const body: unknown = ...`，对齐同文件下方 `payload` 已有的 `as unknown` |
| `web/chart.tsx` (145/176/177) | recharts `Payload.payload` 官方声明为 `any` | 就地 `as { fill?: string }` 收窄取 `.fill`，`indicatorColor` 随之变 `string` |
| `web/chart.tsx` (156) | formatter 第 5 参传的是单条 `item.payload`(any)，而 recharts `Formatter` 该参类型是 `Array<Payload>` | 改传完整 `payload` 数组——既是正确类型也贴合契约；唯一调用方 `AuthPage.tsx:544` 是 3 参 formatter，忽略后两参，行为不变 |
| `web/chart.tsx` (246) | legend `Payload.value` 也是 `any` | React key 用 `String(item.value)` |

## 验证

- `pnpm lint` → **0 problems**（原 8 warnings）
- `pnpm build` / `pnpm typecheck` / `pnpm format` 全绿
- `pnpm test` → 1876/1876 通过

无 DB 迁移、无配置变更、无面向用户的文档变化。