### PR TITLE
feat(spire): 遗物钩子 onExhaust/onEnemyKilled/onUsePotion + 4 触发型遗物

### DIFF
--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -325,6 +325,15 @@ function triggerRelicTurnStart(state: GameState): void {
 function triggerRelicLoseHp(state: GameState): void {
   fireRelicsCollectingEmits(state, (hooks, self, emit) => hooks.onLoseHp?.(state, self, emit));
 }
+function triggerRelicExhaust(state: GameState): void {
+  fireRelicsCollectingEmits(state, (hooks, self, emit) => hooks.onExhaust?.(state, self, emit));
+}
+function triggerRelicEnemyKilled(state: GameState): void {
+  fireRelicsCollectingEmits(state, (hooks, self, emit) => hooks.onEnemyKilled?.(state, self, emit));
+}
+function triggerRelicUsePotion(state: GameState): void {
+  fireRelicsCollectingEmits(state, (hooks, self, emit) => hooks.onUsePotion?.(state, self, emit));
+}
 function triggerRelicTurnEnd(state: GameState): void {
   fireRelicsCollectingEmits(state, (hooks, self, emit) => hooks.onTurnEnd?.(state, self, emit));
 }
@@ -343,6 +352,8 @@ function exhaustCard(state: GameState, instance: CardInstance): void {
   if (exhaustDef.onExhaust && exhaustDef.onExhaust.length > 0) {
     applyEffects(state, exhaustDef.onExhaust, { side: "player" }, null);
   }
+  // 消耗牌触发型遗物（卡戎之烬 AoE、枯枝加牌）。
+  triggerRelicExhaust(state);
   const feelNoPain = getPower(combat.playerPowers, "feel_no_pain");
   if (feelNoPain > 0) {
     combat.playerBlock += feelNoPain; // 直接加，不再触发主宰（避免连锁）。
@@ -2283,6 +2294,10 @@ function dealDamageToEnemy(
       addPower(enemy.powers, "strength", AWAKENED_REVIVE_STRENGTH);
       state.log.push(`${enemy.name}复活了！`);
     }
+    // 击杀触发型遗物（哥布林之角 +能量+抽牌）；仅在敌人真正死亡（未复活）时。
+    if (enemy.hp === 0) {
+      triggerRelicEnemyKilled(state);
+    }
   }
   // 拉加维林：睡眠中受到穿透格挡的伤害立即苏醒，去掉金属化。
   if (enemy.asleep && afterBlock > 0 && enemy.hp > 0) {
@@ -2853,6 +2868,7 @@ export function usePotion(
   applyEffects(state, def.effects, { side: "player" }, resolvedTarget);
   state.log.push(`你使用了「${def.name}」。`);
   if (combat) {
+    triggerRelicUsePotion(state); // 用药水触发型遗物（玩具扑翼机回血）。
     resolveCombatIfEnded(state);
   }
   return { ok: true };

--- a/apps/spire/src/engine/relics/relics.ts
+++ b/apps/spire/src/engine/relics/relics.ts
@@ -34,6 +34,12 @@ export type RelicHooks = {
   onEquip?: (state: GameState, self: RelicState) => void;
   /** 玩家受到穿透格挡的伤害（失血）后结算（百年谜题首次失血抽牌）。可 emit 战斗 Effect。 */
   onLoseHp?: (state: GameState, self: RelicState, emit: Emit) => void;
+  /** 每当一张牌被消耗（进消耗堆）后结算（卡戎之烬 AoE、枯枝加牌）。 */
+  onExhaust?: (state: GameState, self: RelicState, emit: Emit) => void;
+  /** 每当一个敌人被击杀（经攻击伤害致死）后结算（哥布林之角 +能量+抽牌）。 */
+  onEnemyKilled?: (state: GameState, self: RelicState, emit: Emit) => void;
+  /** 每当使用一瓶药水后结算（玩具扑翼机回血）。 */
+  onUsePotion?: (state: GameState, self: RelicState, emit: Emit) => void;
 };
 
 /** 计数型遗物：自增 self.counter，达到 every 则归零并返回 true（触发效果）。 */
@@ -704,6 +710,47 @@ const RELIC_LIST: RelicDef[] = [
     rarity: "boss",
     description: "每当你失去生命时，少失去 1 点。",
     hooks: {},
+  },
+  // —— 消耗 / 击杀 / 用药水 触发型遗物批次 ——
+  {
+    id: "charons_ashes",
+    name: "卡戎之烬",
+    rarity: "rare",
+    characterLock: "ironclad",
+    description: "每当你消耗一张牌，对所有敌人造成 3 点伤害。",
+    hooks: {
+      onExhaust: (_state, _self, emit) => emit({ kind: "deal_damage_all", amount: 3 }),
+    },
+  },
+  {
+    id: "dead_branch",
+    name: "枯枝",
+    rarity: "rare",
+    description: "每当你消耗一张牌，将一张随机无色牌加入手牌。",
+    hooks: {
+      onExhaust: (_state, _self, emit) => emit({ kind: "add_random_colorless", count: 1 }),
+    },
+  },
+  {
+    id: "gremlin_horn",
+    name: "哥布林之角",
+    rarity: "uncommon",
+    description: "每当一个敌人死亡，获得 1 点能量并抽 1 张牌。",
+    hooks: {
+      onEnemyKilled: (_state, _self, emit) => {
+        emit({ kind: "gain_energy", amount: 1 });
+        emit({ kind: "draw", amount: 1 });
+      },
+    },
+  },
+  {
+    id: "toy_ornithopter",
+    name: "玩具扑翼机",
+    rarity: "common",
+    description: "每当你使用一瓶药水，回复 5 点生命。",
+    hooks: {
+      onUsePotion: (_state, _self, emit) => emit({ kind: "heal", amount: 5 }),
+    },
   },
 ];
 

--- a/apps/spire/test/relics-hooks2.test.ts
+++ b/apps/spire/test/relics-hooks2.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat, usePotion } from "../src/engine/combat/combat.js";
+import { grantRelic, getRelicDef } from "../src/engine/relics/relics.js";
+import type { CardInstance, Effect, GameState, RelicState } from "../src/engine/types.js";
+
+// PR（消耗/击杀/用药水 触发型遗物 + 三个新钩子）。
+
+function run(): GameState {
+  return newRun({ runId: "rh2", seed: 3, character: "ironclad" });
+}
+function card(s: GameState, defId: string): CardInstance {
+  return { uid: s.nextUid++, defId, upgraded: false };
+}
+function emitOf(id: string, hook: "onExhaust" | "onEnemyKilled" | "onUsePotion"): Effect[] {
+  const self: RelicState = { id, counter: 0 };
+  const out: Effect[] = [];
+  getRelicDef(id).hooks[hook]?.(run(), self, e => out.push(e));
+  return out;
+}
+
+describe("钩子发射内容", () => {
+  it("卡戎之烬：消耗 → 全体 3 伤害", () => {
+    expect(emitOf("charons_ashes", "onExhaust")).toEqual([{ kind: "deal_damage_all", amount: 3 }]);
+  });
+  it("枯枝：消耗 → 加一张随机无色牌", () => {
+    expect(emitOf("dead_branch", "onExhaust")).toEqual([
+      { kind: "add_random_colorless", count: 1 },
+    ]);
+  });
+  it("哥布林之角：击杀 → +1 能量 + 抽 1", () => {
+    expect(emitOf("gremlin_horn", "onEnemyKilled")).toEqual([
+      { kind: "gain_energy", amount: 1 },
+      { kind: "draw", amount: 1 },
+    ]);
+  });
+});
+
+describe("玩具扑翼机：用药水回 5 血（onUsePotion 端到端）", () => {
+  it("使用药水后回复 5 生命", () => {
+    const s = run();
+    grantRelic(s, "toy_ornithopter");
+    startCombat(s, "cultist");
+    s.hp = 100;
+    s.maxHp = 200;
+    s.potions[0] = "block_potion";
+    expect(usePotion(s, 0, null).ok).toBe(true);
+    expect(s.hp).toBe(105);
+  });
+});
+
+describe("卡戎之烬：消耗触发 AoE（onExhaust 端到端）", () => {
+  it("用灵丹药水消耗一张技能 → 敌人吃 3 伤害", () => {
+    const s = run();
+    grantRelic(s, "charons_ashes");
+    startCombat(s, "cultist");
+    s.hp = 200;
+    s.maxHp = 200;
+    s.combat!.hand = [card(s, "defend")]; // 非攻击，将被灵丹消耗
+    s.potions[0] = "elixir_potion";
+    const before = s.combat!.enemies[0]!.hp;
+    expect(usePotion(s, 0, null).ok).toBe(true);
+    expect(before - s.combat!.enemies[0]!.hp).toBe(3);
+  });
+});


### PR DESCRIPTION
## 背景
遗物钩子总线第二轮扩展，解锁「消耗/击杀/用药水」触发型遗物。

## 改动
**3 个新钩子点（各单一触发位，emit 战斗 Effect）**
- `onExhaust`：`exhaustCard` 内，每张牌被消耗后。
- `onEnemyKilled`：`dealDamageToEnemy` 攻击致死且未复活时。
- `onUsePotion`：`usePotion` 内，药水结算后。

**4 个新遗物**
| 遗物 | 稀有度 | 钩子 | 效果 |
|---|---|---|---|
| 卡戎之烬 charons_ashes | rare·铁甲 | onExhaust | 消耗牌→全体 3 伤害 |
| 枯枝 dead_branch | rare | onExhaust | 消耗牌→加随机无色牌（原版「随机牌」的近似） |
| 哥布林之角 gremlin_horn | uncommon | onEnemyKilled | 击杀→+1 能量 + 抽 1 |
| 玩具扑翼机 toy_ornithopter | common | onUsePotion | 用药水→回 5 血 |

## 测试
`test/relics-hooks2.test.ts`（5 例）：三钩子发射内容 + 玩具扑翼机 & 卡戎之烬两条端到端（用药水回血 / 灵丹消耗触发 AoE）。spire **705 passed**；根级四项检查全绿。