### PR TITLE
refactor: 收敛 knip warn 存量——冗余 export 降级 / 有意面 ignore / 真死删除

### DIFF
--- a/apps/agent/src/agent/apps/amap/amap-screen.ts
+++ b/apps/agent/src/agent/apps/amap/amap-screen.ts
@@ -191,7 +191,7 @@ function formatDuration(seconds: string): string {
 }
 
 /** 转义标签正文里的动态文本：< > & 转实体，防止伪造 <amap_*> 标签注入上下文。 */
-export function esc(value: string | null | undefined): string {
+function esc(value: string | null | undefined): string {
   return (value ?? "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 

--- a/apps/agent/src/agent/apps/amap/amap.app.ts
+++ b/apps/agent/src/agent/apps/amap/amap.app.ts
@@ -13,7 +13,7 @@ import { PlanTransitTool } from "./tools/plan-transit.tool.js";
 import { WeatherTool } from "./tools/weather.tool.js";
 import { StaticMapTool } from "./tools/static-map.tool.js";
 
-export const AMAP_APP_ID = "amap";
+const AMAP_APP_ID = "amap";
 
 const PositiveInt = z.number().int().positive();
 

--- a/apps/agent/src/agent/apps/amap/client/amap-client.ts
+++ b/apps/agent/src/agent/apps/amap/client/amap-client.ts
@@ -99,7 +99,7 @@ const PoiResponseSchema = z.object({
   count: Str,
   pois: z.array(PoiSchema).nullish(),
 });
-export type AmapPoi = z.infer<typeof PoiSchema>;
+type AmapPoi = z.infer<typeof PoiSchema>;
 export type AmapPoiResult = { count: string | null; pois: AmapPoi[] };
 
 // === 路径规划（driving/walking/bicycling） ===
@@ -184,8 +184,8 @@ const WeatherResponseSchema = z.object({
   lives: z.array(WeatherLiveSchema).nullish(),
   forecasts: z.array(WeatherForecastSchema).nullish(),
 });
-export type AmapWeatherLive = z.infer<typeof WeatherLiveSchema>;
-export type AmapWeatherForecast = z.infer<typeof WeatherForecastSchema>;
+type AmapWeatherLive = z.infer<typeof WeatherLiveSchema>;
+type AmapWeatherForecast = z.infer<typeof WeatherForecastSchema>;
 export type AmapWeatherResult = {
   kind: "base" | "all";
   lives: AmapWeatherLive[];

--- a/apps/agent/src/agent/apps/amap/tools/geocode.tool.ts
+++ b/apps/agent/src/agent/apps/amap/tools/geocode.tool.ts
@@ -4,7 +4,7 @@ import { renderGeocode } from "../amap-screen.js";
 import type { AmapClient } from "../client/amap-client.js";
 import type { RootAgentEffect } from "../../../runtime/effect/root-agent-effect.js";
 
-export const GEOCODE_TOOL_NAME = "geocode";
+const GEOCODE_TOOL_NAME = "geocode";
 
 const Schema = z.object({
   address: z.string().min(1),

--- a/apps/agent/src/agent/apps/amap/tools/plan-route.tool.ts
+++ b/apps/agent/src/agent/apps/amap/tools/plan-route.tool.ts
@@ -4,7 +4,7 @@ import { renderRoute } from "../amap-screen.js";
 import type { AmapClient } from "../client/amap-client.js";
 import type { RootAgentEffect } from "../../../runtime/effect/root-agent-effect.js";
 
-export const PLAN_ROUTE_TOOL_NAME = "plan_route";
+const PLAN_ROUTE_TOOL_NAME = "plan_route";
 
 const Schema = z.object({
   origin: z.string().min(1),

--- a/apps/agent/src/agent/apps/amap/tools/plan-transit.tool.ts
+++ b/apps/agent/src/agent/apps/amap/tools/plan-transit.tool.ts
@@ -4,7 +4,7 @@ import { renderTransit } from "../amap-screen.js";
 import type { AmapClient } from "../client/amap-client.js";
 import type { RootAgentEffect } from "../../../runtime/effect/root-agent-effect.js";
 
-export const PLAN_TRANSIT_TOOL_NAME = "plan_transit";
+const PLAN_TRANSIT_TOOL_NAME = "plan_transit";
 
 // city1/city2 是 citycode，模型易当数字传——收下数字并转字符串（注意：带前导零的 citycode 如
 // "010" 必须由模型以字符串传，数字 10 已丢前导零，此处无法还原，只是不再硬拒）。

--- a/apps/agent/src/agent/apps/amap/tools/regeocode.tool.ts
+++ b/apps/agent/src/agent/apps/amap/tools/regeocode.tool.ts
@@ -4,7 +4,7 @@ import { renderRegeocode } from "../amap-screen.js";
 import type { AmapClient } from "../client/amap-client.js";
 import type { RootAgentEffect } from "../../../runtime/effect/root-agent-effect.js";
 
-export const REGEOCODE_TOOL_NAME = "regeocode";
+const REGEOCODE_TOOL_NAME = "regeocode";
 
 const Schema = z.object({
   location: z.string().min(1),

--- a/apps/agent/src/agent/apps/amap/tools/search-around.tool.ts
+++ b/apps/agent/src/agent/apps/amap/tools/search-around.tool.ts
@@ -4,7 +4,7 @@ import { escapeAttr, renderPoiList } from "../amap-screen.js";
 import type { AmapClient } from "../client/amap-client.js";
 import type { RootAgentEffect } from "../../../runtime/effect/root-agent-effect.js";
 
-export const SEARCH_AROUND_TOOL_NAME = "search_around";
+const SEARCH_AROUND_TOOL_NAME = "search_around";
 
 const Schema = z.object({
   location: z.string().min(1),

--- a/apps/agent/src/agent/apps/amap/tools/search-poi.tool.ts
+++ b/apps/agent/src/agent/apps/amap/tools/search-poi.tool.ts
@@ -4,7 +4,7 @@ import { escapeAttr, renderPoiList } from "../amap-screen.js";
 import type { AmapClient } from "../client/amap-client.js";
 import type { RootAgentEffect } from "../../../runtime/effect/root-agent-effect.js";
 
-export const SEARCH_POI_TOOL_NAME = "search_poi";
+const SEARCH_POI_TOOL_NAME = "search_poi";
 
 const Schema = z
   .object({

--- a/apps/agent/src/agent/apps/amap/tools/static-map.tool.ts
+++ b/apps/agent/src/agent/apps/amap/tools/static-map.tool.ts
@@ -6,7 +6,7 @@ import { escapeAttr } from "../amap-screen.js";
 import type { RootAgentEffect } from "../../../runtime/effect/root-agent-effect.js";
 import type { OssClient } from "../../../../acl/oss-client.js";
 
-export const STATIC_MAP_TOOL_NAME = "static_map";
+const STATIC_MAP_TOOL_NAME = "static_map";
 
 const logger = new AppLogger({ source: "agent.amap.static_map" });
 

--- a/apps/agent/src/agent/apps/amap/tools/weather.tool.ts
+++ b/apps/agent/src/agent/apps/amap/tools/weather.tool.ts
@@ -4,7 +4,7 @@ import { renderWeather } from "../amap-screen.js";
 import type { AmapClient } from "../client/amap-client.js";
 import type { RootAgentEffect } from "../../../runtime/effect/root-agent-effect.js";
 
-export const WEATHER_TOOL_NAME = "weather";
+const WEATHER_TOOL_NAME = "weather";
 
 const Schema = z.object({
   // 模型常把 adcode（如 110000）当数字传，zod 会拒成 "Expected string received number"——收下数字并转字符串。

--- a/apps/agent/src/agent/apps/browser/browser.app.ts
+++ b/apps/agent/src/agent/apps/browser/browser.app.ts
@@ -12,7 +12,7 @@ import type { RootAgentEffect } from "../../runtime/effect/root-agent-effect.js"
 import type { OssClient } from "../../../acl/oss-client.js";
 import type { BrowserClient } from "../../../acl/browser-client.js";
 
-export const BROWSER_APP_ID = "browser";
+const BROWSER_APP_ID = "browser";
 
 type BrowserAppDeps = {
   /** 浏览器动作客户端：打到独立的 kagami-browser 进程（issue #173）。 */

--- a/apps/agent/src/agent/apps/calc/calc.app.ts
+++ b/apps/agent/src/agent/apps/calc/calc.app.ts
@@ -3,7 +3,7 @@ import type { App, AppStartupContext } from "@kagami/agent-runtime";
 import { renderServerStaticTemplate } from "@kagami/kernel/runtime/read-static-text";
 import { CalculateTool } from "./tools/calculate.tool.js";
 
-export const CALC_APP_ID = "calc";
+const CALC_APP_ID = "calc";
 
 const CalcConfigSchema = z
   .object({

--- a/apps/agent/src/agent/apps/calc/tools/calculate.tool.ts
+++ b/apps/agent/src/agent/apps/calc/tools/calculate.tool.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { ZodToolComponent, type JsonSchema, type ToolKind } from "@kagami/agent-runtime";
 
-export const CALCULATE_TOOL_NAME = "calculate";
+const CALCULATE_TOOL_NAME = "calculate";
 
 const OPERATORS = ["+", "-", "*", "/"] as const;
 type Operator = (typeof OPERATORS)[number];

--- a/apps/agent/src/agent/apps/clock/clock.app.ts
+++ b/apps/agent/src/agent/apps/clock/clock.app.ts
@@ -2,7 +2,7 @@ import type { App } from "@kagami/agent-runtime";
 import { renderServerStaticTemplate } from "@kagami/kernel/runtime/read-static-text";
 import { ViewTimeTool } from "./tools/view-time.tool.js";
 
-export const CLOCK_APP_ID = "clock";
+const CLOCK_APP_ID = "clock";
 
 /**
  * Clock App。Agent 主动查询当前时间的最小 App。

--- a/apps/agent/src/agent/apps/clock/tools/view-time.tool.ts
+++ b/apps/agent/src/agent/apps/clock/tools/view-time.tool.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { ZodToolComponent, type JsonSchema, type ToolKind } from "@kagami/agent-runtime";
 import { BEIJING_TIME_ZONE } from "@kagami/kernel/utils/time";
 
-export const VIEW_TIME_TOOL_NAME = "view_time";
+const VIEW_TIME_TOOL_NAME = "view_time";
 
 const ViewTimeArgumentsSchema = z.object({});
 

--- a/apps/agent/src/agent/apps/hn/client/algolia.ts
+++ b/apps/agent/src/agent/apps/hn/client/algolia.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { hnFetchJson, type HnFetchOptions } from "./hn-fetch.js";
 
 /** HN 官方背书的第三方搜索 API（Algolia）只读 baseURL。 */
-export const HN_ALGOLIA_BASE_URL = "https://hn.algolia.com/api/v1";
+const HN_ALGOLIA_BASE_URL = "https://hn.algolia.com/api/v1";
 
 export type HnSearchSort = "relevance" | "date";
 export type HnSearchTag = "story" | "comment" | "ask_hn" | "show_hn";

--- a/apps/agent/src/agent/apps/hn/client/firebase.ts
+++ b/apps/agent/src/agent/apps/hn/client/firebase.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { hnFetchJson, type HnFetchOptions } from "./hn-fetch.js";
 
 /** HN 官方 Firebase API 的只读 baseURL。 */
-export const HN_FIREBASE_BASE_URL = "https://hacker-news.firebaseio.com/v0";
+const HN_FIREBASE_BASE_URL = "https://hacker-news.firebaseio.com/v0";
 
 export type HnFeed = "top" | "new" | "best" | "ask" | "show" | "job";
 

--- a/apps/agent/src/agent/apps/hn/hn.app.ts
+++ b/apps/agent/src/agent/apps/hn/hn.app.ts
@@ -11,7 +11,7 @@ import { OpenHnThreadTool } from "./tools/open-hn-thread.tool.js";
 import { SearchHnTool } from "./tools/search-hn.tool.js";
 import { OpenHnUserTool } from "./tools/open-hn-user.tool.js";
 
-export const HN_APP_ID = "hn";
+const HN_APP_ID = "hn";
 
 const DEFAULT_USER_AGENT =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Kagami/1.0";

--- a/apps/agent/src/agent/apps/hn/tools/glance-hn.tool.ts
+++ b/apps/agent/src/agent/apps/hn/tools/glance-hn.tool.ts
@@ -4,7 +4,7 @@ import { renderHnFrontPageContent } from "../hn-screen.js";
 import type { RootAgentEffect } from "../../../runtime/effect/root-agent-effect.js";
 import type { HnReader } from "../hn-reader.js";
 
-export const GLANCE_HN_TOOL_NAME = "glance_hn";
+const GLANCE_HN_TOOL_NAME = "glance_hn";
 
 const GlanceHnArgumentsSchema = z.object({
   feed: z.enum(["top", "new", "best", "ask", "show", "job"]).optional(),

--- a/apps/agent/src/agent/apps/hn/tools/open-hn-thread.tool.ts
+++ b/apps/agent/src/agent/apps/hn/tools/open-hn-thread.tool.ts
@@ -4,7 +4,7 @@ import { renderHnThreadContent } from "../hn-screen.js";
 import type { RootAgentEffect } from "../../../runtime/effect/root-agent-effect.js";
 import type { HnReader } from "../hn-reader.js";
 
-export const OPEN_HN_THREAD_TOOL_NAME = "open_hn_thread";
+const OPEN_HN_THREAD_TOOL_NAME = "open_hn_thread";
 
 const OpenHnThreadArgumentsSchema = z.object({
   id: z.number().int().positive(),

--- a/apps/agent/src/agent/apps/hn/tools/open-hn-user.tool.ts
+++ b/apps/agent/src/agent/apps/hn/tools/open-hn-user.tool.ts
@@ -4,7 +4,7 @@ import { renderHnUserContent } from "../hn-screen.js";
 import type { RootAgentEffect } from "../../../runtime/effect/root-agent-effect.js";
 import type { HnReader } from "../hn-reader.js";
 
-export const OPEN_HN_USER_TOOL_NAME = "open_hn_user";
+const OPEN_HN_USER_TOOL_NAME = "open_hn_user";
 
 const OpenHnUserArgumentsSchema = z.object({
   username: z.string().min(1),

--- a/apps/agent/src/agent/apps/hn/tools/search-hn.tool.ts
+++ b/apps/agent/src/agent/apps/hn/tools/search-hn.tool.ts
@@ -4,7 +4,7 @@ import { renderHnSearchContent } from "../hn-screen.js";
 import type { RootAgentEffect } from "../../../runtime/effect/root-agent-effect.js";
 import type { HnReader } from "../hn-reader.js";
 
-export const SEARCH_HN_TOOL_NAME = "search_hn";
+const SEARCH_HN_TOOL_NAME = "search_hn";
 
 const SearchHnArgumentsSchema = z.object({
   query: z.string().min(1),

--- a/apps/agent/src/agent/apps/ithome/tools/open-ithome-article.tool.ts
+++ b/apps/agent/src/agent/apps/ithome/tools/open-ithome-article.tool.ts
@@ -4,7 +4,7 @@ import { renderIthomeArticleDetailContent } from "../ithome-screen.js";
 import type { IthomeService } from "../../../capabilities/ithome/application/ithome.service.js";
 import type { RootAgentEffect } from "../../../runtime/effect/root-agent-effect.js";
 
-export const OPEN_ITHOME_ARTICLE_TOOL_NAME = "open_ithome_article";
+const OPEN_ITHOME_ARTICLE_TOOL_NAME = "open_ithome_article";
 
 const OpenIthomeArticleArgumentsSchema = z.object({
   articleId: z.number().int().positive(),

--- a/apps/agent/src/agent/apps/pixel/pixel.app.ts
+++ b/apps/agent/src/agent/apps/pixel/pixel.app.ts
@@ -15,7 +15,7 @@ import type { RootAgentEffect } from "../../runtime/effect/root-agent-effect.js"
 import type { OssClient } from "../../../acl/oss-client.js";
 import type { PixelClient } from "../../../acl/pixel-client.js";
 
-export const PIXEL_APP_ID = "pixel";
+const PIXEL_APP_ID = "pixel";
 
 type PixelAppDeps = {
   /** 绘图动作客户端：打到独立的 kagami-pixel 进程（issue #365）。 */

--- a/apps/agent/src/agent/apps/qq/qq.app.ts
+++ b/apps/agent/src/agent/apps/qq/qq.app.ts
@@ -64,7 +64,7 @@ function toConversationId(id: string): ConversationId {
   return id as ConversationId;
 }
 
-export const QQ_APP_ID = "qq";
+const QQ_APP_ID = "qq";
 
 /** view_forward 每页条数（默认显示前 50 条，其余靠 offset 翻页）。 */
 const FORWARD_PAGE_SIZE = 50;

--- a/apps/agent/src/agent/apps/spire/spire.app.ts
+++ b/apps/agent/src/agent/apps/spire/spire.app.ts
@@ -11,7 +11,7 @@ import { renderSpirePortal } from "../../capabilities/spire/render/spire-screen.
 import type { RootAgentEffect } from "../../runtime/effect/root-agent-effect.js";
 import type { SpireClient } from "../../../acl/spire-client.js";
 
-export const SPIRE_APP_ID = "spire";
+const SPIRE_APP_ID = "spire";
 
 type SpireAppDeps = {
   /** 游戏动作客户端：打到独立的 kagami-spire 进程（issue #234）。 */

--- a/apps/agent/src/agent/apps/todo/tools/add-todo.tool.ts
+++ b/apps/agent/src/agent/apps/todo/tools/add-todo.tool.ts
@@ -3,7 +3,7 @@ import { ZodToolComponent, type ToolExecutionResult, type ToolKind } from "@kaga
 import { InvalidTimeError } from "../../../capabilities/todo/application/parse-reminder-time.js";
 import type { TodoService } from "../../../capabilities/todo/application/todo.service.js";
 
-export const ADD_TODO_TOOL_NAME = "add_todo";
+const ADD_TODO_TOOL_NAME = "add_todo";
 
 const AddTodoArgumentsSchema = z.object({
   title: z.string().min(1),

--- a/apps/agent/src/agent/apps/todo/tools/complete-todo.tool.ts
+++ b/apps/agent/src/agent/apps/todo/tools/complete-todo.tool.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { ZodToolComponent, type ToolExecutionResult, type ToolKind } from "@kagami/agent-runtime";
 import type { TodoService } from "../../../capabilities/todo/application/todo.service.js";
 
-export const COMPLETE_TODO_TOOL_NAME = "complete_todo";
+const COMPLETE_TODO_TOOL_NAME = "complete_todo";
 
 const CompleteTodoArgumentsSchema = z.object({
   id: z.number().int().positive(),

--- a/apps/agent/src/agent/apps/todo/tools/list-todos.tool.ts
+++ b/apps/agent/src/agent/apps/todo/tools/list-todos.tool.ts
@@ -4,7 +4,7 @@ import { TODO_LIST_RENDER_LIMIT } from "../../../capabilities/todo/application/t
 import type { TodoService } from "../../../capabilities/todo/application/todo.service.js";
 import { renderTodoListContent } from "../render-todo-list.js";
 
-export const LIST_TODOS_TOOL_NAME = "list_todos";
+const LIST_TODOS_TOOL_NAME = "list_todos";
 
 const ListTodosArgumentsSchema = z.object({
   filter: z.enum(["pending", "all", "done"]).optional(),

--- a/apps/agent/src/agent/apps/todo/tools/remove-todo.tool.ts
+++ b/apps/agent/src/agent/apps/todo/tools/remove-todo.tool.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { ZodToolComponent, type ToolExecutionResult, type ToolKind } from "@kagami/agent-runtime";
 import type { TodoService } from "../../../capabilities/todo/application/todo.service.js";
 
-export const REMOVE_TODO_TOOL_NAME = "remove_todo";
+const REMOVE_TODO_TOOL_NAME = "remove_todo";
 
 const RemoveTodoArgumentsSchema = z.object({
   id: z.number().int().positive(),

--- a/apps/agent/src/agent/apps/todo/tools/snooze-todo.tool.ts
+++ b/apps/agent/src/agent/apps/todo/tools/snooze-todo.tool.ts
@@ -3,7 +3,7 @@ import { ZodToolComponent, type ToolExecutionResult, type ToolKind } from "@kaga
 import { InvalidTimeError } from "../../../capabilities/todo/application/parse-reminder-time.js";
 import type { TodoService } from "../../../capabilities/todo/application/todo.service.js";
 
-export const SNOOZE_TODO_TOOL_NAME = "snooze_todo";
+const SNOOZE_TODO_TOOL_NAME = "snooze_todo";
 
 const SnoozeTodoArgumentsSchema = z.object({
   id: z.number().int().positive(),

--- a/apps/agent/src/agent/apps/todo/tools/update-todo.tool.ts
+++ b/apps/agent/src/agent/apps/todo/tools/update-todo.tool.ts
@@ -3,7 +3,7 @@ import { ZodToolComponent, type ToolExecutionResult, type ToolKind } from "@kaga
 import { InvalidTimeError } from "../../../capabilities/todo/application/parse-reminder-time.js";
 import type { TodoService } from "../../../capabilities/todo/application/todo.service.js";
 
-export const UPDATE_TODO_TOOL_NAME = "update_todo";
+const UPDATE_TODO_TOOL_NAME = "update_todo";
 
 const UpdateTodoArgumentsSchema = z
   .object({

--- a/apps/agent/src/agent/capabilities/browser/tools/click.tool.ts
+++ b/apps/agent/src/agent/capabilities/browser/tools/click.tool.ts
@@ -3,7 +3,7 @@ import type { ToolKind } from "@kagami/agent-runtime";
 import { BrowserToolComponent } from "./browser-tool-component.js";
 import type { BrowserClient } from "../../../../acl/browser-client.js";
 
-export const BROWSER_CLICK_TOOL_NAME = "browser_click";
+const BROWSER_CLICK_TOOL_NAME = "browser_click";
 
 const Schema = z.object({ target: z.string().min(1) });
 

--- a/apps/agent/src/agent/capabilities/browser/tools/eval.tool.ts
+++ b/apps/agent/src/agent/capabilities/browser/tools/eval.tool.ts
@@ -3,7 +3,7 @@ import type { ToolKind } from "@kagami/agent-runtime";
 import { BrowserToolComponent } from "./browser-tool-component.js";
 import type { BrowserClient } from "../../../../acl/browser-client.js";
 
-export const BROWSER_EVAL_TOOL_NAME = "browser_eval";
+const BROWSER_EVAL_TOOL_NAME = "browser_eval";
 
 const Schema = z.object({ script: z.string().min(1) });
 

--- a/apps/agent/src/agent/capabilities/browser/tools/navigate.tool.ts
+++ b/apps/agent/src/agent/capabilities/browser/tools/navigate.tool.ts
@@ -3,7 +3,7 @@ import type { ToolKind } from "@kagami/agent-runtime";
 import { BrowserToolComponent } from "./browser-tool-component.js";
 import type { BrowserClient } from "../../../../acl/browser-client.js";
 
-export const BROWSER_NAVIGATE_TOOL_NAME = "browser_navigate";
+const BROWSER_NAVIGATE_TOOL_NAME = "browser_navigate";
 
 const Schema = z.object({ url: z.string().min(1) });
 

--- a/apps/agent/src/agent/capabilities/browser/tools/observe.tool.ts
+++ b/apps/agent/src/agent/capabilities/browser/tools/observe.tool.ts
@@ -3,7 +3,7 @@ import type { ToolKind } from "@kagami/agent-runtime";
 import { BrowserToolComponent } from "./browser-tool-component.js";
 import type { BrowserClient } from "../../../../acl/browser-client.js";
 
-export const BROWSER_OBSERVE_TOOL_NAME = "browser_observe";
+const BROWSER_OBSERVE_TOOL_NAME = "browser_observe";
 
 const Schema = z.object({});
 

--- a/apps/agent/src/agent/capabilities/browser/tools/press.tool.ts
+++ b/apps/agent/src/agent/capabilities/browser/tools/press.tool.ts
@@ -3,7 +3,7 @@ import type { ToolKind } from "@kagami/agent-runtime";
 import { BrowserToolComponent } from "./browser-tool-component.js";
 import type { BrowserClient } from "../../../../acl/browser-client.js";
 
-export const BROWSER_PRESS_TOOL_NAME = "browser_press";
+const BROWSER_PRESS_TOOL_NAME = "browser_press";
 
 const Schema = z.object({ key: z.string().min(1) });
 

--- a/apps/agent/src/agent/capabilities/browser/tools/screenshot.tool.ts
+++ b/apps/agent/src/agent/capabilities/browser/tools/screenshot.tool.ts
@@ -6,7 +6,7 @@ import type { BrowserClient } from "../../../../acl/browser-client.js";
 import type { RootAgentEffect } from "../../../runtime/effect/root-agent-effect.js";
 import type { OssClient } from "../../../../acl/oss-client.js";
 
-export const BROWSER_SCREENSHOT_TOOL_NAME = "browser_screenshot";
+const BROWSER_SCREENSHOT_TOOL_NAME = "browser_screenshot";
 
 const Schema = z.object({});
 

--- a/apps/agent/src/agent/capabilities/browser/tools/type.tool.ts
+++ b/apps/agent/src/agent/capabilities/browser/tools/type.tool.ts
@@ -4,7 +4,7 @@ import { BrowserToolComponent } from "./browser-tool-component.js";
 import { BrowserError } from "../domain/errors.js";
 import type { BrowserClient } from "../../../../acl/browser-client.js";
 
-export const BROWSER_TYPE_TOOL_NAME = "browser_type";
+const BROWSER_TYPE_TOOL_NAME = "browser_type";
 
 const Schema = z.object({
   ref: z.string().min(1),

--- a/apps/agent/src/agent/capabilities/browser/tools/wait-for.tool.ts
+++ b/apps/agent/src/agent/capabilities/browser/tools/wait-for.tool.ts
@@ -4,7 +4,7 @@ import { BrowserToolComponent } from "./browser-tool-component.js";
 import { BrowserError } from "../domain/errors.js";
 import type { BrowserClient } from "../../../../acl/browser-client.js";
 
-export const BROWSER_WAIT_FOR_TOOL_NAME = "browser_wait_for";
+const BROWSER_WAIT_FOR_TOOL_NAME = "browser_wait_for";
 
 const Schema = z.object({
   selector: z.string().optional(),

--- a/apps/agent/src/agent/capabilities/inner-voice/domain/ledger-idle-signals.ts
+++ b/apps/agent/src/agent/capabilities/inner-voice/domain/ledger-idle-signals.ts
@@ -2,7 +2,7 @@ import type { LlmMessage } from "@kagami/llm-client";
 import { isWaitToolCall, type InnerVoiceIdleSignals } from "./idle-detector.js";
 
 /** 注入进上下文的 `<inner_thought>` 伪标签，回扫时凭它辨识历史注入。 */
-export const INNER_THOUGHT_TAG = "<inner_thought>";
+const INNER_THOUGHT_TAG = "<inner_thought>";
 
 /**
  * 从 ledger 记录（时间升序或任意序）重建摸鱼判定信号：

--- a/apps/agent/src/agent/capabilities/messaging/tools/send-message.tool.ts
+++ b/apps/agent/src/agent/capabilities/messaging/tools/send-message.tool.ts
@@ -6,7 +6,7 @@ import type { AiToneScorer } from "../infra/ai-tone-scorer.js";
 import { MutedSendError, formatMutedNote } from "../application/muted-send-error.js";
 import type { NapcatChatTarget } from "@kagami/napcat-api/message";
 
-export const SEND_MESSAGE_TOOL_NAME = "send_message";
+const SEND_MESSAGE_TOOL_NAME = "send_message";
 
 const SendMessageArgumentsSchema = z.object({
   message: z.string().trim().min(1).optional(),

--- a/apps/agent/src/agent/capabilities/messaging/tools/send-resource.tool.ts
+++ b/apps/agent/src/agent/capabilities/messaging/tools/send-resource.tool.ts
@@ -6,7 +6,7 @@ import type { ResourceService } from "../../resource/application/resource.servic
 import type { AgentMessageService } from "../application/agent-message.service.js";
 import { MutedSendError, formatMutedNote } from "../application/muted-send-error.js";
 
-export const SEND_RESOURCE_TOOL_NAME = "send_resource";
+const SEND_RESOURCE_TOOL_NAME = "send_resource";
 
 const SendResourceArgumentsSchema = z.object({
   resid: z.string().trim().min(1),

--- a/apps/agent/src/agent/capabilities/pixel/tools/circle.tool.ts
+++ b/apps/agent/src/agent/capabilities/pixel/tools/circle.tool.ts
@@ -4,7 +4,7 @@ import { PixelToolComponent } from "./pixel-tool-component.js";
 import { renderDrawResponse } from "../render/pixel-screen.js";
 import type { PixelClient } from "../../../../acl/pixel-client.js";
 
-export const PIXEL_CIRCLE_TOOL_NAME = "circle";
+const PIXEL_CIRCLE_TOOL_NAME = "circle";
 
 const Schema = z.object({
   cx: z.number().int().min(0),

--- a/apps/agent/src/agent/capabilities/pixel/tools/clear.tool.ts
+++ b/apps/agent/src/agent/capabilities/pixel/tools/clear.tool.ts
@@ -4,7 +4,7 @@ import { PixelToolComponent } from "./pixel-tool-component.js";
 import { renderDrawResponse } from "../render/pixel-screen.js";
 import type { PixelClient } from "../../../../acl/pixel-client.js";
 
-export const PIXEL_CLEAR_TOOL_NAME = "clear";
+const PIXEL_CLEAR_TOOL_NAME = "clear";
 
 const Schema = z.object({});
 

--- a/apps/agent/src/agent/capabilities/pixel/tools/ellipse.tool.ts
+++ b/apps/agent/src/agent/capabilities/pixel/tools/ellipse.tool.ts
@@ -4,7 +4,7 @@ import { PixelToolComponent } from "./pixel-tool-component.js";
 import { renderDrawResponse } from "../render/pixel-screen.js";
 import type { PixelClient } from "../../../../acl/pixel-client.js";
 
-export const PIXEL_ELLIPSE_TOOL_NAME = "ellipse";
+const PIXEL_ELLIPSE_TOOL_NAME = "ellipse";
 
 const Schema = z.object({
   cx: z.number().int().min(0),

--- a/apps/agent/src/agent/capabilities/pixel/tools/fill.tool.ts
+++ b/apps/agent/src/agent/capabilities/pixel/tools/fill.tool.ts
@@ -4,7 +4,7 @@ import { PixelToolComponent } from "./pixel-tool-component.js";
 import { renderDrawResponse } from "../render/pixel-screen.js";
 import type { PixelClient } from "../../../../acl/pixel-client.js";
 
-export const PIXEL_FILL_TOOL_NAME = "fill";
+const PIXEL_FILL_TOOL_NAME = "fill";
 
 const Schema = z.object({
   x: z.number().int().min(0),

--- a/apps/agent/src/agent/capabilities/pixel/tools/line.tool.ts
+++ b/apps/agent/src/agent/capabilities/pixel/tools/line.tool.ts
@@ -4,7 +4,7 @@ import { PixelToolComponent } from "./pixel-tool-component.js";
 import { renderDrawResponse } from "../render/pixel-screen.js";
 import type { PixelClient } from "../../../../acl/pixel-client.js";
 
-export const PIXEL_LINE_TOOL_NAME = "line";
+const PIXEL_LINE_TOOL_NAME = "line";
 
 const Schema = z.object({
   x1: z.number().int().min(0),

--- a/apps/agent/src/agent/capabilities/pixel/tools/new-canvas.tool.ts
+++ b/apps/agent/src/agent/capabilities/pixel/tools/new-canvas.tool.ts
@@ -5,7 +5,7 @@ import { PixelToolComponent } from "./pixel-tool-component.js";
 import { renderDrawResponse } from "../render/pixel-screen.js";
 import type { PixelClient } from "../../../../acl/pixel-client.js";
 
-export const PIXEL_NEW_CANVAS_TOOL_NAME = "new_canvas";
+const PIXEL_NEW_CANVAS_TOOL_NAME = "new_canvas";
 
 const Schema = z.object({
   width: z.number().int().min(1).max(MAX_CANVAS_SIZE),

--- a/apps/agent/src/agent/capabilities/pixel/tools/rect.tool.ts
+++ b/apps/agent/src/agent/capabilities/pixel/tools/rect.tool.ts
@@ -4,7 +4,7 @@ import { PixelToolComponent } from "./pixel-tool-component.js";
 import { renderDrawResponse } from "../render/pixel-screen.js";
 import type { PixelClient } from "../../../../acl/pixel-client.js";
 
-export const PIXEL_RECT_TOOL_NAME = "rect";
+const PIXEL_RECT_TOOL_NAME = "rect";
 
 const Schema = z.object({
   x1: z.number().int().min(0),

--- a/apps/agent/src/agent/capabilities/pixel/tools/render.tool.ts
+++ b/apps/agent/src/agent/capabilities/pixel/tools/render.tool.ts
@@ -6,7 +6,7 @@ import type { RootAgentEffect } from "../../../runtime/effect/root-agent-effect.
 import type { OssClient } from "../../../../acl/oss-client.js";
 import type { PixelClient } from "../../../../acl/pixel-client.js";
 
-export const PIXEL_RENDER_TOOL_NAME = "render";
+const PIXEL_RENDER_TOOL_NAME = "render";
 
 const logger = new AppLogger({ source: "agent.pixel.render" });
 

--- a/apps/agent/src/agent/capabilities/pixel/tools/set-pixels.tool.ts
+++ b/apps/agent/src/agent/capabilities/pixel/tools/set-pixels.tool.ts
@@ -5,7 +5,7 @@ import { PixelToolComponent } from "./pixel-tool-component.js";
 import { renderDrawResponse } from "../render/pixel-screen.js";
 import type { PixelClient } from "../../../../acl/pixel-client.js";
 
-export const PIXEL_SET_PIXELS_TOOL_NAME = "set_pixels";
+const PIXEL_SET_PIXELS_TOOL_NAME = "set_pixels";
 
 // 与契约 setPixels 的上限一致（整幅画布的格子数）：本地就封顶，超量在 agent 侧即拒，
 // 不把巨大数组发出去撞服务端 400（那会被 mapFallbackError 误报成 PIXEL_NOT_READY）。

--- a/apps/agent/src/agent/capabilities/resource/tools/download-resource.tool.ts
+++ b/apps/agent/src/agent/capabilities/resource/tools/download-resource.tool.ts
@@ -3,7 +3,7 @@ import { ZodToolComponent, type ToolExecutionResult, type ToolKind } from "@kaga
 import { BizError } from "@kagami/kernel/errors/biz-error";
 import type { ResourceFileService } from "../application/resource-file.service.js";
 
-export const DOWNLOAD_RESOURCE_TOOL_NAME = "download_resource";
+const DOWNLOAD_RESOURCE_TOOL_NAME = "download_resource";
 
 const DownloadResourceArgumentsSchema = z.object({
   resid: z.string().trim().min(1),

--- a/apps/agent/src/agent/capabilities/resource/tools/upload-resource.tool.ts
+++ b/apps/agent/src/agent/capabilities/resource/tools/upload-resource.tool.ts
@@ -3,7 +3,7 @@ import { ZodToolComponent, type ToolExecutionResult, type ToolKind } from "@kaga
 import { BizError } from "@kagami/kernel/errors/biz-error";
 import type { ResourceFileService } from "../application/resource-file.service.js";
 
-export const UPLOAD_RESOURCE_TOOL_NAME = "upload_resource";
+const UPLOAD_RESOURCE_TOOL_NAME = "upload_resource";
 
 const UploadResourceArgumentsSchema = z.object({
   path: z.string().trim().min(1),

--- a/apps/agent/src/agent/capabilities/spire/tools/choose.tool.ts
+++ b/apps/agent/src/agent/capabilities/spire/tools/choose.tool.ts
@@ -4,7 +4,7 @@ import { SpireToolComponent } from "./spire-tool-component.js";
 import { renderSpireScreen } from "../render/spire-screen.js";
 import type { SpireClient } from "../../../../acl/spire-client.js";
 
-export const SPIRE_CHOOSE_TOOL_NAME = "choose";
+const SPIRE_CHOOSE_TOOL_NAME = "choose";
 
 const Schema = z.object({ option_index: z.number().int().min(0) });
 

--- a/apps/agent/src/agent/capabilities/spire/tools/end-turn.tool.ts
+++ b/apps/agent/src/agent/capabilities/spire/tools/end-turn.tool.ts
@@ -4,7 +4,7 @@ import { SpireToolComponent } from "./spire-tool-component.js";
 import { renderSpireScreen } from "../render/spire-screen.js";
 import type { SpireClient } from "../../../../acl/spire-client.js";
 
-export const SPIRE_END_TURN_TOOL_NAME = "end_turn";
+const SPIRE_END_TURN_TOOL_NAME = "end_turn";
 
 const Schema = z.object({});
 

--- a/apps/agent/src/agent/capabilities/spire/tools/look.tool.ts
+++ b/apps/agent/src/agent/capabilities/spire/tools/look.tool.ts
@@ -4,7 +4,7 @@ import { SpireToolComponent } from "./spire-tool-component.js";
 import { renderSpireScreen, renderSpireNoRun } from "../render/spire-screen.js";
 import type { SpireClient } from "../../../../acl/spire-client.js";
 
-export const SPIRE_LOOK_TOOL_NAME = "look";
+const SPIRE_LOOK_TOOL_NAME = "look";
 
 const Schema = z.object({});
 

--- a/apps/agent/src/agent/capabilities/spire/tools/lookup.tool.ts
+++ b/apps/agent/src/agent/capabilities/spire/tools/lookup.tool.ts
@@ -4,7 +4,7 @@ import { SpireToolComponent } from "./spire-tool-component.js";
 import { renderSpireReference } from "../render/spire-screen.js";
 import type { SpireClient } from "../../../../acl/spire-client.js";
 
-export const SPIRE_LOOKUP_TOOL_NAME = "lookup";
+const SPIRE_LOOKUP_TOOL_NAME = "lookup";
 
 const Schema = z.object({ query: z.string().optional() });
 

--- a/apps/agent/src/agent/capabilities/spire/tools/play-card.tool.ts
+++ b/apps/agent/src/agent/capabilities/spire/tools/play-card.tool.ts
@@ -4,7 +4,7 @@ import { SpireToolComponent } from "./spire-tool-component.js";
 import { renderSpireScreen } from "../render/spire-screen.js";
 import type { SpireClient } from "../../../../acl/spire-client.js";
 
-export const SPIRE_PLAY_CARD_TOOL_NAME = "play_card";
+const SPIRE_PLAY_CARD_TOOL_NAME = "play_card";
 
 const Schema = z.object({
   hand_index: z.number().int().min(0),

--- a/apps/agent/src/agent/capabilities/spire/tools/start-run.tool.ts
+++ b/apps/agent/src/agent/capabilities/spire/tools/start-run.tool.ts
@@ -4,7 +4,7 @@ import { SpireToolComponent } from "./spire-tool-component.js";
 import { renderSpireScreen } from "../render/spire-screen.js";
 import type { SpireClient } from "../../../../acl/spire-client.js";
 
-export const SPIRE_START_RUN_TOOL_NAME = "start_run";
+const SPIRE_START_RUN_TOOL_NAME = "start_run";
 
 const Schema = z.object({
   character: z.enum(["ironclad", "silent", "defect", "watcher"]).optional(),

--- a/apps/agent/src/agent/capabilities/spire/tools/use-potion.tool.ts
+++ b/apps/agent/src/agent/capabilities/spire/tools/use-potion.tool.ts
@@ -4,7 +4,7 @@ import { SpireToolComponent } from "./spire-tool-component.js";
 import { renderSpireScreen } from "../render/spire-screen.js";
 import type { SpireClient } from "../../../../acl/spire-client.js";
 
-export const SPIRE_USE_POTION_TOOL_NAME = "use_potion";
+const SPIRE_USE_POTION_TOOL_NAME = "use_potion";
 
 const Schema = z.object({
   slot_index: z.number().int().min(0),

--- a/apps/agent/src/agent/capabilities/terminal/application/terminal.service.ts
+++ b/apps/agent/src/agent/capabilities/terminal/application/terminal.service.ts
@@ -27,7 +27,7 @@ export type TerminalServiceDeps = {
   terminalOutputDao: TerminalOutputDao;
 };
 
-export type RunBashSuccess = {
+type RunBashSuccess = {
   ok: true;
   exitCode: number;
   outputId: string | null;
@@ -41,7 +41,7 @@ export type RunBashSuccess = {
   durationMs: number;
 };
 
-export type RunBashFailure = {
+type RunBashFailure = {
   ok: false;
   error: TerminalErrorCode;
   message: string;
@@ -57,7 +57,7 @@ export type RunBashFailure = {
 
 export type RunBashResult = RunBashSuccess | RunBashFailure;
 
-export type ReadOutputSuccess = {
+type ReadOutputSuccess = {
   ok: true;
   outputId: string;
   stream: "stdout" | "stderr";
@@ -69,7 +69,7 @@ export type ReadOutputSuccess = {
   eof: boolean;
 };
 
-export type ReadOutputFailure = {
+type ReadOutputFailure = {
   ok: false;
   error: TerminalErrorCode;
   message: string;

--- a/apps/agent/src/agent/runtime/context/agent-context.ts
+++ b/apps/agent/src/agent/runtime/context/agent-context.ts
@@ -14,11 +14,11 @@ export type AgentContextDashboardSummary = {
   recentItems: AgentContextDashboardItem[];
   recentItemsTruncated: boolean;
 };
-export type ContextEventItem = {
+type ContextEventItem = {
   kind: "event";
   event: Event;
 };
-export type ContextLlmMessageItem = {
+type ContextLlmMessageItem = {
   kind: "llm_message";
   message: LlmMessage;
 };

--- a/apps/agent/src/agent/runtime/event/event.ts
+++ b/apps/agent/src/agent/runtime/event/event.ts
@@ -7,7 +7,7 @@ import type { AsyncTaskCompletion } from "@kagami/agent-runtime";
  * 路由时装配成一条 `<notification>` user message 追加到上下文尾部，并触发一轮 round。
  * 这条事件进队列本身就是「唤醒」——见 Queue 的 wake-up generality。
  */
-export type NotificationEvent = {
+type NotificationEvent = {
   type: "notification";
   data: {
     /** 每个源一行，已渲染好的展示文本。 */
@@ -22,7 +22,7 @@ export type NotificationEvent = {
  *
  * Session routing treats it as a no-op.
  */
-export type WakeEvent = {
+type WakeEvent = {
   type: "wake";
 };
 
@@ -31,7 +31,7 @@ export type WakeEvent = {
  * 的事件队列。Session 路由时装配成一条 `<async_tool_result>` user message 追加到上下文，
  * 并触发新一轮 round，让主 Agent 凭 task_id 对应到当初的发起。
  */
-export type AsyncToolResultCompletedEvent = {
+type AsyncToolResultCompletedEvent = {
   type: "async_tool_result_completed";
   data: AsyncTaskCompletion;
 };
@@ -43,7 +43,7 @@ export type AsyncToolResultCompletedEvent = {
  * 焦点已切走时向当前 App 拉空即 no-op，drain 的语义是「拉当前前台的未消费增量」，
  * 不存在错投。事件是通用原语，QQ 只是首个消费者。
  */
-export type ForegroundInputEvent = {
+type ForegroundInputEvent = {
   type: "foreground_input";
 };
 
@@ -52,7 +52,7 @@ export type ForegroundInputEvent = {
  * （issue #265）。Session 路由时装配成一条 `<inner_thought>` user message 追加到
  * 上下文尾部并触发一轮 round；enqueue 本身兼作唤醒（她摸鱼时多半正阻塞在 wait 里）。
  */
-export type InnerThoughtEvent = {
+type InnerThoughtEvent = {
   type: "inner_thought";
   data: {
     /** 已经以小镜口吻写好的第一人称念头文本。 */

--- a/apps/agent/src/agent/runtime/root-agent/persistence/root-agent-runtime-snapshot.ts
+++ b/apps/agent/src/agent/runtime/root-agent/persistence/root-agent-runtime-snapshot.ts
@@ -55,7 +55,7 @@ const LlmMessageSchema: z.ZodType<LlmMessage> = z.union([
   }),
 ]);
 
-export const PersistedAgentContextSnapshotSchema = z.object({
+const PersistedAgentContextSnapshotSchema = z.object({
   messages: z.array(LlmMessageSchema),
 });
 

--- a/apps/agent/src/agent/runtime/root-agent/tools/switch.tool.ts
+++ b/apps/agent/src/agent/runtime/root-agent/tools/switch.tool.ts
@@ -12,7 +12,7 @@ import type { RootAgentSessionController } from "../session/root-agent-session.j
 export const SWITCH_TOOL_NAME = "switch";
 
 /** 自动吐出的 App 能力说明所用的结构标识伪标签（结构标识非语气文案，留 TS 常量）。 */
-export const APP_HELP_TAG = "app_help";
+const APP_HELP_TAG = "app_help";
 
 /**
  * 把一段 help 文本包进 `<app_help app="...">` 结构标签。app id 取自注册常量（可信），但

--- a/apps/browser/src/app/config.ts
+++ b/apps/browser/src/app/config.ts
@@ -18,7 +18,7 @@ const BrowserBehaviorConfigSchema = z
   })
   .default({});
 
-export type BrowserBehaviorConfig = z.infer<typeof BrowserBehaviorConfigSchema>;
+type BrowserBehaviorConfig = z.infer<typeof BrowserBehaviorConfigSchema>;
 
 export type BrowserProcessConfig = {
   /** 监听端口，来自顶层 services.browser.port（单一事实来源，见 issue #162）。 */

--- a/apps/browser/src/domain/errors.ts
+++ b/apps/browser/src/domain/errors.ts
@@ -31,16 +31,6 @@ export type BrowserErrorContext = {
   navigating?: boolean;
 };
 
-const CONTEXT_FIELD_ORDER: readonly (keyof BrowserErrorContext)[] = [
-  "url",
-  "pageId",
-  "ref",
-  "epoch",
-  "currentEpoch",
-  "locatorState",
-  "navigating",
-];
-
 export class BrowserError extends Error {
   public readonly code: BrowserErrorCode;
   public readonly contextInfo: BrowserErrorContext;
@@ -55,34 +45,4 @@ export class BrowserError extends Error {
     this.code = code;
     this.contextInfo = contextInfo;
   }
-}
-
-/**
- * 把任意错误序列化成冻结结构的 JSON 字符串。字段顺序固定：
- * { ok:false, error:<code>, message, context:{...按 CONTEXT_FIELD_ORDER} }。
- * 非 BrowserError 归一为 BROWSER_ERROR，保证主 Agent 永远拿到同形状的失败结果。
- */
-export function serializeBrowserError(error: unknown): string {
-  if (error instanceof BrowserError) {
-    const orderedContext: Record<string, unknown> = {};
-    for (const key of CONTEXT_FIELD_ORDER) {
-      const value = error.contextInfo[key];
-      if (value !== undefined) {
-        orderedContext[key] = value;
-      }
-    }
-    return JSON.stringify({
-      ok: false,
-      error: error.code,
-      message: error.message,
-      context: orderedContext,
-    });
-  }
-
-  return JSON.stringify({
-    ok: false,
-    error: "BROWSER_ERROR" satisfies BrowserErrorCode,
-    message: error instanceof Error ? error.message : String(error),
-    context: {},
-  });
 }

--- a/apps/napcat/src/application/napcat-gateway.service.ts
+++ b/apps/napcat/src/application/napcat-gateway.service.ts
@@ -63,7 +63,7 @@ export type NapcatGroupMessageEvent = {
   data: NapcatGroupMessageData;
 };
 
-export type NapcatPrivateMessageData = {
+type NapcatPrivateMessageData = {
   userId: string;
   nickname: string;
   remark: string | null;
@@ -78,7 +78,7 @@ export type NapcatPrivateMessageEvent = {
   data: NapcatPrivateMessageData;
 };
 
-export type NapcatFriendListUpdatedEvent = {
+type NapcatFriendListUpdatedEvent = {
   type: "napcat_friend_list_updated";
   data: {
     friends: NapcatFriendInfo[];
@@ -104,7 +104,7 @@ export type NapcatGroupBanData = {
   time: number | null;
 };
 
-export type NapcatGroupBanEvent = {
+type NapcatGroupBanEvent = {
   type: "napcat_group_ban";
   data: NapcatGroupBanData;
 };
@@ -115,7 +115,7 @@ export type NapcatAgentEvent =
   | NapcatFriendListUpdatedEvent
   | NapcatGroupBanEvent;
 
-export type NapcatChatTarget =
+type NapcatChatTarget =
   | {
       chatType: "group";
       groupId: string;
@@ -158,7 +158,7 @@ export type NapcatForwardMessagePage = {
 };
 
 /** 群文件系统里的一个文件。 */
-export type NapcatGroupFileEntry = {
+type NapcatGroupFileEntry = {
   fileId: string;
   fileName: string;
   size: number;
@@ -167,7 +167,7 @@ export type NapcatGroupFileEntry = {
 };
 
 /** 群文件系统里的一个文件夹。 */
-export type NapcatGroupFolderEntry = {
+type NapcatGroupFolderEntry = {
   folderId: string;
   folderName: string;
   fileCount: number;

--- a/apps/napcat/src/application/napcat-gateway/shared.ts
+++ b/apps/napcat/src/application/napcat-gateway/shared.ts
@@ -14,7 +14,6 @@ import {
   type NapcatReceiveImageSegment,
   type NapcatReceiveMessageSegment,
   type NapcatReceiveReplySegment,
-  type NapcatReceiveTextSegment,
 } from "../../domain/napcat-segment.js";
 import {
   QQ_FACE_NAMES,
@@ -23,7 +22,7 @@ import {
   FORWARD_ID_DISPLAY_PREFIX,
 } from "@kagami/napcat-api/rendering";
 
-export type { NapcatReceiveAtSegment, NapcatReceiveMessageSegment, NapcatReceiveTextSegment };
+export type { NapcatReceiveAtSegment, NapcatReceiveMessageSegment };
 
 export type WebSocketLike = {
   readonly readyState: number;
@@ -52,7 +51,7 @@ export const WS_OPEN_READY_STATE = 1;
 export const BLOCKED_NAPCAT_EVENT_POST_TYPES = new Set<string>(["meta_event"]);
 export const GROUP_MEMBER_DISPLAY_NAME_CACHE_TTL_MS = 10 * 60 * 1000;
 
-export const MessageSegmentsSchema = z.array(NapcatReceiveMessageSegmentSchema);
+const MessageSegmentsSchema = z.array(NapcatReceiveMessageSegmentSchema);
 
 export const ActionResponseSchema = z.object({
   status: z.string(),
@@ -218,7 +217,7 @@ export function renderSupportedMessageSegments(
  * 合并转发段：只渲染成带 res_id 的占位符,不内联展开内容。Kagami 想看靠 QQ App 的
  * view_forward(forward_id) 工具按需拉取——大段聊天记录绝不直接进主上下文（KV 缓存优先）。
  */
-export function formatForwardSegment(segment: NapcatReceiveForwardSegment): string {
+function formatForwardSegment(segment: NapcatReceiveForwardSegment): string {
   const id = toNullableString(segment.data.id);
   return id ? `[forward_id: ${FORWARD_ID_DISPLAY_PREFIX}${id}]` : "[合并转发]";
 }
@@ -228,7 +227,7 @@ export function formatForwardSegment(segment: NapcatReceiveForwardSegment): stri
  * 现在渲染成 `[表情: 名字]`。名字优先取 NapCat 给的 `raw.faceText`（最权威），其次查兜底字典，
  * 都没有再退化成通用 `[表情]`。和 `[图片: 描述]` / `[合并转发]` 的方括号占位约定保持一致。
  */
-export function formatFaceSegment(segment: NapcatReceiveFaceSegment): string {
+function formatFaceSegment(segment: NapcatReceiveFaceSegment): string {
   const name = resolveFaceName(segment);
   return name ? `[表情: ${name}]` : "[表情]";
 }
@@ -357,7 +356,7 @@ function createFaceSegment(name: string): NapcatSendFaceSegment | null {
   return id ? { type: "face", data: { id } } : null;
 }
 
-export function formatAtSegment(segment: NapcatReceiveAtSegment): string | null {
+function formatAtSegment(segment: NapcatReceiveAtSegment): string | null {
   const qq = segment.data.qq;
   const name = toNullableString(segment.data.name) ?? (qq === "all" ? "全体成员" : null);
   if (!name) {
@@ -395,7 +394,7 @@ export function extractDisplayNameFromGroupMemberInfo(
   return toNullableString(data.nickname);
 }
 
-export function formatReplySegment(segment: NapcatReceiveReplySegment): string {
+function formatReplySegment(segment: NapcatReceiveReplySegment): string {
   const nickname = toNullableString(segment.data.senderNickname);
   const userId = toNullableString(segment.data.senderUserId);
   const preview = toNullableString(segment.data.messagePreview);

--- a/apps/oss/src/store/object-store.ts
+++ b/apps/oss/src/store/object-store.ts
@@ -86,7 +86,7 @@ interface DeleteOutcome {
 }
 
 /** 控制台对象浏览的列表行（object ⋈ blob，size/refcount 取自权威的 blob 行）。 */
-export interface ObjectListRow {
+interface ObjectListRow {
   /** object 表自增 id；对外 key = `res-<id>`（映射在 HTTP 层完成）。 */
   id: number;
   mime: string;

--- a/apps/scheduler/src/application/tick-broadcaster.ts
+++ b/apps/scheduler/src/application/tick-broadcaster.ts
@@ -99,6 +99,6 @@ export class TickBroadcaster {
 }
 
 /** 一个 tick 序列化成 SSE 帧：`data: <tick JSON>\n\n`（无 id 行——不做 Last-Event-ID 回放）。 */
-export function serializeTickFrame(tick: SchedulerTickEvent): string {
+function serializeTickFrame(tick: SchedulerTickEvent): string {
   return `data: ${JSON.stringify(tick)}\n\n`;
 }

--- a/apps/spire/src/application/reference.ts
+++ b/apps/spire/src/application/reference.ts
@@ -7,7 +7,7 @@ import { GLOSSARY, type GlossaryEntry } from "../engine/glossary.js";
 //
 // 供 agent 侧 lookup 工具消费（GET /reference?q=）。数据是游戏事实，渲染框架文案在 agent .hbs。
 
-export type CardRef = {
+type CardRef = {
   name: string;
   type: string;
   cost: number | null;
@@ -17,13 +17,13 @@ export type CardRef = {
   upgradedDescription: string;
 };
 
-export type RelicRef = {
+type RelicRef = {
   name: string;
   rarity: string;
   description: string;
 };
 
-export type PotionRef = {
+type PotionRef = {
   name: string;
   rarity: string;
   targeted: boolean;

--- a/apps/spire/src/engine/cards/cards.ts
+++ b/apps/spire/src/engine/cards/cards.ts
@@ -6036,7 +6036,6 @@ export function rewardCardPoolOf(color: CardDef["color"]): readonly string[] {
 export const COMMON_CARD_POOL: readonly string[] = cardPoolOf("red", "common");
 export const UNCOMMON_CARD_POOL: readonly string[] = cardPoolOf("red", "uncommon");
 export const RARE_CARD_POOL: readonly string[] = cardPoolOf("red", "rare");
-export const REWARD_CARD_POOL: readonly string[] = rewardCardPoolOf("red");
 
 /** 取一张牌当前生效的效果（升级则用升级效果）。 */
 export function effectsOf(def: CardDef, upgraded: boolean): CardDef["effects"] {

--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -3579,5 +3579,3 @@ function resolveCombatIfEnded(state: GameState): void {
   }
   // 非 Boss 的奖励生成在 run 层处理（避免 combat 依赖 run）。
 }
-
-export { livingEnemies };

--- a/apps/spire/src/engine/events/events.ts
+++ b/apps/spire/src/engine/events/events.ts
@@ -18,7 +18,7 @@ export type EventOutcome =
   | { kind: "upgrade_random_card"; count: number }
   | { kind: "nothing" };
 
-export type EventChoice = {
+type EventChoice = {
   /** 选项按钮文案（原创）。 */
   label: string;
   /** 选择后展示的结果叙述（原创）。 */

--- a/apps/spire/src/engine/potions/potions.ts
+++ b/apps/spire/src/engine/potions/potions.ts
@@ -342,7 +342,6 @@ function potionIdsForCharacter(character: CharacterId, rarity: PotionRarity): re
 }
 
 export const COMMON_POTION_POOL: readonly string[] = potionIdsOfRarity("common");
-export const UNCOMMON_POTION_POOL: readonly string[] = potionIdsOfRarity("uncommon");
 export const RARE_POTION_POOL: readonly string[] = potionIdsOfRarity("rare");
 
 /** 全部通用药水 id（不含角色专属）。 */

--- a/apps/spire/src/engine/relics/relics.ts
+++ b/apps/spire/src/engine/relics/relics.ts
@@ -19,12 +19,12 @@ import { nextInt } from "../rng.js";
 // 直接状态改动（力量/敏捷/格挡/能量/回血）在钩子里做；需要走伤害结算的用 emit 发 Effect。
 // hooks 第二参 self 是该遗物自己的 RelicState，计数型遗物读写 self.counter。
 
-export type RelicRarity = "starter" | "common" | "uncommon" | "rare" | "boss";
+type RelicRarity = "starter" | "common" | "uncommon" | "rare" | "boss";
 
 /** emit：以玩家为行动者发射一个战斗 Effect（发伤 / AoE / 加牌走 add_card）。 */
 type Emit = (effect: Effect) => void;
 
-export type RelicHooks = {
+type RelicHooks = {
   onCombatStart?: (state: GameState, self: RelicState, emit: Emit) => void;
   onCombatEnd?: (state: GameState, self: RelicState, emit: Emit) => void;
   onTurnStart?: (state: GameState, self: RelicState, emit: Emit) => void;

--- a/apps/spire/src/engine/run/run.ts
+++ b/apps/spire/src/engine/run/run.ts
@@ -146,7 +146,7 @@ export function grantRandomRelic(state: GameState): void {
 }
 
 /** 结算完一个节点后回到地图选路屏。 */
-export function backToMap(state: GameState): void {
+function backToMap(state: GameState): void {
   state.screen = "map";
 }
 

--- a/apps/spire/src/engine/types.ts
+++ b/apps/spire/src/engine/types.ts
@@ -13,7 +13,7 @@ export type CardType = "attack" | "skill" | "power" | "status" | "curse";
 export type CardColor = "red" | "green" | "blue" | "purple" | "colorless" | "status" | "curse";
 
 /** 卡稀有度：奖励按稀有度加权抽取；starter/special 不进普通奖励池。 */
-export type CardRarity = "starter" | "common" | "uncommon" | "rare" | "special";
+type CardRarity = "starter" | "common" | "uncommon" | "rare" | "special";
 
 /** 状态效果标识。切片集合：被动修正器 + 时机触发机制（见 powers/）。 */
 export type PowerId =
@@ -362,7 +362,7 @@ export type CardInstance = {
 export type PowerInstance = { id: PowerId; amount: number };
 
 /** 敌人一次出招。intent 是给玩家看的意图分类；effects 是实际结算。 */
-export type EnemyMove = {
+type EnemyMove = {
   id: string;
   name: string;
   effects: Effect[];
@@ -370,10 +370,10 @@ export type EnemyMove = {
   intent: EnemyIntentKind;
 };
 
-export type EnemyIntentKind = "attack" | "defend" | "buff" | "debuff" | "unknown";
+type EnemyIntentKind = "attack" | "defend" | "buff" | "debuff" | "unknown";
 
 /** 敌人意图选择规则：脚本开局 + 加权随机 + 连续限制（复刻 StS 手感，issue #234 C8）。 */
-export type IntentRule = {
+type IntentRule = {
   /** 按回合序号固定出招（1-based）；用尽后转 weighted。 */
   scripted: string[];
   weighted: { move: string; weight: number; maxInARow: number }[];
@@ -507,7 +507,7 @@ export type CombatState = {
   timeWarpEndTurnPending: boolean;
 };
 
-export type RewardState = {
+type RewardState = {
   /** 三选一（或跳过）的卡奖励，存 defId + 是否升级。 */
   cardChoices: { defId: string; upgraded: boolean }[];
 };
@@ -534,18 +534,10 @@ export type MapGraph = {
   bossNodeId: string;
 };
 
-export type Screen =
-  | "map"
-  | "combat"
-  | "reward"
-  | "rest"
-  | "event"
-  | "shop"
-  | "gameover"
-  | "victory";
+type Screen = "map" | "combat" | "reward" | "rest" | "event" | "shop" | "gameover" | "victory";
 
 /** 当前进行中的事件（? 节点）。 */
-export type EventState = { id: string };
+type EventState = { id: string };
 
 /** 商店一件在售商品。sold 后不可再买。 */
 export type ShopItem =

--- a/apps/spire/src/sim/policy.ts
+++ b/apps/spire/src/sim/policy.ts
@@ -12,7 +12,7 @@ import type { RngState } from "../engine/types.js";
 // 与黄金种子回归（确定性）。策略自带 RNG（与游戏 RNG 分离，不污染对局种子）。
 
 /** 枚举当前态下的合法动作。 */
-export function legalActions(state: GameState): GameAction[] {
+function legalActions(state: GameState): GameAction[] {
   if (state.screen === "combat" && state.combat) {
     const combat = state.combat;
     const target = lowestHpEnemyIndex(state);

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -41,10 +41,6 @@ export function buildApiUrl(path: string): string {
   return `${baseUrl.replace(/\/+$/, "")}${normalizedPath}`;
 }
 
-export function isApiError(error: unknown): error is ApiError {
-  return error instanceof ApiError;
-}
-
 export function getApiErrorMessage(error: unknown): string {
   if (error instanceof ApiError) {
     return error.message;
@@ -196,4 +192,4 @@ function readApiErrorBodyMessage(body: unknown): string | null {
   return null;
 }
 
-export { apiRequest, apiRequestWithSchema, apiPost, apiGetWithSchema, apiPostWithSchema };
+export { apiPost, apiGetWithSchema, apiPostWithSchema };

--- a/apps/web/src/pages/llm-playground/playground-editor.ts
+++ b/apps/web/src/pages/llm-playground/playground-editor.ts
@@ -34,7 +34,7 @@ export type EditorTextPart = {
   text: string;
 };
 
-export type EditorImagePart = {
+type EditorImagePart = {
   id: string;
   type: "image";
   fileName: string;
@@ -51,20 +51,20 @@ export type EditorToolCall = {
   argumentsText: string;
 };
 
-export type EditorUserMessage = {
+type EditorUserMessage = {
   id: string;
   role: "user";
   parts: EditorContentPart[];
 };
 
-export type EditorAssistantMessage = {
+type EditorAssistantMessage = {
   id: string;
   role: "assistant";
   content: string;
   toolCalls: EditorToolCall[];
 };
 
-export type EditorToolMessage = {
+type EditorToolMessage = {
   id: string;
   role: "tool";
   toolCallId: string;
@@ -170,7 +170,7 @@ export function parsePlaygroundPayload({
   };
 }
 
-export function serializeMessages(messages: EditorMessage[]):
+function serializeMessages(messages: EditorMessage[]):
   | {
       success: true;
       data: PlaygroundMessage[];
@@ -307,7 +307,7 @@ export function serializeMessages(messages: EditorMessage[]):
   };
 }
 
-export function serializeTools(tools: EditorTool[]):
+function serializeTools(tools: EditorTool[]):
   | {
       success: true;
       data: LlmToolDefinition[];
@@ -384,7 +384,7 @@ export function serializeTools(tools: EditorTool[]):
   };
 }
 
-export function serializeToolChoice({
+function serializeToolChoice({
   toolChoiceMode,
   selectedToolNameForChoice,
   currentToolNames,
@@ -601,7 +601,7 @@ export function playgroundMessageToEditor(message: PlaygroundMessage): EditorMes
   };
 }
 
-export function playgroundContentPartToEditor(part: PlaygroundContentPart): EditorContentPart {
+function playgroundContentPartToEditor(part: PlaygroundContentPart): EditorContentPart {
   if (part.type === "text") {
     return createTextPart(part.text);
   }
@@ -615,7 +615,7 @@ export function playgroundContentPartToEditor(part: PlaygroundContentPart): Edit
   };
 }
 
-export function normalizeEditorPropertyType(value: unknown): EditorPropertyType {
+function normalizeEditorPropertyType(value: unknown): EditorPropertyType {
   if (
     value === "string" ||
     value === "number" ||

--- a/apps/web/src/pages/llm-playground/playground-import.ts
+++ b/apps/web/src/pages/llm-playground/playground-import.ts
@@ -11,18 +11,18 @@ import {
   type PlaygroundMessage,
 } from "@kagami/agent-api/playground";
 
-export type PlaygroundImportWarningCode =
+type PlaygroundImportWarningCode =
   | "image_omitted"
   | "provider_unavailable"
   | "model_unavailable"
   | "no_provider_available";
 
-export type PlaygroundImportWarning = {
+type PlaygroundImportWarning = {
   code: PlaygroundImportWarningCode;
   message: string;
 };
 
-export type PlaygroundImportSource = {
+type PlaygroundImportSource = {
   itemId: number;
   requestId: string;
   createdAt: string;

--- a/knip.json
+++ b/knip.json
@@ -16,7 +16,17 @@
     "duplicates": "warn"
   },
   "ignoreDependencies": ["@prisma/client", "better-sqlite3", "pm2"],
-  "ignore": ["**/prisma/generated/**", "**/prisma/schema.prisma"],
+  "ignore": [
+    "**/prisma/generated/**",
+    "**/prisma/schema.prisma",
+    "apps/napcat/src/domain/napcat-segment.ts",
+    "apps/web/src/components/ui/**",
+    "**/test/helpers/**",
+    "**/*.test-helper.ts",
+    "apps/agent/src/acl/spire-client.ts",
+    "apps/agent/src/acl/napcat-client.ts",
+    "apps/spire/src/application/state-view.ts"
+  ],
   "workspaces": {
     ".": {
       "entry": ["scripts/*.mjs", "ecosystem.config.cjs"]


### PR DESCRIPTION
## 背景

上一个 PR（#453）引入 knip 分级门禁后，`exports`/`types` 是 warn 级，留下 131 unused export + 78 unused type 的存量。这个 PR 把这 209 项处理干净，让 knip warn 收敛到 0——以后再报 unused export 都值得看。

## 方法：与 Codex 会诊的三分法

核实后发现这 209 项**几乎没有逻辑死代码**，而是三类性质不同的东西，分别处理：

| 类别 | 处理 | 说明 |
|---|---|---|
| **冗余 export**（实现细节 export 了） | **去掉 export** 关键字 | 58 个 tool/app name 常量（`WEATHER_TOOL_NAME` 等，只在本文件 `name = X` 自用）+ 若干文件内自用的 function/type。降为文件内 const/type，不破坏「每个 tool 文件长得一样」的对称约定——把「对称导出」降回「对称实现」。 |
| **有意的完整面** | **knip ignore** | napcat segment 协议 schema（同文件 union 聚合的协议表面）、web shadcn UI 组件族（库惯例全量导出）、agent acl 契约类型别名（`z.infer` 契约驱动，注释明确「改契约两端编译报错」）、spire state-view、test helpers（成套测试脚手架）。这些是有意公开的协议/契约/组件面，不该删也不该去 export。 |
| **真死代码** | **删除** | 跨文件 + 文件内均零引用：spire `REWARD_CARD_POOL`/`UNCOMMON_POTION_POOL`（未接入的池数据）、browser 服务侧 `serializeBrowserError`（agent 侧同名函数是另一处、仍活跃，已核实区分）、web `isApiError`。git 历史保留，需要时 revert 一行。 |

> Codex 的关键论点：**不要用 ignore 掩盖「本来就不该 export 的实现细节」，但要 ignore 那些「确实是协议/组件公共表面」的导出**。这样 knip warn 长期保持高信噪比。

## 验证

- `build` / `typecheck` / `lint` / `format` / `knip` 全绿
- knip warn：**209 → 0**（exit 0，无 error 无 warn）
- 去 export 零风险：typecheck 全过（有跨文件引用即编译失败）
- 删除零误删：`serializeBrowserError` 经核实是 browser 服务侧孤立死函数，agent 侧同名函数在另一模块仍活跃（7 处引用）
- 86 文件改动，绝大多数是去 export 的一行改动

## 影响

纯代码可见性收敛 + 死代码删除，无运行时行为变化，无需部署。