### PR TITLE
feat(spire): onEquip 一次性遗物（古钱币/芒果/李的松饼）

### DIFF
--- a/apps/spire/src/engine/relics/relics.ts
+++ b/apps/spire/src/engine/relics/relics.ts
@@ -878,6 +878,42 @@ const RELIC_LIST: RelicDef[] = [
       },
     },
   },
+  // —— onEquip 一次性遗物批次 ——
+  {
+    id: "old_coin",
+    name: "古钱币",
+    rarity: "rare",
+    description: "获得时，金币 +300。",
+    hooks: {
+      onEquip: state => {
+        state.gold += 300;
+      },
+    },
+  },
+  {
+    id: "mango",
+    name: "芒果",
+    rarity: "rare",
+    description: "获得时，最大生命 +14。",
+    hooks: {
+      onEquip: state => {
+        state.maxHp += 14;
+        state.hp += 14;
+      },
+    },
+  },
+  {
+    id: "lees_waffle",
+    name: "李的松饼",
+    rarity: "rare",
+    description: "获得时，最大生命 +7，并回复全部生命。",
+    hooks: {
+      onEquip: state => {
+        state.maxHp += 7;
+        state.hp = state.maxHp;
+      },
+    },
+  },
 ];
 
 /** 首领遗物池（rarity=boss；含该角色专属 boss 遗物）。打首领时随机掉一件未持有的。 */

--- a/apps/spire/test/relics-batch6.test.ts
+++ b/apps/spire/test/relics-batch6.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { grantRelic } from "../src/engine/relics/relics.js";
+
+// onEquip 一次性遗物。
+describe("onEquip 遗物", () => {
+  it("古钱币：+300 金币", () => {
+    const s = newRun({ runId: "oc", seed: 1, character: "ironclad" });
+    const g = s.gold;
+    grantRelic(s, "old_coin");
+    expect(s.gold).toBe(g + 300);
+  });
+  it("芒果：+14 最大生命", () => {
+    const s = newRun({ runId: "mg", seed: 1, character: "ironclad" });
+    const m = s.maxHp;
+    grantRelic(s, "mango");
+    expect(s.maxHp).toBe(m + 14);
+  });
+  it("李的松饼：+7 最大生命并回满", () => {
+    const s = newRun({ runId: "lw", seed: 1, character: "ironclad" });
+    s.hp = 10;
+    const m = s.maxHp;
+    grantRelic(s, "lees_waffle");
+    expect(s.maxHp).toBe(m + 7);
+    expect(s.hp).toBe(m + 7);
+  });
+});


### PR DESCRIPTION
onEquip 遗物：古钱币(+300金)/芒果(+14最大生命)/李的松饼(+7最大生命并回满)。test/relics-batch6.test.ts（3例）。spire 728 passed；四项检查全绿。