### PR TITLE
feat(spire): 通用遗物批次 2（战争艺术/墨水瓶/熏香炉/自塑黏土/杜巫娃娃）

### DIFF
--- a/apps/spire/src/engine/relics/relics.ts
+++ b/apps/spire/src/engine/relics/relics.ts
@@ -596,6 +596,78 @@ const RELIC_LIST: RelicDef[] = [
     description: "当你的一次无格挡攻击伤害为 4 或更低时，改为造成 5 点。",
     hooks: {},
   },
+  // —— 通用遗物批次 2（借既有钩子：计数 / 回合始 / 失血 / 战斗始）——
+  {
+    id: "art_of_war",
+    name: "战争艺术",
+    rarity: "common",
+    description: "若某个回合你没有打出攻击牌，下个回合开始时获得 1 点能量。",
+    hooks: {
+      onCombatStart: (_state, self) => {
+        self.counter = 0;
+      },
+      onTurnStart: (_state, self, emit) => {
+        if (self.counter === 0) {
+          emit({ kind: "gain_energy", amount: 1 });
+        }
+        self.counter = 0;
+      },
+      onCardPlayed: (_state, self, cardType) => {
+        if (cardType === "attack") {
+          self.counter = 1;
+        }
+      },
+    },
+  },
+  {
+    id: "ink_bottle",
+    name: "墨水瓶",
+    rarity: "uncommon",
+    description: "每打出 10 张牌，抽 1 张牌。",
+    hooks: {
+      onCardPlayed: (_state, self, _cardType, emit) => {
+        if (tickEvery(self, 10)) {
+          emit({ kind: "draw", amount: 1 });
+        }
+      },
+    },
+  },
+  {
+    id: "incense_burner",
+    name: "熏香炉",
+    rarity: "rare",
+    description: "每过 6 个回合，获得 1 层虚无缥缈。",
+    hooks: {
+      onTurnStart: (_state, self, emit) => {
+        if (tickEvery(self, 6)) {
+          emit({ kind: "apply_power", power: "intangible", amount: 1, on: "self" });
+        }
+      },
+    },
+  },
+  {
+    id: "self_forming_clay",
+    name: "自塑黏土",
+    rarity: "uncommon",
+    description: "每当你失去生命，下个回合开始时获得 3 点格挡。",
+    hooks: {
+      onLoseHp: (_state, _self, emit) => emit({ kind: "gain_block_next_turn", amount: 3 }),
+    },
+  },
+  {
+    id: "du_vu_doll",
+    name: "杜巫娃娃",
+    rarity: "rare",
+    description: "牌组中每有一张诅咒牌，战斗开始时获得 1 点力量。",
+    hooks: {
+      onCombatStart: (state, _self, emit) => {
+        const curses = state.deck.filter(card => getCardDef(card.defId).type === "curse").length;
+        if (curses > 0) {
+          emit({ kind: "apply_power", power: "strength", amount: curses, on: "self" });
+        }
+      },
+    },
+  },
 ];
 
 /** 获得一件遗物：入列 + 结算 onEquip（草莓 +最大生命等一次性效果）。日志由调用方按情景补。 */

--- a/apps/spire/test/relics-batch3.test.ts
+++ b/apps/spire/test/relics-batch3.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat } from "../src/engine/combat/combat.js";
+import { grantRelic, getRelicDef } from "../src/engine/relics/relics.js";
+import { getPower } from "../src/engine/powers/powers.js";
+import type { Effect, GameState, RelicState } from "../src/engine/types.js";
+
+// PR（遗物批次 2）：借既有钩子（计数 / 回合始 / 失血 / 战斗始）的通用遗物。
+
+function run(): GameState {
+  return newRun({ runId: "rb3", seed: 6, character: "ironclad" });
+}
+
+/** 反复调用一个 emit 型钩子，收集其发射的 Effect。 */
+function collectHook(times: number, invoke: (self: RelicState, emit: (e: Effect) => void) => void) {
+  const self: RelicState = { id: "x", counter: 0 };
+  const emitted: Effect[] = [];
+  for (let i = 0; i < times; i += 1) {
+    invoke(self, e => emitted.push(e));
+  }
+  return emitted;
+}
+
+describe("战争艺术：不出攻击则下回合 +1 能量", () => {
+  it("战斗第一回合即 +1 能量", () => {
+    const s = run();
+    grantRelic(s, "art_of_war");
+    startCombat(s, "cultist");
+    expect(s.combat!.energy).toBe(s.combat!.maxEnergy + 1);
+  });
+});
+
+describe("墨水瓶：每 10 张牌抽 1", () => {
+  it("第 10 次出牌触发抽 1", () => {
+    const hooks = getRelicDef("ink_bottle").hooks;
+    const emitted = collectHook(10, (self, emit) =>
+      hooks.onCardPlayed!(run(), self, "skill", emit),
+    );
+    expect(emitted).toEqual([{ kind: "draw", amount: 1 }]);
+  });
+});
+
+describe("熏香炉：每 6 回合 +1 虚无缥缈", () => {
+  it("第 6 次回合始触发", () => {
+    const hooks = getRelicDef("incense_burner").hooks;
+    const emitted = collectHook(6, (self, emit) => hooks.onTurnStart!(run(), self, emit));
+    expect(emitted).toEqual([{ kind: "apply_power", power: "intangible", amount: 1, on: "self" }]);
+  });
+});
+
+describe("自塑黏土：失血 → 下回合 +3 格挡", () => {
+  it("每次失血 emit 一次下回合格挡", () => {
+    const hooks = getRelicDef("self_forming_clay").hooks;
+    const emitted = collectHook(1, (self, emit) => hooks.onLoseHp!(run(), self, emit));
+    expect(emitted).toEqual([{ kind: "gain_block_next_turn", amount: 3 }]);
+  });
+});
+
+describe("杜巫娃娃：每张诅咒 +1 力量（战斗开始）", () => {
+  it("牌组 2 张诅咒 → 战斗开始 +2 力量", () => {
+    const s = run();
+    grantRelic(s, "du_vu_doll");
+    s.deck.push(
+      { uid: s.nextUid++, defId: "injury", upgraded: false },
+      { uid: s.nextUid++, defId: "regret", upgraded: false },
+    );
+    startCombat(s, "cultist");
+    expect(getPower(s.combat!.playerPowers, "strength")).toBe(2);
+  });
+});


### PR DESCRIPTION
## 背景
遗物补全批次 2。全部复用 PR6 已有 / 扩展的钩子，无新引擎逻辑。

## 改动（5 件通用遗物）
| 遗物 | 稀有度 | 钩子 | 效果 |
|---|---|---|---|
| 战争艺术 art_of_war | common | onTurnStart+onCardPlayed | 某回合没打攻击 → 下回合 +1 能量 |
| 墨水瓶 ink_bottle | uncommon | onCardPlayed 计数 | 每打出 10 张牌抽 1 |
| 熏香炉 incense_burner | rare | onTurnStart 计数 | 每 6 回合 +1 虚无缥缈 |
| 自塑黏土 self_forming_clay | uncommon | onLoseHp | 失血 → 下回合 +3 格挡 |
| 杜巫娃娃 du_vu_doll | rare | onCombatStart | 牌组每张诅咒 → 战斗始 +1 力量 |

自动并入奖励/商店遗物池。

## 测试
`test/relics-batch3.test.ts`（5 例，集成 + 钩子单测）。spire **664 passed**；根级 build/typecheck/lint/format 全绿。