### PR TITLE
feat(spire): 首领遗物奖励通路 + 8 件 boss 遗物

### DIFF
--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -22,7 +22,13 @@ import {
   getPower,
   removePower,
 } from "../powers/powers.js";
-import { getRelicDef, hasRelic, THE_BOOT_MIN_DAMAGE } from "../relics/relics.js";
+import {
+  getRelicDef,
+  hasRelic,
+  grantRelic,
+  bossRelicPool,
+  THE_BOOT_MIN_DAMAGE,
+} from "../relics/relics.js";
 import type { RelicDef } from "../relics/relics.js";
 import { getPotionDef } from "../potions/potions.js";
 
@@ -2840,6 +2846,9 @@ export function usePotion(
   if (potionId === undefined || potionId === null) {
     return { ok: false, reason: `药水槽 ${slotIndex} 是空的。` };
   }
+  if (hasRelic(state, "sozu")) {
+    return { ok: false, reason: "斗笠让你无法使用药水。" };
+  }
   const def = getPotionDef(potionId);
   const combat = state.combat;
   if (def.combatOnly && (!combat || state.screen !== "combat")) {
@@ -3607,6 +3616,13 @@ function resolveCombatIfEnded(state: GameState): void {
     const gold = nextRange(state.rng, BOSS_GOLD_MIN, BOSS_GOLD_MAX);
     state.gold += gold;
     state.log.push(`击败首领，获得 ${gold} 金币。`);
+    // 首领遗物奖励：随机掉一件未持有的 boss 遗物。
+    const bossRelics = bossRelicPool(state.character).filter(id => !hasRelic(state, id));
+    if (bossRelics.length > 0) {
+      const id = bossRelics[nextInt(state.rng, bossRelics.length)]!;
+      grantRelic(state, id);
+      state.log.push(`首领倒下，你获得了遗物「${getRelicDef(id).name}」。`);
+    }
     state.screen = "victory";
   }
   // 非 Boss 的奖励生成在 run 层处理（避免 combat 依赖 run）。

--- a/apps/spire/src/engine/relics/relics.ts
+++ b/apps/spire/src/engine/relics/relics.ts
@@ -90,6 +90,13 @@ function upgradeRandomCardsOfType(state: GameState, type: CardType, count: numbe
   }
 }
 
+/** 从牌组随机移除 count 张牌（空笼获得时净化牌组）。 */
+function removeRandomCards(state: GameState, count: number): void {
+  for (let n = 0; n < count && state.deck.length > 0; n += 1) {
+    state.deck.splice(nextInt(state.rng, state.deck.length), 1);
+  }
+}
+
 const RELIC_LIST: RelicDef[] = [
   {
     id: "burning_blood",
@@ -795,7 +802,88 @@ const RELIC_LIST: RelicDef[] = [
       },
     },
   },
+  // —— 首领遗物批次（打首领掉落；均带「代价」，此切片以正收益为主，部分代价近似/略）——
+  {
+    id: "coffee_dripper",
+    name: "咖啡滴滤器",
+    rarity: "boss",
+    description: "每回合开始时多获得 1 点能量（代价：无法在篝火休息回血）。",
+    hooks: { onCombatStart: (_s, _self, emit) => emit({ kind: "change_max_energy", delta: 1 }) },
+  },
+  {
+    id: "fusion_hammer",
+    name: "融合锤",
+    rarity: "boss",
+    description: "每回合开始时多获得 1 点能量（代价：无法在篝火打铁升级）。",
+    hooks: { onCombatStart: (_s, _self, emit) => emit({ kind: "change_max_energy", delta: 1 }) },
+  },
+  {
+    id: "runic_dome",
+    name: "符文圆顶",
+    rarity: "boss",
+    description: "每回合开始时多获得 1 点能量（代价：无法看到敌人意图）。",
+    hooks: { onCombatStart: (_s, _self, emit) => emit({ kind: "change_max_energy", delta: 1 }) },
+  },
+  {
+    id: "sozu",
+    name: "斗笠",
+    // 「无法使用药水」由 combat.ts 的 usePotion 按 hasRelic 拦截。
+    rarity: "boss",
+    description: "每回合开始时多获得 1 点能量（代价：无法使用药水）。",
+    hooks: { onCombatStart: (_s, _self, emit) => emit({ kind: "change_max_energy", delta: 1 }) },
+  },
+  {
+    id: "philosophers_stone",
+    name: "贤者之石",
+    rarity: "boss",
+    description: "每回合开始时多获得 1 点能量；所有敌人在战斗开始时获得 1 点力量。",
+    hooks: {
+      onCombatStart: (_s, _self, emit) => {
+        emit({ kind: "change_max_energy", delta: 1 });
+        emit({ kind: "apply_power", power: "strength", amount: 1, on: "all_enemies" });
+      },
+    },
+  },
+  {
+    id: "mark_of_pain",
+    name: "痛苦烙印",
+    rarity: "boss",
+    characterLock: "ironclad",
+    description: "每回合开始时多获得 1 点能量；每场战斗开始时抽牌堆放入 2 张伤口。",
+    hooks: {
+      onCombatStart: (_s, _self, emit) => {
+        emit({ kind: "change_max_energy", delta: 1 });
+        emit({ kind: "add_card", cardId: "wound", pile: "draw", count: 2 });
+      },
+    },
+  },
+  {
+    id: "empty_cage",
+    name: "空笼",
+    rarity: "boss",
+    description: "获得时，从牌组中移除 2 张牌。",
+    hooks: { onEquip: state => removeRandomCards(state, 2) },
+  },
+  {
+    id: "tiny_house",
+    name: "小屋",
+    rarity: "boss",
+    description: "获得时，最大生命 +6、金币 +50，并升级一张随机牌。",
+    hooks: {
+      onEquip: state => {
+        state.maxHp += 6;
+        state.hp += 6;
+        state.gold += 50;
+        upgradeRandomCardsOfType(state, "attack", 1);
+      },
+    },
+  },
 ];
+
+/** 首领遗物池（rarity=boss；含该角色专属 boss 遗物）。打首领时随机掉一件未持有的。 */
+export function bossRelicPool(character: CharacterId): readonly string[] {
+  return [...relicIdsOfRarity("boss"), ...relicIdsForCharacter(character, "boss")];
+}
 
 /** 获得一件遗物：入列 + 结算 onEquip（草莓 +最大生命等一次性效果）。日志由调用方按情景补。 */
 export function grantRelic(state: GameState, id: string): void {

--- a/apps/spire/test/boss-relics.test.ts
+++ b/apps/spire/test/boss-relics.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { newRun, applyAction } from "../src/engine/engine.js";
+import { startCombat, usePotion } from "../src/engine/combat/combat.js";
+import { grantRelic, getRelicDef } from "../src/engine/relics/relics.js";
+import { getPower } from "../src/engine/powers/powers.js";
+import type { GameState } from "../src/engine/types.js";
+
+// 首领遗物奖励通路 + boss 遗物批次。
+
+function combatWith(relic: string, encounter = "cultist", character = "ironclad"): GameState {
+  const s = newRun({ runId: "br", seed: 3, character: character as GameState["character"] });
+  grantRelic(s, relic);
+  startCombat(s, encounter);
+  s.hp = 300;
+  s.maxHp = 300;
+  return s;
+}
+
+describe("首领遗物奖励：打首领掉一件 boss 遗物", () => {
+  it("击败守卫者 → 获得一件 boss 稀有度遗物", () => {
+    const s = newRun({ runId: "boss", seed: 5, character: "ironclad" });
+    startCombat(s, "guardian");
+    const relicsBefore = s.relics.length;
+    s.combat!.enemies[0]!.hp = 3;
+    s.combat!.hand = [{ uid: s.nextUid++, defId: "strike", upgraded: false }];
+    s.combat!.energy = 3;
+    s.version = 1;
+    applyAction(s, { type: "play_card", handIndex: 0, targetIndex: 0 });
+    expect(s.relics.length).toBe(relicsBefore + 1);
+    const gained = getRelicDef(s.relics[s.relics.length - 1]!.id);
+    expect(gained.rarity).toBe("boss");
+  });
+});
+
+describe("+1 能量类", () => {
+  it("咖啡滴滤器：回合能量与上限各 +1", () => {
+    const s = combatWith("coffee_dripper");
+    expect(s.combat!.maxEnergy).toBe(4);
+    expect(s.combat!.energy).toBe(4);
+  });
+});
+
+describe("斗笠：无法使用药水", () => {
+  it("使用药水被拦截", () => {
+    const s = combatWith("sozu");
+    s.potions[0] = "block_potion";
+    expect(usePotion(s, 0, null).ok).toBe(false);
+  });
+});
+
+describe("贤者之石：敌人开局各 +1 力量", () => {
+  it("双敌各获得 1 力量", () => {
+    const s = combatWith("philosophers_stone", "two_louse");
+    for (const e of s.combat!.enemies) {
+      expect(getPower(e.powers, "strength")).toBe(1);
+    }
+  });
+});
+
+describe("痛苦烙印：开局放 2 张伤口进抽牌堆", () => {
+  it("牌堆里共 2 张伤口", () => {
+    const s = combatWith("mark_of_pain");
+    const wounds = [...s.combat!.hand, ...s.combat!.drawPile, ...s.combat!.discardPile].filter(
+      c => c.defId === "wound",
+    );
+    expect(wounds).toHaveLength(2);
+  });
+});
+
+describe("onEquip 类 boss 遗物", () => {
+  it("空笼：获得时移除 2 张牌", () => {
+    const s = newRun({ runId: "cage", seed: 1, character: "ironclad" });
+    const size = s.deck.length;
+    grantRelic(s, "empty_cage");
+    expect(s.deck.length).toBe(size - 2);
+  });
+
+  it("小屋：+6 最大生命 +50 金币 + 升 1 牌", () => {
+    const s = newRun({ runId: "house", seed: 1, character: "ironclad" });
+    const maxHp = s.maxHp;
+    const gold = s.gold;
+    grantRelic(s, "tiny_house");
+    expect(s.maxHp).toBe(maxHp + 6);
+    expect(s.gold).toBe(gold + 50);
+    expect(s.deck.filter(c => c.upgraded).length).toBe(1);
+  });
+});

--- a/apps/spire/test/combat-gold.test.ts
+++ b/apps/spire/test/combat-gold.test.ts
@@ -47,8 +47,11 @@ describe("首领奖励金币", () => {
       s.combat!.energy = 9;
       playCard(s, 0, 0);
       expect(s.screen).toBe("victory");
-      expect(s.gold).toBeGreaterThanOrEqual(95);
-      expect(s.gold).toBeLessThanOrEqual(105);
+      // 首领金币掉落固定 95-105；首领遗物奖励可能另加金币（如小屋 +50），故按掉落日志校验。
+      const dropLine = s.log.find(l => l.includes("击败首领，获得"));
+      const dropped = Number(dropLine?.match(/(\d+)/)?.[1]);
+      expect(dropped).toBeGreaterThanOrEqual(95);
+      expect(dropped).toBeLessThanOrEqual(105);
     }
   });
 });


### PR DESCRIPTION
## 背景
目标：补全遗物。本 PR 打通**首领遗物奖励通路**（此前完全没有），并落一批 boss 遗物——这条线一开，之前定义但不可获得的 boss 遗物（符文魔方/钨钢棒）与本批新增的都能真正掉落。

## 改动
**奖励通路**：`resolveCombatIfEnded` 的 boss 分支在掉金币后，随机掉一件**未持有**的 boss 稀有度遗物（`grantRelic` 会触发 onEquip）。新增 `bossRelicPool(character)`。

**8 件 boss 遗物**
| 遗物 | 效果（代价） |
|---|---|
| 咖啡滤器/融合锤/符文圆顶 | 每回合 +1 能量（代价近似/略：禁休息/打铁/看意图） |
| 斗笠 sozu | +1 能量（**禁用药水**，usePotion 已拦截） |
| 贤者之石 | +1 能量；敌人开局各 +1 力量 |
| 痛苦烙印（铁甲） | +1 能量；开局抽牌堆塞 2 张伤口 |
| 空笼 empty_cage | 获得时移除 2 张牌 |
| 小屋 tiny_house | +6 最大生命、+50 金币、升 1 张牌 |

## 测试
`test/boss-relics.test.ts`（7 例）：击败守卫者掉 boss 遗物、+1 能量、斗笠禁药水、贤者石敌人力量、痛苦烙印伤口、空笼/小屋 onEquip。另修 `combat-gold` 首领金币断言（改按掉落日志校验，避免与遗物金币混淆）。spire **725 passed**；根级四项检查全绿。