### PR TITLE
fix: 修复三处会导致消息静默丢失/会话打挂的稳定性缺陷

### DIFF
--- a/apps/agent/src/acl/napcat-event-subscriber.ts
+++ b/apps/agent/src/acl/napcat-event-subscriber.ts
@@ -42,6 +42,7 @@ export class NapcatEventSubscriber {
   private running = false;
   private controller: AbortController | null = null;
   private lastConsumedSeq = 0;
+  private cursorLoaded = false;
 
   public constructor({
     baseUrl,
@@ -55,13 +56,14 @@ export class NapcatEventSubscriber {
     this.fetchImpl = fetchImpl ?? fetch;
   }
 
-  /** 启动后台订阅循环（不阻塞）。 */
+  /** 启动后台订阅循环（不阻塞）。绝不因启动瞬间的游标读取失败而 reject——游标加载已下沉进
+   * loop 的可重试路径。外层是 `void start()`，若这里 reject 会变成无人处理的 unhandled
+   * rejection，订阅静默死掉、QQ 入站永久断流。 */
   public async start(): Promise<void> {
     if (this.running) {
       return;
     }
     this.running = true;
-    this.lastConsumedSeq = await this.cursorStore.load();
     void this.loop();
   }
 
@@ -74,6 +76,12 @@ export class NapcatEventSubscriber {
     let backoffMs = INITIAL_BACKOFF_MS;
     while (this.running) {
       try {
+        // 首次连接前惰性加载持久游标；读取失败与连接错误一同走退避重试，绝不让「启动瞬间
+        // DB/app_state 读失败」把整个订阅打死。加载成功后置位，后续重连不再重复读游标。
+        if (!this.cursorLoaded) {
+          this.lastConsumedSeq = await this.cursorStore.load();
+          this.cursorLoaded = true;
+        }
         await this.connectOnce();
         // 服务端干净关闭（如 napcat 重启）：立即以最小退避重连。
         backoffMs = INITIAL_BACKOFF_MS;

--- a/apps/agent/src/agent/apps/amap/amap-screen.ts
+++ b/apps/agent/src/agent/apps/amap/amap-screen.ts
@@ -1,3 +1,4 @@
+import { truncateWithEllipsis } from "@kagami/kernel/utils/text";
 import type {
   AmapGeocodeItem,
   AmapPoiResult,
@@ -203,8 +204,7 @@ export function escapeAttr(value: string): string {
 }
 
 function truncate(text: string, maxChars: number): string {
-  if (text.length <= maxChars) {
-    return text;
-  }
-  return `${text.slice(0, maxChars)}\n…（内容过长已截断）`;
+  // 按 Unicode 码点截断，绝不从代理对（emoji）中间切开——半个 emoji 会让上游 400 掉
+  // 整条请求（见「按 UTF-16 长度截断劈开代理对」事故）。
+  return truncateWithEllipsis(text, maxChars, "\n…（内容过长已截断）");
 }

--- a/apps/agent/src/agent/capabilities/ithome/application/ithome.service.ts
+++ b/apps/agent/src/agent/capabilities/ithome/application/ithome.service.ts
@@ -1,3 +1,4 @@
+import { stripLoneSurrogates } from "@kagami/kernel/utils/text";
 import type { IthomeArticleDao, IthomeArticleListItem } from "./ithome-article.dao.js";
 import type { IthomeFeedCursorDao } from "./ithome-feed-cursor.dao.js";
 import type { IthomeClient } from "./ithome-client.js";
@@ -256,15 +257,19 @@ function truncateText(
   text: string;
   truncated: boolean;
 } {
-  if (value.length <= maxChars) {
+  // 按 Unicode 码点截断，绝不从代理对（emoji）中间切开——半个 emoji 会让上游 400 掉
+  // 整条请求（见「引用预览按 UTF-16 长度截断劈开代理对」事故）。先剥落单代理项再按码点判长。
+  const clean = stripLoneSurrogates(value);
+  const codePoints = Array.from(clean);
+  if (codePoints.length <= maxChars) {
     return {
-      text: value,
+      text: clean,
       truncated: false,
     };
   }
 
   return {
-    text: `${value.slice(0, maxChars).trimEnd()}……`,
+    text: `${codePoints.slice(0, maxChars).join("").trimEnd()}……`,
     truncated: true,
   };
 }

--- a/apps/agent/test/agent/ithome.service.test.ts
+++ b/apps/agent/test/agent/ithome.service.test.ts
@@ -109,6 +109,36 @@ describe("IthomeService", () => {
       truncated: false,
     });
   });
+
+  it("should truncate on a code-point boundary so an emoji is never split into a lone surrogate", async () => {
+    // 8 个 emoji（每个 2 个 UTF-16 码元）；截到 5 个码点。裸 .slice(0,5) 会切在第 3 个 emoji 中间
+    // 留下半个代理项，让上游 400 掉整条请求（历史事故）。码点截断必须整段留 5 个完整 emoji。
+    const articleDao = createArticleDao({
+      findById: vi.fn().mockResolvedValueOnce({
+        ...createRecord(1, "emoji 长文"),
+        articleContent: "😀".repeat(8),
+        articleContentStatus: "succeeded",
+      } satisfies IthomeArticleRecord),
+    });
+    const service = new IthomeService({
+      articleDao,
+      cursorDao: createCursorDao(),
+      ithomeClient: createClient(),
+      recentArticleLimit: 8,
+      articleMaxChars: 5,
+    });
+
+    const result = await service.openArticle({ articleId: 1 });
+
+    expect(result?.truncated).toBe(true);
+    expect(result?.content).toBe(`${"😀".repeat(5)}……`);
+    // 无落单代理项：Array.from 按码点拆分，任何半个 emoji 都会破坏这个等式。
+    expect(
+      Array.from(result?.content ?? "").filter(
+        ch => ch.length === 1 && ch >= "\ud800" && ch <= "\udfff",
+      ),
+    ).toEqual([]);
+  });
 });
 
 function createArticleDao(overrides: Partial<IthomeArticleDao> = {}): IthomeArticleDao {

--- a/apps/agent/test/agent/napcat-event-subscriber.test.ts
+++ b/apps/agent/test/agent/napcat-event-subscriber.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  NapcatEventSubscriber,
+  type NapcatCursorStore,
+} from "../../src/acl/napcat-event-subscriber.js";
+import { initTestLoggerRuntime } from "../helpers/logger.js";
+
+/** 永不 resolve 的 fetch：让 connectOnce 在读到响应前一直挂起，便于断言「已发起连接」而不推进后续。 */
+function hangingFetch(): typeof fetch {
+  return vi.fn().mockReturnValue(new Promise(() => {})) as unknown as typeof fetch;
+}
+
+describe("NapcatEventSubscriber — 启动韧性（游标读取失败不静默打死订阅）", () => {
+  beforeEach(() => {
+    initTestLoggerRuntime();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("start() 不因游标读取失败而 reject，且持续退避重试加载游标", async () => {
+    const load = vi.fn<NapcatCursorStore["load"]>().mockRejectedValue(new Error("app_state down"));
+    const cursorStore: NapcatCursorStore = { load, save: vi.fn().mockResolvedValue(undefined) };
+    const fetchImpl = hangingFetch();
+    const subscriber = new NapcatEventSubscriber({
+      baseUrl: "http://napcat",
+      onEvent: vi.fn(),
+      cursorStore,
+      fetch: fetchImpl,
+    });
+
+    // 关键：即使游标读取一定失败，start() 也必须 resolve（外层是 void start()，reject 会成 unhandled）。
+    await expect(subscriber.start()).resolves.toBeUndefined();
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(load).toHaveBeenCalledTimes(1);
+    // 读游标失败 → 未发起 SSE 连接，进入退避重试。
+    expect(fetchImpl).not.toHaveBeenCalled();
+
+    // 推进一个退避周期，游标读取被再次重试（订阅没有死）。
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(load.mock.calls.length).toBeGreaterThanOrEqual(2);
+
+    subscriber.stop();
+  });
+
+  it("游标读取先失败后成功：不丢订阅，用恢复的 seq 作 Last-Event-ID 连接", async () => {
+    const load = vi
+      .fn<NapcatCursorStore["load"]>()
+      .mockRejectedValueOnce(new Error("app_state down"))
+      .mockResolvedValueOnce(42);
+    const cursorStore: NapcatCursorStore = { load, save: vi.fn().mockResolvedValue(undefined) };
+    const fetchImpl = hangingFetch();
+    const subscriber = new NapcatEventSubscriber({
+      baseUrl: "http://napcat",
+      onEvent: vi.fn(),
+      cursorStore,
+      fetch: fetchImpl,
+    });
+
+    await subscriber.start();
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(fetchImpl).not.toHaveBeenCalled();
+
+    // 退避后重试：游标读取成功 → 发起 SSE 连接，且带上恢复出来的 seq。
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(load).toHaveBeenCalledTimes(2);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    const init = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0]![1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Last-Event-ID"]).toBe("42");
+
+    subscriber.stop();
+  });
+});

--- a/apps/napcat/src/application/napcat-gateway.impl.service.ts
+++ b/apps/napcat/src/application/napcat-gateway.impl.service.ts
@@ -932,17 +932,17 @@ export class DefaultNapcatGatewayService implements NapcatGatewayService {
   }
 
   private async findFriendByUserId(userId: string): Promise<NapcatFriendInfo | null> {
-    const hadCachedFriendList = this.friendInfoByUserId !== null;
     const cachedFriend = (await this.loadFriendInfoByUserId()).get(userId);
     if (cachedFriend) {
       return cachedFriend;
     }
 
-    if (!hadCachedFriendList) {
-      return null;
-    }
-
-    return (await this.loadFriendInfoByUserId({ refresh: true })).get(userId) ?? null;
+    // miss 时刷新一次再判定：缓存可能已过期（含冷启动窗口内刚加为好友的用户，其首条私聊
+    // 此前会被误当非好友静默永久丢弃）。走 refreshFriendList 复用单飞锁，让并发 miss 合并成
+    // 一次 get_friend_list、规避「读-改-写好友表」的覆盖竞态；刷新失败在其内部被吞（记日志），
+    // 此处退化为干净地按非好友处理，不把瞬时拉取失败抛成整条消息 failed。
+    await this.refreshFriendList({ force: true, reason: "friend_lookup_miss" });
+    return this.friendInfoByUserId?.get(userId) ?? null;
   }
 
   private async loadFriendInfoByUserId(input?: {
@@ -1007,7 +1007,10 @@ export class DefaultNapcatGatewayService implements NapcatGatewayService {
     this.friendListRefreshTimer = null;
   }
 
-  private async refreshFriendList(input?: { force?: boolean; reason?: "interval" }): Promise<void> {
+  private async refreshFriendList(input?: {
+    force?: boolean;
+    reason?: "interval" | "friend_lookup_miss";
+  }): Promise<void> {
     if (this.friendListRefreshPromise) {
       return await this.friendListRefreshPromise;
     }

--- a/apps/napcat/test/napcat-gateway.impl.service.test.ts
+++ b/apps/napcat/test/napcat-gateway.impl.service.test.ts
@@ -754,6 +754,9 @@ describe("DefaultNapcatGatewayService", () => {
     );
     await waitOneTick();
     emitActionResponse(socket, 0, []);
+    // miss 会触发一次刷新兜底（冷启动新好友救回路径）；刷新后仍空 → 确认非好友。
+    await waitOneTick();
+    emitActionResponse(socket, 1, []);
     await waitOneTick();
     await waitOneTick();
     await waitOneTick();
@@ -774,6 +777,85 @@ describe("DefaultNapcatGatewayService", () => {
         }),
       );
     });
+
+    await gateway.stop();
+  });
+
+  it("should recover a just-added friend's first DM via a refresh when the cold-start list misses", async () => {
+    // 冷启动窗口内刚加为好友：首次 get_friend_list 还没收录该用户（miss），若不刷新兜底，
+    // 这条首私聊会被静默永久丢弃。刷新后好友列表已收录 → 消息必须照常入队。
+    const sockets: FakeWebSocket[] = [];
+    const eventQueue = createAgentEventQueue();
+    const napcatGroupMessageDao = createNapcatGroupMessageDao();
+    const gateway = await DefaultNapcatGatewayService.create({
+      configManager: createConfigManager(),
+      enqueueGroupMessageEvent: eventQueue.enqueue,
+      persistenceWriter: new NapcatEventPersistenceWriter({
+        napcatQqMessageDao: napcatGroupMessageDao,
+      }),
+      imageMessageAnalyzer,
+      qqMessageDao: createNapcatGroupMessageDao(),
+      createWebSocket: () => {
+        const socket = new FakeWebSocket();
+        sockets.push(socket);
+        return socket;
+      },
+    });
+
+    const startPromise = gateway.start();
+    const socket = sockets[0];
+    socket.emitOpen();
+    await startPromise;
+
+    socket.emitMessage(
+      JSON.stringify({
+        post_type: "message",
+        message_type: "private",
+        sub_type: "friend",
+        user_id: 123456,
+        self_id: 654321,
+        message_id: 9988,
+        raw_message: "hi",
+        message: [
+          {
+            type: "text",
+            data: {
+              text: "hi",
+            },
+          },
+        ],
+        time: 1710000000,
+        sender: {
+          nickname: "新好友",
+        },
+      }),
+    );
+    await waitOneTick();
+    // 冷启动首拉：列表还没收录这个刚加的好友。
+    emitActionResponse(socket, 0, []);
+    await waitOneTick();
+    // 刷新兜底：列表已收录 → 认定为好友。
+    emitActionResponse(socket, 1, [
+      {
+        user_id: 123456,
+        nickname: "新好友",
+        remark: null,
+      },
+    ]);
+    await waitOneTick();
+    await waitOneTick();
+
+    expect(eventQueue.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "napcat_private_message",
+        data: expect.objectContaining({
+          userId: "123456",
+          nickname: "新好友",
+          rawMessage: "hi",
+          messageId: 9988,
+        }),
+      }),
+    );
 
     await gateway.stop();
   });


### PR DESCRIPTION
## 背景
对全仓做通用审查（Codex + 三个专项 subagent）后，挑出三处「会造成消息静默丢失或把会话打挂」的真 bug，一并修复。均为内部稳定性修复，不改配置/schema/文档面。

## 三处修复

### 1. ithome/amap 外部文本裸 `.slice()` 截断 → 半个 emoji 打挂主 Agent（高）
外部文本（ithome 文章正文、amap 屏幕）按 UTF-16 `.slice(0, n)` 截断，会从代理对（emoji）中间劈开留下落单代理项，让上游 400 掉整条请求、陷入每轮死循环（同历史事故拓扑）。改用码点安全截断：ithome 用 `stripLoneSurrogates` + `Array.from`，amap 复用 kernel 的 `truncateWithEllipsis`。

### 2. NapCat SSE 订阅启动时游标读失败 → QQ 入站静默死掉（高）
`start()` 在进自恢复 loop 前 `await cursorStore.load()`，外层是 `void start()`，一旦读 app_state 失败就变成 unhandled rejection、订阅静默死、QQ 入站永久断流。把游标加载下沉进可重试 loop（`cursorLoaded` 一次性守卫），`start()` 不再 reject；读失败与连接错误一同走退避重试。

### 3. 冷启动新好友首条私聊被静默永久丢弃（中）
冷启动窗口内刚加为好友的用户，其首条私聊因 `hadCachedFriendList` guard 跳过刷新而被误当非好友丢弃。改为 miss 时经 `refreshFriendList`（复用单飞锁）刷新一次再判定——顺带把并发 miss 合并成一次 `get_friend_list`、规避好友表读-改-写覆盖竞态，并让瞬时拉取失败退化为干净的非好友处理（不再抛成整条消息 failed）。

## 测试
- 新增：ithome emoji 边界截断、SSE 游标读失败退避重试（含 start 不 reject + 恢复后用正确 Last-Event-ID）、冷启动新好友经刷新救回。
- 更新：已有非好友用例补上刷新兜底的第二次 `get_friend_list` 响应。
- 五件套（build/typecheck/lint/format/knip）全过，全量 2017 测试通过。

## 审查
Codex + 3 个 opus subagent 交叉审查。cross-file finder 指出 miss→refresh 绕过单飞锁的并发/竞态隐患，已在本 PR 内经 `refreshFriendList` 路由一并解决（同时消掉 correctness finder 指出的「刷新失败把消息标 failed」的 wart）。

无 DB 迁移，不涉及部署 schema 变更。