### PR TITLE
feat(spire): 事件批次 2 + 去牌/升级 outcome（净化漩涡/闪光/篝火火魂/活墙）

### DIFF
--- a/apps/spire/src/engine/events/events.ts
+++ b/apps/spire/src/engine/events/events.ts
@@ -12,6 +12,10 @@ export type EventOutcome =
   | { kind: "add_card"; cardId: string }
   | { kind: "gain_relic" }
   | { kind: "gain_potion" }
+  // 移除一张牌（自动优先移除诅咒/状态牌，否则随机一张非基础牌）。
+  | { kind: "remove_random_card" }
+  // 升级 count 张随机未升级的牌（攻击/技能/能力）。
+  | { kind: "upgrade_random_card"; count: number }
   | { kind: "nothing" };
 
 export type EventChoice = {
@@ -427,6 +431,80 @@ const EVENT_LIST: EventDef[] = [
         label: "向石像祈祷（回复生命）",
         resultText: "你合十默祷，一阵微光拂过，倦意稍解。",
         outcomes: [{ kind: "heal", amount: 15 }],
+      },
+    ],
+  },
+  // —— 补全批次 2：涉及改牌/去牌/升级的事件 ——
+  {
+    id: "whirlpool_of_purity",
+    description:
+      "一汪静止的清池泛着奇异的洁光，凑近时，你手里最碍事的那张牌隐隐发烫，像想被它带走。",
+    choices: [
+      {
+        label: "把一张牌投进池中净化",
+        resultText: "牌落水的瞬间化作光点消散，你的牌组清爽了几分。",
+        outcomes: [{ kind: "remove_random_card" }],
+      },
+      {
+        label: "不舍得，转身离开",
+        resultText: "你把牌重新收好，绕过了水池。",
+        outcomes: [{ kind: "nothing" }],
+      },
+    ],
+  },
+  {
+    id: "shining_light",
+    description: "石室深处悬着一团刺目的白光，传说踏入者会被灼痛，却也会因此被磨砺得更利。",
+    choices: [
+      {
+        label: "走进光中（受创，但两张牌被磨砺）",
+        resultText: "白光灼过全身，退出时你发现随身的两件家伙都更趁手了。",
+        outcomes: [
+          { kind: "lose_hp", amount: 12 },
+          { kind: "upgrade_random_card", count: 2 },
+        ],
+      },
+      {
+        label: "遮住眼退开",
+        resultText: "你不愿平白受这份罪，退出了石室。",
+        outcomes: [{ kind: "nothing" }],
+      },
+    ],
+  },
+  {
+    id: "bonfire_spirits",
+    description: "篝火里跃动着几缕通灵的火魂，它们伸出手，示意你可以投入一张牌，换取火中之物。",
+    choices: [
+      {
+        label: "投入一张牌，静待馈赠",
+        resultText: "牌在火中噼啪炸开，灰烬里凝出一件温热的器物。",
+        outcomes: [{ kind: "remove_random_card" }, { kind: "gain_relic" }],
+      },
+      {
+        label: "不献祭，烤烤火就走",
+        resultText: "你就着火光暖了暖身子，什么也没舍得投。",
+        outcomes: [{ kind: "heal", amount: 10 }],
+      },
+    ],
+  },
+  {
+    id: "living_wall",
+    description: "一整面墙缓缓起伏，像在呼吸。它开口说话，愿意为你的牌组做一件事——添、削、或是磨。",
+    choices: [
+      {
+        label: "吸纳（获得一张随机无色牌）",
+        resultText: "墙面凸起，一张陌生的牌被推进你怀里。",
+        outcomes: [{ kind: "add_card", cardId: "apparition" }],
+      },
+      {
+        label: "遗忘（移除一张牌）",
+        resultText: "墙面凹陷，你最累赘的一张牌被吞了进去。",
+        outcomes: [{ kind: "remove_random_card" }],
+      },
+      {
+        label: "深化（升级一张牌）",
+        resultText: "墙面纹路流转，你的一张牌被打磨得更加锋利。",
+        outcomes: [{ kind: "upgrade_random_card", count: 1 }],
       },
     ],
   },

--- a/apps/spire/src/engine/run/run.ts
+++ b/apps/spire/src/engine/run/run.ts
@@ -314,6 +314,33 @@ function applyEventOutcome(state: GameState, outcome: EventOutcome): void {
       }
       break;
     }
+    case "remove_random_card": {
+      // 优先移除诅咒/状态牌，否则随机移除一张牌。
+      const junk = state.deck.filter(card => {
+        const type = getCardDef(card.defId).type;
+        return type === "curse" || type === "status";
+      });
+      const pool = junk.length > 0 ? junk : state.deck;
+      if (pool.length > 0) {
+        const victim = pool[nextInt(state.rng, pool.length)]!;
+        const idx = state.deck.findIndex(card => card.uid === victim.uid);
+        if (idx >= 0) {
+          state.deck.splice(idx, 1);
+          state.log.push(`「${getCardDef(victim.defId).name}」从牌组中移除了。`);
+        }
+      }
+      break;
+    }
+    case "upgrade_random_card": {
+      // 升级 count 张随机未升级的牌（攻击/技能/能力；status/curse cost=null 天然被 upgradableCards 排除）。
+      const candidates = upgradableCards(state);
+      for (let n = 0; n < outcome.count && candidates.length > 0; n += 1) {
+        const idx = nextInt(state.rng, candidates.length);
+        candidates[idx]!.upgraded = true;
+        candidates.splice(idx, 1);
+      }
+      break;
+    }
     case "nothing":
       break;
     default: {

--- a/apps/spire/test/events-batch2.test.ts
+++ b/apps/spire/test/events-batch2.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { newRun, applyAction } from "../src/engine/engine.js";
+import type { GameState } from "../src/engine/types.js";
+
+// 事件补全批次 2：涉及去牌 / 升级 / 加牌的事件（新 EventOutcome）。
+
+function atEvent(id: string): GameState {
+  const s = newRun({ runId: "ev2", seed: 3, character: "ironclad" });
+  s.screen = "event";
+  s.event = { id };
+  s.version = 1;
+  return s;
+}
+
+describe("净化漩涡：移除一张牌（优先诅咒）", () => {
+  it("牌组含诅咒时优先移除诅咒", () => {
+    const s = atEvent("whirlpool_of_purity");
+    s.deck.push({ uid: s.nextUid++, defId: "injury", upgraded: false });
+    const size = s.deck.length;
+    applyAction(s, { type: "choose", optionIndex: 0 });
+    expect(s.deck.length).toBe(size - 1);
+    expect(s.deck.some(c => c.defId === "injury")).toBe(false);
+  });
+});
+
+describe("闪光：受创并升级 2 张牌", () => {
+  it("升级 2 张 + 掉血", () => {
+    const s = atEvent("shining_light");
+    const hp = s.hp;
+    applyAction(s, { type: "choose", optionIndex: 0 });
+    expect(s.deck.filter(c => c.upgraded).length).toBe(2);
+    expect(s.hp).toBe(hp - 12);
+  });
+});
+
+describe("活墙：三种改牌选项", () => {
+  it("遗忘 → 牌组 -1", () => {
+    const s = atEvent("living_wall");
+    const size = s.deck.length;
+    applyAction(s, { type: "choose", optionIndex: 1 });
+    expect(s.deck.length).toBe(size - 1);
+  });
+
+  it("深化 → 多一张升级牌", () => {
+    const s = atEvent("living_wall");
+    const upg = s.deck.filter(c => c.upgraded).length;
+    applyAction(s, { type: "choose", optionIndex: 2 });
+    expect(s.deck.filter(c => c.upgraded).length).toBe(upg + 1);
+  });
+
+  it("吸纳 → 牌组多一张", () => {
+    const s = atEvent("living_wall");
+    const size = s.deck.length;
+    applyAction(s, { type: "choose", optionIndex: 0 });
+    expect(s.deck.length).toBe(size + 1);
+  });
+});


### PR DESCRIPTION
## 背景
事件补全批次 2。为解锁「改牌类」事件，先给 `EventOutcome` 补两种结果类型，再落 4 个事件。

## 改动
**新 EventOutcome（自动挑选，沿用引擎「自动取最优/随机」约定）**
- `remove_random_card`：移除一张牌，优先诅咒/状态牌，否则随机一张。
- `upgrade_random_card { count }`：升级 count 张随机未升级的牌（status/curse cost=null 天然排除）。

**4 个新事件**
- 净化漩涡：移除一张牌 / 离开
- 闪光：受创 12 + 升级 2 张牌 / 离开
- 篝火火魂：献一张牌 → 遗物 / 烤火回血
- 活墙：吸纳(加无色牌) / 遗忘(移除) / 深化(升级) 三选一

? 节点事件池 22 → 26。

## 测试
`test/events-batch2.test.ts`（5 例）：优先移除诅咒、升级 2 张 + 掉血、活墙三选项的加/去/升。spire **669 passed**；根级 build/typecheck/lint/format 全绿。