### PR TITLE
feat(spire): 补全 6 个缺口敌人 + 7 组遭遇

### DIFF
--- a/apps/spire/src/engine/enemies/enemies.ts
+++ b/apps/spire/src/engine/enemies/enemies.ts
@@ -1678,6 +1678,220 @@ const ENEMY_LIST: EnemyDef[] = [
     // 出招由 combat.ts 的 slime_boss 专属分支处理（黏液→蓄力→猛砸 循环），intentRule 留空。
     intentRule: { scripted: [], weighted: [] },
   },
+
+  // —— 补全敌人：填平各幕遭遇缺口（HP/伤害对齐 sts_lightspeed asc0；飞行/反应/复生等异形机制近似为加权出招）——
+  {
+    id: "byrd",
+    name: "拜鸟",
+    hpMin: 25,
+    hpMax: 31,
+    moves: [
+      {
+        id: "byrd_peck",
+        name: "啄击",
+        effects: [{ kind: "deal_damage_multi", amount: 1, times: 5 }],
+        intent: "attack",
+      },
+      {
+        id: "byrd_swoop",
+        name: "俯冲",
+        effects: [{ kind: "deal_damage", amount: 12 }],
+        intent: "attack",
+      },
+      {
+        id: "byrd_caw",
+        name: "啼鸣",
+        effects: [{ kind: "apply_power", power: "strength", amount: 1, on: "self" }],
+        intent: "buff",
+      },
+    ],
+    intentRule: {
+      scripted: [],
+      weighted: [
+        { move: "byrd_peck", weight: 50, maxInARow: 2 },
+        { move: "byrd_swoop", weight: 30, maxInARow: 1 },
+        { move: "byrd_caw", weight: 20, maxInARow: 1 },
+      ],
+    },
+  },
+  {
+    id: "mugger",
+    name: "劫匪",
+    hpMin: 48,
+    hpMax: 52,
+    moves: [
+      {
+        id: "mugger_mug",
+        name: "抢劫",
+        effects: [
+          { kind: "deal_damage", amount: 10 },
+          { kind: "steal_gold", amount: 15 },
+        ],
+        intent: "attack",
+      },
+      {
+        id: "mugger_lunge",
+        name: "扑击逃窜",
+        effects: [
+          { kind: "deal_damage", amount: 16 },
+          { kind: "steal_gold", amount: 15 },
+          { kind: "escape" },
+        ],
+        intent: "attack",
+      },
+    ],
+    intentRule: {
+      scripted: ["mugger_mug"],
+      weighted: [
+        { move: "mugger_mug", weight: 60, maxInARow: 2 },
+        { move: "mugger_lunge", weight: 40, maxInARow: 1 },
+      ],
+    },
+  },
+  {
+    id: "darkling",
+    name: "暗影客",
+    hpMin: 48,
+    hpMax: 56,
+    moves: [
+      {
+        id: "darkling_nip",
+        name: "撕咬",
+        effects: [{ kind: "deal_damage", amount: 8 }],
+        intent: "attack",
+      },
+      {
+        id: "darkling_chomp",
+        name: "啃食",
+        effects: [{ kind: "deal_damage", amount: 9 }],
+        intent: "attack",
+      },
+      {
+        id: "darkling_harden",
+        name: "硬化",
+        effects: [{ kind: "gain_block", amount: 12 }],
+        intent: "defend",
+      },
+    ],
+    intentRule: {
+      scripted: [],
+      weighted: [
+        { move: "darkling_nip", weight: 40, maxInARow: 2 },
+        { move: "darkling_chomp", weight: 40, maxInARow: 1 },
+        { move: "darkling_harden", weight: 20, maxInARow: 1 },
+      ],
+    },
+  },
+  {
+    id: "spire_growth",
+    name: "尖塔幼体",
+    hpMin: 170,
+    hpMax: 170,
+    moves: [
+      {
+        id: "sg_quick_tackle",
+        name: "急冲",
+        effects: [{ kind: "deal_damage", amount: 16 }],
+        intent: "attack",
+      },
+      {
+        id: "sg_smash",
+        name: "重砸",
+        effects: [
+          { kind: "deal_damage", amount: 22 },
+          { kind: "apply_power", power: "weak", amount: 1, on: "target" },
+        ],
+        intent: "attack",
+      },
+    ],
+    intentRule: {
+      scripted: [],
+      weighted: [
+        { move: "sg_quick_tackle", weight: 50, maxInARow: 2 },
+        { move: "sg_smash", weight: 50, maxInARow: 1 },
+      ],
+    },
+  },
+  {
+    id: "the_maw",
+    name: "巨口",
+    hpMin: 300,
+    hpMax: 300,
+    moves: [
+      {
+        id: "maw_roar",
+        name: "咆哮",
+        effects: [
+          { kind: "apply_power", power: "weak", amount: 3, on: "target" },
+          { kind: "apply_power", power: "frail", amount: 3, on: "target" },
+        ],
+        intent: "debuff",
+      },
+      {
+        id: "maw_slam",
+        name: "重击",
+        effects: [{ kind: "deal_damage", amount: 25 }],
+        intent: "attack",
+      },
+      {
+        id: "maw_nom",
+        name: "吞噬",
+        effects: [{ kind: "deal_damage_multi", amount: 5, times: 3 }],
+        intent: "attack",
+      },
+    ],
+    intentRule: {
+      scripted: ["maw_roar"],
+      weighted: [
+        { move: "maw_slam", weight: 50, maxInARow: 1 },
+        { move: "maw_nom", weight: 50, maxInARow: 1 },
+      ],
+    },
+  },
+  {
+    id: "writhing_mass",
+    name: "蠕动之物",
+    hpMin: 160,
+    hpMax: 160,
+    moves: [
+      {
+        id: "wm_multi_strike",
+        name: "乱抽",
+        effects: [{ kind: "deal_damage_multi", amount: 7, times: 3 }],
+        intent: "attack",
+      },
+      {
+        id: "wm_strong_strike",
+        name: "重抽",
+        effects: [{ kind: "deal_damage", amount: 32 }],
+        intent: "attack",
+      },
+      {
+        id: "wm_flail",
+        name: "挥击",
+        effects: [{ kind: "deal_damage", amount: 15 }],
+        intent: "attack",
+      },
+      {
+        id: "wm_wither",
+        name: "萎缩",
+        effects: [
+          { kind: "deal_damage", amount: 10 },
+          { kind: "apply_power", power: "weak", amount: 2, on: "target" },
+        ],
+        intent: "attack",
+      },
+    ],
+    intentRule: {
+      scripted: [],
+      weighted: [
+        { move: "wm_multi_strike", weight: 30, maxInARow: 1 },
+        { move: "wm_strong_strike", weight: 20, maxInARow: 1 },
+        { move: "wm_flail", weight: 25, maxInARow: 2 },
+        { move: "wm_wither", weight: 25, maxInARow: 1 },
+      ],
+    },
+  },
 ];
 
 const ENEMY_MAP: ReadonlyMap<string, EnemyDef> = new Map(
@@ -1796,6 +2010,22 @@ const ENCOUNTERS: Record<string, EncounterDef> = {
     enemies: ["jaw_worm", "jaw_worm", "jaw_worm"],
     isBoss: false,
   },
+  // —— 新敌人遭遇 ——
+  three_byrds: { id: "three_byrds", enemies: ["byrd", "byrd", "byrd"], isBoss: false },
+  chosen_and_byrds: {
+    id: "chosen_and_byrds",
+    enemies: ["chosen", "byrd", "byrd"],
+    isBoss: false,
+  },
+  two_thieves: { id: "two_thieves", enemies: ["mugger", "mugger"], isBoss: false },
+  three_darklings: {
+    id: "three_darklings",
+    enemies: ["darkling", "darkling", "darkling"],
+    isBoss: false,
+  },
+  spire_growth: { id: "spire_growth", enemies: ["spire_growth"], isBoss: false },
+  the_maw: { id: "the_maw", enemies: ["the_maw"], isBoss: false },
+  writhing_mass: { id: "writhing_mass", enemies: ["writhing_mass"], isBoss: false },
   champ: { id: "champ", enemies: ["champ"], isBoss: true },
   bronze_automaton: { id: "bronze_automaton", enemies: ["bronze_automaton"], isBoss: true },
   the_collector: { id: "the_collector", enemies: ["the_collector"], isBoss: true },
@@ -1874,6 +2104,7 @@ const ACT2_WEAK_POOL: readonly WeightedEncounter[] = [
   { id: "centurion", weight: 1 },
   { id: "shelled_parasite", weight: 1 },
   { id: "chosen", weight: 1 },
+  { id: "three_byrds", weight: 1 },
 ];
 
 const ACT2_STRONG_POOL: readonly WeightedEncounter[] = [
@@ -1888,6 +2119,8 @@ const ACT2_STRONG_POOL: readonly WeightedEncounter[] = [
   { id: "three_cultists", weight: 1 },
   { id: "shelled_parasite_and_fungi", weight: 1 },
   { id: "sentry_and_sphere", weight: 1 },
+  { id: "chosen_and_byrds", weight: 1 },
+  { id: "two_thieves", weight: 1 },
 ];
 
 // —— 第三幕（超越）战斗池（切片）——
@@ -1909,6 +2142,10 @@ const ACT3_STRONG_POOL: readonly WeightedEncounter[] = [
   { id: "four_shapes", weight: 1 },
   { id: "sphere_and_two_shapes", weight: 1 },
   { id: "jaw_worm_horde", weight: 1 },
+  { id: "three_darklings", weight: 2 },
+  { id: "spire_growth", weight: 1 },
+  { id: "the_maw", weight: 1 },
+  { id: "writhing_mass", weight: 1 },
 ];
 
 function actWeakPool(act: number): readonly WeightedEncounter[] {

--- a/apps/spire/test/act2.test.ts
+++ b/apps/spire/test/act2.test.ts
@@ -33,6 +33,9 @@ describe("第二幕战斗池", () => {
     "three_cultists",
     "shelled_parasite_and_fungi",
     "sentry_and_sphere",
+    "three_byrds",
+    "chosen_and_byrds",
+    "two_thieves",
   ]);
 
   it("act=2 普通池只出第二幕怪", () => {

--- a/apps/spire/test/act3.test.ts
+++ b/apps/spire/test/act3.test.ts
@@ -46,6 +46,10 @@ describe("三幕", () => {
       "four_shapes",
       "sphere_and_two_shapes",
       "jaw_worm_horde",
+      "three_darklings",
+      "spire_growth",
+      "the_maw",
+      "writhing_mass",
     ]);
     for (let seed = 0; seed < 40; seed += 1) {
       const rng = seedRng(seed);

--- a/apps/spire/test/new-enemies.test.ts
+++ b/apps/spire/test/new-enemies.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat, endTurn } from "../src/engine/combat/combat.js";
+import { getEnemyDef } from "../src/engine/enemies/enemies.js";
+import type { GameState } from "../src/engine/types.js";
+
+// 补全敌人 + 遭遇：起战、生成正确数量、HP 对齐 asc0。
+
+const ENEMY_HP: Record<string, [number, number]> = {
+  byrd: [25, 31],
+  mugger: [48, 52],
+  darkling: [48, 56],
+  spire_growth: [170, 170],
+  the_maw: [300, 300],
+  writhing_mass: [160, 160],
+};
+
+describe("新敌人：HP 对齐 sts_lightspeed asc0", () => {
+  for (const [id, [lo, hi]] of Object.entries(ENEMY_HP)) {
+    it(`${id} HP ${lo}-${hi}`, () => {
+      const def = getEnemyDef(id);
+      expect(def.hpMin).toBe(lo);
+      expect(def.hpMax).toBe(hi);
+    });
+  }
+});
+
+const ENCOUNTERS: [string, number][] = [
+  ["three_byrds", 3],
+  ["chosen_and_byrds", 3],
+  ["two_thieves", 2],
+  ["three_darklings", 3],
+  ["spire_growth", 1],
+  ["the_maw", 1],
+  ["writhing_mass", 1],
+];
+
+describe("新遭遇：起战与敌人数量", () => {
+  for (const [enc, count] of ENCOUNTERS) {
+    it(`${enc} → ${count} 敌人，均有正血量与已 telegraph 意图`, () => {
+      const s: GameState = newRun({ runId: `ne-${enc}`, seed: 2 });
+      startCombat(s, enc);
+      expect(s.combat!.enemies).toHaveLength(count);
+      for (const e of s.combat!.enemies) {
+        expect(e.hp).toBeGreaterThan(0);
+        expect(e.currentMove).toBeTruthy();
+      }
+    });
+  }
+});
+
+describe("巨口：首招咆哮施加虚弱+脆弱", () => {
+  it("被咆哮后玩家吃虚弱与脆弱", () => {
+    const s = newRun({ runId: "maw", seed: 1, character: "ironclad" });
+    startCombat(s, "the_maw");
+    s.hp = 300;
+    s.maxHp = 300;
+    s.combat!.enemies[0]!.currentMove = "maw_roar";
+    s.combat!.hand = [];
+    endTurn(s);
+    const weak = s.combat!.playerPowers.find(p => p.id === "weak");
+    const frail = s.combat!.playerPowers.find(p => p.id === "frail");
+    expect(weak?.amount).toBe(3);
+    expect(frail?.amount).toBe(3);
+  });
+});


### PR DESCRIPTION
## 背景
补全之前 defer 的「需新敌人」遭遇，把标准遭遇战名册补齐。

## 改动
6 个新敌人（HP/伤害对齐 `sts_lightspeed` asc0）：
| 敌人 | HP | 核心招式 |
|---|---|---|
| 拜鸟 byrd | 25-31 | 啄击 1×5 / 俯冲 12 / 啼鸣 +1力量 |
| 劫匪 mugger | 48-52 | 抢劫 10+偷金 / 扑击逃窜 16+偷金+逃跑 |
| 暗影客 darkling | 48-56 | 撕咬 8 / 啃食 9 / 硬化 12格挡 |
| 尖塔幼体 spire_growth | 170 | 急冲 16 / 重砸 22+虚弱 |
| 巨口 the_maw | 300 | 咆哮 虚弱3+脆弱3 / 重击 25 / 吞噬 5×3 |
| 蠕动之物 writhing_mass | 160 | 乱抽 7×3 / 重抽 32 / 挥击 15 / 萎缩 10+虚弱2 |

7 组遭遇并入 act2/act3 池：三拜鸟、天选者+双拜鸟、双劫匪、三暗影客、尖塔幼体、巨口、蠕动之物。

**忠实度**：HP 与招式伤害严格对齐 asc0；飞行（拜鸟）/反应式变招（蠕动之物）/相互复生（暗影客）/寄生实装（蠕动之物）等异形机制近似为加权出招，未引入新 power——与本引擎既有敌人的近似口径一致。

## 测试
`test/new-enemies.test.ts`（14 例）：6 敌人 HP 校准 + 7 遭遇起战数量 + 巨口咆哮双减益。act2/act3 池断言同步扩充。spire **696 passed**；根级四项检查全绿。