### PR TITLE
feat(spire): 补充 9 个 ? 节点事件（机制忠实、文案原创）

### DIFF
--- a/apps/spire/src/engine/events/events.ts
+++ b/apps/spire/src/engine/events/events.ts
@@ -253,6 +253,183 @@ const EVENT_LIST: EventDef[] = [
       },
     ],
   },
+  // —— 补全批次：更多 ? 节点事件（机制忠实、文案原创）——
+  {
+    id: "golden_idol",
+    description:
+      "祭坛中央供着一尊沉甸甸的金像，它的眼睛像是在盯着你看。伸手去拿，总觉得会惊动什么。",
+    choices: [
+      {
+        label: "抱走金像",
+        resultText: "金像入手的刹那，一道无形的诅咒钻进了你的牌组。",
+        outcomes: [{ kind: "gain_relic" }, { kind: "add_card", cardId: "injury" }],
+      },
+      {
+        label: "不碰，转身离开",
+        resultText: "你压下贪念，退出了这间密室。",
+        outcomes: [{ kind: "nothing" }],
+      },
+    ],
+  },
+  {
+    id: "big_fish",
+    description: "一汪水潭里游着条通人性的大鱼。它吐出三样东西，示意你只能挑一件。",
+    choices: [
+      {
+        label: "香蕉（回复生命）",
+        resultText: "果肉香甜，倦意与伤痛都消退了不少。",
+        outcomes: [{ kind: "heal", amount: 25 }],
+      },
+      {
+        label: "甜甜圈（最大生命 +6）",
+        resultText: "一股扎实的暖流沉入身体，你比先前更耐打了。",
+        outcomes: [{ kind: "gain_max_hp", amount: 6 }],
+      },
+      {
+        label: "木盒（一件遗物，附带代价）",
+        resultText: "盒中是件古物，可打开它也松开了封在里面的悔意。",
+        outcomes: [{ kind: "gain_relic" }, { kind: "add_card", cardId: "regret" }],
+      },
+    ],
+  },
+  {
+    id: "golden_shrine",
+    description: "一座敷着金箔的神龛静立在尘埃里，隐隐透出可以被亵渎、也可以被敬奉的气息。",
+    choices: [
+      {
+        label: "虔诚祈祷",
+        resultText: "神龛回应了你的敬意，几枚金币凭空落下。",
+        outcomes: [{ kind: "gain_gold", amount: 100 }],
+      },
+      {
+        label: "撬走金箔（更多金币，招致诅咒）",
+        resultText: "你剥下所有金箔，也剥落了自己的一点体面。",
+        outcomes: [
+          { kind: "gain_gold", amount: 275 },
+          { kind: "add_card", cardId: "regret" },
+        ],
+      },
+      {
+        label: "转身离开",
+        resultText: "你向神龛行了一礼，退了出去。",
+        outcomes: [{ kind: "nothing" }],
+      },
+    ],
+  },
+  {
+    id: "the_serpent",
+    description:
+      "阴影里盘着一条会说话的长蛇，它用尾尖挑着一袋金币，语气甜得发腻：拿去吧，不要白不要。",
+    choices: [
+      {
+        label: "接过金币（种下疑虑）",
+        resultText: "钱袋沉甸甸的，可你心里从此多了一根拔不掉的刺。",
+        outcomes: [
+          { kind: "gain_gold", amount: 175 },
+          { kind: "add_card", cardId: "doubt" },
+        ],
+      },
+      {
+        label: "不理它，走开",
+        resultText: "你没有回头，蛇的嗤笑消失在身后。",
+        outcomes: [{ kind: "nothing" }],
+      },
+    ],
+  },
+  {
+    id: "world_of_goop",
+    description: "整个房间灌满了半凝的黏液，金币若隐若现地悬在其中。伸手去捞，代价是弄得满身狼狈。",
+    choices: [
+      {
+        label: "把手伸进黏液捞金币",
+        resultText: "你抓到了不少硬币，也被黏液啃掉了一层皮。",
+        outcomes: [
+          { kind: "gain_gold", amount: 75 },
+          { kind: "lose_hp", amount: 11 },
+        ],
+      },
+      {
+        label: "绕开这摊麻烦",
+        resultText: "你贴着墙根挪了出去，一枚金币也没沾。",
+        outcomes: [{ kind: "nothing" }],
+      },
+    ],
+  },
+  {
+    id: "scrap_ooze",
+    description: "一团软泥裹着某样硬邦邦的东西缓缓蠕动。想拿到它，就得忍着它的腐蚀往里掏。",
+    choices: [
+      {
+        label: "忍痛掏出里面的东西",
+        resultText: "腐蚀灼着你的手，但指尖终于扣住了一件遗物。",
+        outcomes: [{ kind: "lose_hp", amount: 3 }, { kind: "gain_relic" }],
+      },
+      {
+        label: "不值得，走开",
+        resultText: "你甩了甩发麻的手，离开了。",
+        outcomes: [{ kind: "nothing" }],
+      },
+    ],
+  },
+  {
+    id: "the_cleric",
+    description: "一位游方牧师在废墟里支起摊子，说只要付些金币，他能为你诵一段驱痛的祷文。",
+    choices: [
+      {
+        label: "付 35 金币，接受治疗",
+        resultText: "祷文低回，伤口以肉眼可见的速度合拢。",
+        outcomes: [
+          { kind: "lose_gold", amount: 35 },
+          { kind: "heal", amount: 25 },
+        ],
+      },
+      {
+        label: "囊中羞涩，谢过离开",
+        resultText: "牧师点点头，目送你远去。",
+        outcomes: [{ kind: "nothing" }],
+      },
+    ],
+  },
+  {
+    id: "forgotten_altar",
+    description: "一座荒废已久的祭坛，凹槽里还残留着暗褐色的痕迹。它似乎渴望一份献祭。",
+    choices: [
+      {
+        label: "献上鲜血（最大生命 +7）",
+        resultText: "你割破掌心滴入凹槽，祭坛回赠你一具更坚韧的躯体。",
+        outcomes: [
+          { kind: "lose_hp", amount: 5 },
+          { kind: "gain_max_hp", amount: 7 },
+        ],
+      },
+      {
+        label: "供上金币（换一件遗物）",
+        resultText: "金币没入凹槽，祭坛深处升起一件古物。",
+        outcomes: [{ kind: "lose_gold", amount: 50 }, { kind: "gain_relic" }],
+      },
+      {
+        label: "不打扰它，离开",
+        resultText: "你退后一步，让祭坛继续沉睡。",
+        outcomes: [{ kind: "nothing" }],
+      },
+    ],
+  },
+  {
+    id: "wing_statue",
+    description: "一尊长着翅膀的石像立在通道尽头，翼尖挂着一枚闪光的护符，触手可及。",
+    choices: [
+      {
+        label: "取下护符（一件遗物，代价是刺痛）",
+        resultText: "护符入手，石像的翅膀无声地垂了下去。",
+        outcomes: [{ kind: "gain_relic" }, { kind: "lose_hp", amount: 7 }],
+      },
+      {
+        label: "向石像祈祷（回复生命）",
+        resultText: "你合十默祷，一阵微光拂过，倦意稍解。",
+        outcomes: [{ kind: "heal", amount: 15 }],
+      },
+    ],
+  },
 ];
 
 const EVENT_MAP: ReadonlyMap<string, EventDef> = new Map(

--- a/apps/spire/test/events-batch.test.ts
+++ b/apps/spire/test/events-batch.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { newRun, applyAction } from "../src/engine/engine.js";
+import { getEventDef } from "../src/engine/events/events.js";
+import type { GameState } from "../src/engine/types.js";
+
+// 事件补全批次：每个新事件的选项都能正常结算（金币/生命/最大生命/遗物/诅咒牌）。
+
+function atEvent(id: string): GameState {
+  const s = newRun({ runId: "ev", seed: 2, character: "ironclad" });
+  s.screen = "event";
+  s.event = { id };
+  s.version = 1;
+  s.gold = 500;
+  return s;
+}
+
+const NEW_EVENTS = [
+  "golden_idol",
+  "big_fish",
+  "golden_shrine",
+  "the_serpent",
+  "world_of_goop",
+  "scrap_ooze",
+  "the_cleric",
+  "forgotten_altar",
+  "wing_statue",
+];
+
+describe("新事件：结构完整、可结算", () => {
+  for (const id of NEW_EVENTS) {
+    it(`${id} 每个选项都能结算且离开事件屏`, () => {
+      const def = getEventDef(id);
+      expect(def.choices.length).toBeGreaterThanOrEqual(2);
+      for (let i = 0; i < def.choices.length; i += 1) {
+        const s = atEvent(id);
+        const r = applyAction(s, { type: "choose", optionIndex: i });
+        expect(r.ok).toBe(true);
+        expect(s.screen).not.toBe("event"); // 选完离开事件屏
+      }
+    });
+  }
+});
+
+describe("关键事件的具体结果", () => {
+  it("金像：抱走 → 得遗物 + 牌组多一张诅咒", () => {
+    const s = atEvent("golden_idol");
+    const relics = s.relics.length;
+    applyAction(s, { type: "choose", optionIndex: 0 });
+    expect(s.relics.length).toBe(relics + 1);
+    expect(s.deck.some(c => c.defId === "injury")).toBe(true);
+  });
+
+  it("蛇：接过金币 → +175 金币 + 疑虑诅咒", () => {
+    const s = atEvent("the_serpent");
+    applyAction(s, { type: "choose", optionIndex: 0 });
+    expect(s.gold).toBe(500 + 175);
+    expect(s.deck.some(c => c.defId === "doubt")).toBe(true);
+  });
+
+  it("大鱼：甜甜圈 → 最大生命 +6", () => {
+    const s = atEvent("big_fish");
+    const maxHp = s.maxHp;
+    applyAction(s, { type: "choose", optionIndex: 1 });
+    expect(s.maxHp).toBe(maxHp + 6);
+  });
+});


### PR DESCRIPTION
## 背景
事件补全批次。? 节点事件从 13 → 22，充实探索内容（贴合项目「Agent as a life」的生活输入定位）。

## 改动
用既有 `EventOutcome`（金币/生命/最大生命/加牌/遗物/药水/nothing）拼装 9 个经典事件，复刻其**取舍机制**，**描述与结果全为原创中文**（遵守仓库「只抄机制不抄文案」约束）：

金像（遗物↔诅咒）· 大鱼（回血/最大生命/遗物+诅咒三选一）· 金色神龛（祈祷/亵渎+诅咒）· 长蛇（金币+疑虑）· 黏球世界（金币↔失血）· 废料软泥（失血→遗物）· 游方牧师（付费治疗）· 被遗忘的祭坛（献祭↔最大生命/遗物）· 翼之像（遗物↔失血 / 回血）。

自动并入 `EVENT_POOL`。

## 范围说明
需要**新 outcome 类型**的事件（移除/升级/转化牌、触发战斗、随机化等）留待后续扩展 `EventOutcome` 再补。

## 测试
`test/events-batch.test.ts`（12 例）：每个新事件各选项都能结算并离开事件屏，且校验金像/长蛇/大鱼的具体结果。spire **659 passed**；根级 build/typecheck/lint/format 全绿。