### PR TITLE
fix(persistence): 修 claude_file_cache last_used_at 迁移 SQLite P3018（#433）

### DIFF
--- a/packages/persistence/prisma/migrations/20260705140000_add_claude_file_cache_last_used_at/migration.sql
+++ b/packages/persistence/prisma/migrations/20260705140000_add_claude_file_cache_last_used_at/migration.sql
@@ -1,9 +1,27 @@
--- AlterTable: 新增 last_used_at（GC 判据）。存量行用 CURRENT_TIMESTAMP 回填到迁移时刻（now），
--- 给每条历史行一个 N 天新租约——避免首轮 GC 误删可能还在冷上下文里的历史图。
-ALTER TABLE "claude_file_cache" ADD COLUMN "last_used_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP;
+-- 新增 last_used_at（GC 判据，#433）。SQLite 的 `ALTER TABLE ADD COLUMN` 不允许非常量默认值
+-- （CURRENT_TIMESTAMP 非常量，会 P3018），故走「建新表 → 拷数据 → 改名」的表重建路径——
+-- CREATE TABLE 带 DEFAULT CURRENT_TIMESTAMP 是允许的。存量行 last_used_at 回填到迁移时刻（now），
+-- 给每条历史行一个 N 天新租约，避免首轮 GC 误删可能还在冷上下文里的历史图。
+PRAGMA foreign_keys=OFF;
 
--- DropIndex: created_at 不再被 GC 查询（改按 last_used_at）。
-DROP INDEX "claude_file_cache_created_at_idx";
+CREATE TABLE "new_claude_file_cache" (
+    "content_sha256" TEXT NOT NULL PRIMARY KEY,
+    "file_id" TEXT NOT NULL,
+    "mime_type" TEXT NOT NULL,
+    "size_bytes" INTEGER NOT NULL,
+    "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "last_used_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
 
--- CreateIndex
+INSERT INTO "new_claude_file_cache" ("content_sha256", "file_id", "mime_type", "size_bytes", "created_at", "last_used_at")
+SELECT "content_sha256", "file_id", "mime_type", "size_bytes", "created_at", CURRENT_TIMESTAMP
+FROM "claude_file_cache";
+
+DROP TABLE "claude_file_cache";
+
+ALTER TABLE "new_claude_file_cache" RENAME TO "claude_file_cache";
+
+-- created_at 不再被 GC 查询（改按 last_used_at）：旧表随 DROP 一并消失，只需新建 last_used_at 索引。
 CREATE INDEX "claude_file_cache_last_used_at_idx" ON "claude_file_cache"("last_used_at");
+
+PRAGMA foreign_keys=ON;


### PR DESCRIPTION
## 问题

`pnpm app:deploy` 卡死：第一个待应用迁移 `20260705140000_add_claude_file_cache_last_used_at`（#433 Files API GC，PR #454 已合未部署）在 SQLite 报 **P3018 — Cannot add a column with non-constant default**。

`ALTER TABLE ... ADD COLUMN last_used_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP` —— SQLite 禁止 `ALTER ADD COLUMN` 带非常量默认值（`CURRENT_TIMESTAMP` 非常量）。它排在迁移队列最前，堵死整条部署线（含 #444 的 drop_metric_chart）。

CI 不建库、测不到迁移应用，所以 #454 合并时是绿的、没暴露。

## 修法

改走 SQLite 表重建（建新表 → 拷数据 → 改名）——`CREATE TABLE` 带 `DEFAULT CURRENT_TIMESTAMP` 是允许的，只有 `ALTER ADD COLUMN` 不行。语义完全不变：`last_used_at NOT NULL DEFAULT now`，存量行回填到迁移时刻（新租约）。

## 验证

全新空 DB 从零跑通整条迁移链（`prisma migrate deploy`，All migrations successfully applied）；`claude_file_cache` 结构正确含 `last_used_at` + 索引；从零跑时该迁移正是在「表已存在、无 last_used_at」的生产同形状下执行，增量场景一并验证。

## 上线

合并后主仓库对生产 DB `prisma migrate resolve --rolled-back 20260705140000_add_claude_file_cache_last_used_at`（清掉那条 failed 记录，原 ALTER 被拒、DB 未改动，标记回滚安全），再无参 `pnpm app:deploy` 应用修好的 #433 + #444 两个迁移。