### PR TITLE
feat(spire): 减伤/失血联动遗物（化石螺壳/符文魔方/鸟居/钨钢棒）

### DIFF
--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -2334,6 +2334,14 @@ function dealDamageToPlayer(
   }
   let afterBlock = Math.max(0, dmg - combat.playerBlock);
   combat.playerBlock = Math.max(0, combat.playerBlock - dmg);
+  // 鸟居：受到的无格挡攻击伤害为 1~5 时降为 1。
+  if (afterBlock >= 1 && afterBlock <= 5 && hasRelic(state, "torii")) {
+    afterBlock = 1;
+  }
+  // 钨钢棒：每次失去生命都少失 1 点（下限 0）。
+  if (afterBlock > 0 && hasRelic(state, "tungsten_rod")) {
+    afterBlock = Math.max(0, afterBlock - 1);
+  }
   // 缓冲：抵消这次会让你失去生命的穿透伤害（消耗 1 层）。
   if (afterBlock > 0 && getPower(combat.playerPowers, "buffer") > 0) {
     addPower(combat.playerPowers, "buffer", -1);

--- a/apps/spire/src/engine/relics/relics.ts
+++ b/apps/spire/src/engine/relics/relics.ts
@@ -668,6 +668,43 @@ const RELIC_LIST: RelicDef[] = [
       },
     },
   },
+  // —— 减伤 / 失血联动遗物批次 ——
+  {
+    id: "fossilized_helix",
+    name: "化石螺壳",
+    rarity: "rare",
+    description: "每场战斗开始时，获得 1 层缓冲（抵消下一次会让你失去生命的伤害）。",
+    hooks: {
+      onCombatStart: (_state, _self, emit) =>
+        emit({ kind: "apply_power", power: "buffer", amount: 1, on: "self" }),
+    },
+  },
+  {
+    id: "runic_cube",
+    name: "符文魔方",
+    rarity: "boss",
+    characterLock: "ironclad",
+    description: "每当你失去生命，抽 1 张牌。",
+    hooks: {
+      onLoseHp: (_state, _self, emit) => emit({ kind: "draw", amount: 1 }),
+    },
+  },
+  {
+    id: "torii",
+    name: "鸟居",
+    // 减伤在 combat.ts 的 dealDamageToPlayer 里按 hasRelic 处理（不走钩子）。
+    rarity: "rare",
+    description: "当你受到 5 点或更少的无格挡攻击伤害时，改为只受到 1 点。",
+    hooks: {},
+  },
+  {
+    id: "tungsten_rod",
+    name: "钨钢棒",
+    // 减伤在 combat.ts 的 dealDamageToPlayer 里按 hasRelic 处理（不走钩子）。
+    rarity: "boss",
+    description: "每当你失去生命时，少失去 1 点。",
+    hooks: {},
+  },
 ];
 
 /** 获得一件遗物：入列 + 结算 onEquip（草莓 +最大生命等一次性效果）。日志由调用方按情景补。 */

--- a/apps/spire/test/relics-batch4.test.ts
+++ b/apps/spire/test/relics-batch4.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat, endTurn } from "../src/engine/combat/combat.js";
+import { grantRelic, getRelicDef } from "../src/engine/relics/relics.js";
+import { getPower } from "../src/engine/powers/powers.js";
+import type { Effect, GameState, RelicState } from "../src/engine/types.js";
+
+// PR（减伤 / 失血联动遗物批次）。
+
+function combat(relic: string): GameState {
+  const s = newRun({ runId: "rb4", seed: 8, character: "ironclad" });
+  grantRelic(s, relic);
+  startCombat(s, "cultist");
+  s.hp = 200;
+  s.maxHp = 200;
+  return s;
+}
+
+describe("钨钢棒：每次失血少 1", () => {
+  it("邪教徒暗袭 6 → 只失 5", () => {
+    const s = combat("tungsten_rod");
+    s.combat!.playerBlock = 0;
+    s.combat!.enemies[0]!.currentMove = "dark_strike";
+    const hp = s.hp;
+    endTurn(s);
+    expect(hp - s.hp).toBe(5);
+  });
+});
+
+describe("鸟居：≤5 无格挡攻击伤害降为 1", () => {
+  it("被削弱后的暗袭（≤5）→ 只受 1", () => {
+    const s = combat("torii");
+    s.combat!.playerBlock = 0;
+    s.combat!.enemies[0]!.powers.push({ id: "weak", amount: 3 }); // 6×0.75=4 ≤5
+    s.combat!.enemies[0]!.currentMove = "dark_strike";
+    const hp = s.hp;
+    endTurn(s);
+    expect(hp - s.hp).toBe(1);
+  });
+});
+
+describe("化石螺壳：战斗开始 +1 缓冲", () => {
+  it("战斗开始即持有 1 层缓冲", () => {
+    const s = combat("fossilized_helix");
+    expect(getPower(s.combat!.playerPowers, "buffer")).toBe(1);
+  });
+});
+
+describe("符文魔方：失血抽 1（onLoseHp 钩子）", () => {
+  it("失血 emit 抽 1", () => {
+    const s = newRun({ runId: "rc", seed: 1, character: "ironclad" });
+    const self: RelicState = { id: "runic_cube", counter: 0 };
+    const emitted: Effect[] = [];
+    getRelicDef("runic_cube").hooks.onLoseHp?.(s, self, e => emitted.push(e));
+    expect(emitted).toEqual([{ kind: "draw", amount: 1 }]);
+  });
+});


### PR DESCRIPTION
## 背景
遗物补全批次 3——减伤 / 失血联动。

## 改动（4 件）
| 遗物 | 稀有度 | 实现 | 效果 |
|---|---|---|---|
| 化石螺壳 fossilized_helix | rare | onCombatStart | 战斗开始 +1 缓冲 |
| 符文魔方 runic_cube | boss·铁甲 | onLoseHp | 失血抽 1 |
| 鸟居 torii | rare | dealDamageToPlayer 特判 | ≤5 无格挡攻击伤害降为 1 |
| 钨钢棒 tungsten_rod | boss | dealDamageToPlayer 特判 | 每次失血少失 1 |

两件 boss 遗物待 boss 遗物奖励通路开放后才可获得（当前作完整性定义存在，不影响任何池逻辑）。

## 测试
`test/relics-batch4.test.ts`（4 例）：钨钢棒 6→5、鸟居削弱后 4→1、化石螺壳战斗始缓冲、符文魔方 onLoseHp。spire **673 passed**；根级 build/typecheck/lint/format 全绿。