### PR TITLE
feat(spire): 计数/能量触发型遗物（冰淇淋/怀表/木乃伊手）

### DIFF
--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -3158,7 +3158,12 @@ export function endTurn(state: GameState): void {
   if (blur > 0) {
     addPower(combat.playerPowers, "blur", -1);
   }
-  combat.energy = combat.maxEnergy;
+  // 冰淇淋：能量在回合之间保留（不清零，只叠加本回合上限）；否则正常重置为上限。
+  if (hasRelic(state, "ice_cream")) {
+    combat.energy += combat.maxEnergy;
+  } else {
+    combat.energy = combat.maxEnergy;
+  }
   // 下回合预约结算（闪转腾挪格挡 / 飞膝能量 / 掠食者抽牌），随后清零。
   combat.playerBlock += combat.nextTurnBlock;
   combat.energy += combat.nextTurnEnergy;

--- a/apps/spire/src/engine/relics/relics.ts
+++ b/apps/spire/src/engine/relics/relics.ts
@@ -752,6 +752,49 @@ const RELIC_LIST: RelicDef[] = [
       onUsePotion: (_state, _self, emit) => emit({ kind: "heal", amount: 5 }),
     },
   },
+  // —— 计数 / 能量 触发型遗物批次 ——
+  {
+    id: "ice_cream",
+    name: "冰淇淋",
+    // 能量保留在 combat.ts 的回合开始处按 hasRelic 处理（不走钩子）。
+    rarity: "rare",
+    description: "能量在回合之间保留，不再于回合开始清零。",
+    hooks: {},
+  },
+  {
+    id: "pocketwatch",
+    name: "怀表",
+    rarity: "rare",
+    description: "若某个回合你打出的牌不超过 3 张，下个回合开始时抽 3 张牌。",
+    hooks: {
+      onCombatStart: (_state, self) => {
+        self.counter = 0;
+      },
+      onTurnStart: (_state, self, emit) => {
+        if (self.counter === 1) {
+          emit({ kind: "draw", amount: 3 });
+        }
+        self.counter = 0;
+      },
+      onTurnEnd: (state, self) => {
+        // 本回合出牌 ≤3 → 预约下回合抽 3。
+        self.counter = (state.combat?.cardsPlayedThisTurn ?? 99) <= 3 ? 1 : 0;
+      },
+    },
+  },
+  {
+    id: "mummified_hand",
+    name: "木乃伊手",
+    rarity: "uncommon",
+    description: "每当你打出一张能力牌，手牌中一张随机牌本回合费用变为 0。",
+    hooks: {
+      onCardPlayed: (_state, _self, cardType, emit) => {
+        if (cardType === "power") {
+          emit({ kind: "make_random_hand_card_free" });
+        }
+      },
+    },
+  },
 ];
 
 /** 获得一件遗物：入列 + 结算 onEquip（草莓 +最大生命等一次性效果）。日志由调用方按情景补。 */

--- a/apps/spire/test/relics-batch5.test.ts
+++ b/apps/spire/test/relics-batch5.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat, endTurn } from "../src/engine/combat/combat.js";
+import { grantRelic, getRelicDef } from "../src/engine/relics/relics.js";
+import type { Effect, GameState, RelicState } from "../src/engine/types.js";
+
+// PR（计数/能量触发型遗物）。
+
+function combatWith(relic: string): GameState {
+  const s = newRun({ runId: "rb5", seed: 2, character: "ironclad" });
+  grantRelic(s, relic);
+  startCombat(s, "cultist");
+  s.hp = 300;
+  s.maxHp = 300;
+  return s;
+}
+
+describe("冰淇淋：能量跨回合保留", () => {
+  it("上回合剩 2 能量 → 下回合 2 + 上限", () => {
+    const s = combatWith("ice_cream");
+    s.combat!.energy = 2; // 模拟本回合剩余
+    s.combat!.hand = [];
+    endTurn(s);
+    expect(s.combat!.energy).toBe(2 + s.combat!.maxEnergy);
+  });
+});
+
+describe("怀表：出牌 ≤3 则下回合抽 3", () => {
+  it("回合末≤3张 → 预约；回合始抽 3", () => {
+    const hooks = getRelicDef("pocketwatch").hooks;
+    const self: RelicState = { id: "pocketwatch", counter: 0 };
+    const s = newRun({ runId: "pw", seed: 1 });
+    startCombat(s, "cultist");
+    s.combat!.cardsPlayedThisTurn = 2;
+    hooks.onTurnEnd?.(s, self, () => {});
+    expect(self.counter).toBe(1);
+    const emitted: Effect[] = [];
+    hooks.onTurnStart?.(s, self, e => emitted.push(e));
+    expect(emitted).toEqual([{ kind: "draw", amount: 3 }]);
+    expect(self.counter).toBe(0);
+  });
+
+  it("出牌 4 张则不预约", () => {
+    const hooks = getRelicDef("pocketwatch").hooks;
+    const self: RelicState = { id: "pocketwatch", counter: 0 };
+    const s = newRun({ runId: "pw2", seed: 1 });
+    startCombat(s, "cultist");
+    s.combat!.cardsPlayedThisTurn = 4;
+    hooks.onTurnEnd?.(s, self, () => {});
+    expect(self.counter).toBe(0);
+  });
+});
+
+describe("木乃伊手：打出能力牌 → 随机手牌 0 费", () => {
+  it("能力牌触发 make_random_hand_card_free", () => {
+    const hooks = getRelicDef("mummified_hand").hooks;
+    const self: RelicState = { id: "mummified_hand", counter: 0 };
+    const emitted: Effect[] = [];
+    hooks.onCardPlayed?.(newRun({ runId: "mh", seed: 1 }), self, "power", e => emitted.push(e));
+    expect(emitted).toEqual([{ kind: "make_random_hand_card_free" }]);
+    const none: Effect[] = [];
+    hooks.onCardPlayed?.(newRun({ runId: "mh2", seed: 1 }), self, "attack", e => none.push(e));
+    expect(none).toEqual([]);
+  });
+});


### PR DESCRIPTION
## 背景
遗物补全批次 4，复用既有钩子 + 一处能量模型特判。

## 改动（3 件）
| 遗物 | 稀有度 | 实现 |
|---|---|---|
| 冰淇淋 ice_cream | rare | 回合始能量不清零、叠加上限（dealDamage… 不涉及；回合始 hasRelic 特判） |
| 怀表 pocketwatch | rare | onTurnEnd 记录本回合出牌≤3 → onTurnStart 抽 3 |
| 木乃伊手 mummified_hand | uncommon | onCardPlayed(power) → 随机手牌本回合 0 费 |

## 测试
`test/relics-batch5.test.ts`（4 例）：冰淇淋能量结转、怀表 ≤3/>3 分支、木乃伊手 power/非power。spire **718 passed**；根级四项检查全绿。