### PR TITLE
feat(spire): 药水补全批次 3（流质记忆/赌徒酿/灵丹/熵酿）

### DIFF
--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -1260,6 +1260,17 @@ function applyEffect(
       }
       break;
     }
+    case "fill_potion_slots": {
+      // 熵酿：把所有空药水槽填满随机药水。
+      if (actor.side === "player") {
+        for (let i = 0; i < state.potions.length; i += 1) {
+          if (state.potions[i] === null) {
+            state.potions[i] = ALCHEMIZE_POOL[nextInt(state.rng, ALCHEMIZE_POOL.length)]!;
+          }
+        }
+      }
+      break;
+    }
     case "transmutation": {
       // 嬗变：将 X 张随机无色牌加入手牌，费用视为 0。
       if (actor.side === "player") {

--- a/apps/spire/src/engine/potions/potions.ts
+++ b/apps/spire/src/engine/potions/potions.ts
@@ -312,6 +312,43 @@ const POTION_LIST: PotionDef[] = [
     characterLock: "defect",
     effects: [{ kind: "change_orb_slots", delta: 2 }],
   },
+  // —— 补全批次 3：牌堆操作 / 药水槽 ——
+  {
+    id: "liquid_memories",
+    name: "流质记忆",
+    description: "从弃牌堆取回一张牌到手牌，本回合费用视为 0（自动取最近弃掉的一张）。",
+    rarity: "uncommon",
+    targeted: false,
+    combatOnly: true,
+    effects: [{ kind: "return_from_discard" }],
+  },
+  {
+    id: "gamblers_brew",
+    name: "赌徒酿",
+    description: "弃掉手牌，抽取等量的牌。",
+    rarity: "uncommon",
+    targeted: false,
+    combatOnly: true,
+    effects: [{ kind: "discard_hand_draw_same" }],
+  },
+  {
+    id: "elixir_potion",
+    name: "灵丹药水",
+    description: "消耗手牌中所有非攻击牌。",
+    rarity: "uncommon",
+    targeted: false,
+    combatOnly: true,
+    effects: [{ kind: "exhaust_non_attacks" }],
+  },
+  {
+    id: "entropic_brew",
+    name: "熵酿",
+    description: "把你所有的空药水槽填满随机药水。",
+    rarity: "uncommon",
+    targeted: false,
+    combatOnly: true,
+    effects: [{ kind: "fill_potion_slots" }],
+  },
 ];
 
 const POTION_MAP: ReadonlyMap<string, PotionDef> = new Map(

--- a/apps/spire/src/engine/types.ts
+++ b/apps/spire/src/engine/types.ts
@@ -291,7 +291,8 @@ export type Effect =
   | { kind: "exhaust_hand_gain_energy" } // 消耗手牌中费用最高的一张，获得 = 其费用的能量（回收；自动取最贵）
   | { kind: "double_energy" } // 获得等同于当前能量的能量（双倍能量）
   | { kind: "retain_hand" } // 本回合结束时保留全部手牌（平衡）
-  | { kind: "boss_haste" }; // 敌人自身：回复生命到最大值的一半、清除自身减益（时间吞噬者加速）
+  | { kind: "boss_haste" } // 敌人自身：回复生命到最大值的一半、清除自身减益（时间吞噬者加速）
+  | { kind: "fill_potion_slots" }; // 玩家：把所有空药水槽填满随机药水（熵酿）
 
 /** 卡定义（静态数据表）。cost=null 表示不可打出（status/废牌）。 */
 export type CardDef = {

--- a/apps/spire/test/potions-batch3.test.ts
+++ b/apps/spire/test/potions-batch3.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat, usePotion } from "../src/engine/combat/combat.js";
+import { getCardDef } from "../src/engine/cards/cards.js";
+import type { CardInstance, GameState } from "../src/engine/types.js";
+
+// PR（药水补全批次 3）：牌堆操作 / 药水槽。
+
+function combat(potion: string, slot = 0): GameState {
+  const s = newRun({ runId: "p3", seed: 9, character: "ironclad" });
+  startCombat(s, "cultist");
+  s.hp = 200;
+  s.maxHp = 200;
+  s.potions[slot] = potion;
+  return s;
+}
+
+function card(s: GameState, defId: string): CardInstance {
+  return { uid: s.nextUid++, defId, upgraded: false };
+}
+
+describe("熵酿：填满所有空药水槽", () => {
+  it("三空槽 → 全部填满", () => {
+    const s = combat("entropic_brew");
+    s.potions[1] = null;
+    s.potions[2] = null;
+    expect(usePotion(s, 0, null).ok).toBe(true);
+    expect(s.potions.every(p => p !== null)).toBe(true);
+  });
+});
+
+describe("赌徒酿：弃手牌抽等量", () => {
+  it("弃 3 抽 3", () => {
+    const s = combat("gamblers_brew");
+    s.combat!.hand = [card(s, "strike"), card(s, "defend"), card(s, "strike")];
+    s.combat!.drawPile = [
+      card(s, "defend"),
+      card(s, "strike"),
+      card(s, "defend"),
+      card(s, "strike"),
+    ];
+    expect(usePotion(s, 0, null).ok).toBe(true);
+    expect(s.combat!.hand).toHaveLength(3);
+    expect(s.combat!.discardPile.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe("灵丹药水：消耗所有非攻击牌", () => {
+  it("技能被消耗、攻击保留", () => {
+    const s = combat("elixir_potion");
+    s.combat!.hand = [card(s, "strike"), card(s, "defend"), card(s, "defend")];
+    expect(usePotion(s, 0, null).ok).toBe(true);
+    expect(s.combat!.hand.every(c => getCardDef(c.defId).type === "attack")).toBe(true);
+    expect(s.combat!.exhaustPile.some(c => c.defId === "defend")).toBe(true);
+  });
+});
+
+describe("流质记忆：从弃牌堆取回一张", () => {
+  it("弃牌堆的牌被收回手牌", () => {
+    const s = combat("liquid_memories");
+    s.combat!.hand = [];
+    s.combat!.discardPile = [card(s, "bash")];
+    expect(usePotion(s, 0, null).ok).toBe(true);
+    expect(s.combat!.hand.some(c => c.defId === "bash")).toBe(true);
+  });
+});


### PR DESCRIPTION
## 背景
药水补全批次 3。33 → 37。

## 改动
| 药水 | 稀有度 | 实现 |
|---|---|---|
| 流质记忆 liquid_memories | uncommon | `return_from_discard` |
| 赌徒酿 gamblers_brew | uncommon | `discard_hand_draw_same` |
| 灵丹药水 elixir_potion | uncommon | `exhaust_non_attacks` |
| 熵酿 entropic_brew | uncommon | 新 `fill_potion_slots` effect（填满空药水槽） |

前三张复用既有 effect（赌徒酿/灵丹是「任意数量」的自动近似）。

## 范围说明
需要**重机制**的药水留待后续：仙灵药水（死亡复活）、蛇油（随机费用）、烟雾弹（战斗逃脱）、复制药水（下张双结算）、迅捷药水（临时敏捷）、暗影精华（每槽充暗球）。

## 测试
`test/potions-batch3.test.ts`（4 例）。spire **700 passed**；根级 build/typecheck/lint/format 全绿。