### PR TITLE
feat(spire): 减益免疫遗物 姜/萝卜

### DIFF
--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -2146,7 +2146,7 @@ function applyPowerEffect(
       applyPowerToEnemy(combat.enemies[targetEnemyIndex]!, power, amount);
     }
   } else {
-    applyPowerToPlayer(combat, power, amount);
+    applyPowerToPlayer(state, power, amount);
   }
 }
 
@@ -2170,7 +2170,15 @@ function applyPowerToEnemy(enemy: EnemyState, power: PowerInstance["id"], amount
 }
 
 /** 给玩家加 power；若是减益且玩家有神器，则消耗一层神器抵消（远古药水）。 */
-function applyPowerToPlayer(combat: CombatState, power: PowerInstance["id"], amount: number): void {
+function applyPowerToPlayer(state: GameState, power: PowerInstance["id"], amount: number): void {
+  const combat = state.combat!;
+  // 姜（ginger）免疫虚弱、萝卜（turnip）免疫脆弱。
+  if (amount > 0 && power === "weak" && hasRelic(state, "ginger")) {
+    return;
+  }
+  if (amount > 0 && power === "frail" && hasRelic(state, "turnip")) {
+    return;
+  }
   if (DEBUFF_POWERS.has(power) && amount > 0 && getPower(combat.playerPowers, "artifact") > 0) {
     addPower(combat.playerPowers, "artifact", -1);
     return;

--- a/apps/spire/src/engine/relics/relics.ts
+++ b/apps/spire/src/engine/relics/relics.ts
@@ -914,6 +914,22 @@ const RELIC_LIST: RelicDef[] = [
       },
     },
   },
+  {
+    id: "ginger",
+    name: "姜",
+    // 免疫虚弱在 combat.ts 的 applyPowerToPlayer 里按 hasRelic 处理（不走钩子）。
+    rarity: "rare",
+    description: "你不再受到「虚弱」。",
+    hooks: {},
+  },
+  {
+    id: "turnip",
+    name: "萝卜",
+    // 免疫脆弱在 combat.ts 的 applyPowerToPlayer 里按 hasRelic 处理（不走钩子）。
+    rarity: "rare",
+    description: "你不再受到「脆弱」。",
+    hooks: {},
+  },
 ];
 
 /** 首领遗物池（rarity=boss；含该角色专属 boss 遗物）。打首领时随机掉一件未持有的。 */

--- a/apps/spire/test/relics-ginger-turnip.test.ts
+++ b/apps/spire/test/relics-ginger-turnip.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat, endTurn } from "../src/engine/combat/combat.js";
+import { grantRelic } from "../src/engine/relics/relics.js";
+import { getPower } from "../src/engine/powers/powers.js";
+
+// 姜/萝卜：免疫虚弱/脆弱（敌人施加时被拦截）。
+function setup(relic: string) {
+  const s = newRun({ runId: relic, seed: 1, character: "ironclad" });
+  grantRelic(s, relic);
+  startCombat(s, "the_maw"); // 首招咆哮：虚弱3 + 脆弱3
+  s.hp = 300;
+  s.maxHp = 300;
+  s.combat!.enemies[0]!.currentMove = "maw_roar";
+  s.combat!.hand = [];
+  endTurn(s);
+  return s;
+}
+
+describe("姜：免疫虚弱", () => {
+  it("巨口咆哮后无虚弱、仍吃脆弱", () => {
+    const s = setup("ginger");
+    expect(getPower(s.combat!.playerPowers, "weak")).toBe(0);
+    expect(getPower(s.combat!.playerPowers, "frail")).toBe(3);
+  });
+});
+describe("萝卜：免疫脆弱", () => {
+  it("巨口咆哮后无脆弱、仍吃虚弱", () => {
+    const s = setup("turnip");
+    expect(getPower(s.combat!.playerPowers, "frail")).toBe(0);
+    expect(getPower(s.combat!.playerPowers, "weak")).toBe(3);
+  });
+});


### PR DESCRIPTION
applyPowerToPlayer 透传 state + hasRelic 拦截：姜(免疫虚弱)/萝卜(免疫脆弱)。test/relics-ginger-turnip.test.ts（2例，选择性免疫）。spire 730 passed；四项检查全绿。