### PR TITLE
feat(spire): onShuffle 钩子 + 洗牌遗物（日晷/算盘）

### DIFF
--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -340,6 +340,9 @@ function triggerRelicEnemyKilled(state: GameState): void {
 function triggerRelicUsePotion(state: GameState): void {
   fireRelicsCollectingEmits(state, (hooks, self, emit) => hooks.onUsePotion?.(state, self, emit));
 }
+function triggerRelicShuffle(state: GameState): void {
+  fireRelicsCollectingEmits(state, (hooks, self, emit) => hooks.onShuffle?.(state, self, emit));
+}
 function triggerRelicTurnEnd(state: GameState): void {
   fireRelicsCollectingEmits(state, (hooks, self, emit) => hooks.onTurnEnd?.(state, self, emit));
 }
@@ -446,6 +449,7 @@ function drawCards(state: GameState, count: number): void {
       combat.drawPile = combat.discardPile;
       combat.discardPile = [];
       shuffleInPlace(state.rng, combat.drawPile);
+      triggerRelicShuffle(state); // 洗牌触发型遗物（日晷 +能量、算盘 +格挡）。
     }
     const card = combat.drawPile.pop()!;
     // 烈焰吐息：抽到状态牌或诅咒牌时，对所有敌人造成 = 层数的伤害。

--- a/apps/spire/src/engine/relics/relics.ts
+++ b/apps/spire/src/engine/relics/relics.ts
@@ -40,6 +40,8 @@ type RelicHooks = {
   onEnemyKilled?: (state: GameState, self: RelicState, emit: Emit) => void;
   /** 每当使用一瓶药水后结算（玩具扑翼机回血）。 */
   onUsePotion?: (state: GameState, self: RelicState, emit: Emit) => void;
+  /** 每当抽牌堆被洗牌（弃牌堆洗回抽牌堆）后结算（日晷每 3 次 +能量、算盘 +格挡）。 */
+  onShuffle?: (state: GameState, self: RelicState, emit: Emit) => void;
 };
 
 /** 计数型遗物：自增 self.counter，达到 every 则归零并返回 true（触发效果）。 */
@@ -929,6 +931,29 @@ const RELIC_LIST: RelicDef[] = [
     rarity: "rare",
     description: "你不再受到「脆弱」。",
     hooks: {},
+  },
+  // —— 洗牌触发型遗物 ——
+  {
+    id: "sundial",
+    name: "日晷",
+    rarity: "uncommon",
+    description: "每洗牌 3 次，获得 2 点能量。",
+    hooks: {
+      onShuffle: (_state, self, emit) => {
+        if (tickEvery(self, 3)) {
+          emit({ kind: "gain_energy", amount: 2 });
+        }
+      },
+    },
+  },
+  {
+    id: "the_abacus",
+    name: "算盘",
+    rarity: "uncommon",
+    description: "每当你洗牌，获得 6 点格挡。",
+    hooks: {
+      onShuffle: (_state, _self, emit) => emit({ kind: "gain_block", amount: 6 }),
+    },
   },
 ];
 

--- a/apps/spire/test/relics-shuffle.test.ts
+++ b/apps/spire/test/relics-shuffle.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { getRelicDef } from "../src/engine/relics/relics.js";
+import { newRun } from "../src/engine/engine.js";
+import type { Effect, RelicState } from "../src/engine/types.js";
+
+// 洗牌触发型遗物：日晷（每3次+2能量）、算盘（每次+6格挡）。
+function shuffleEmits(id: string, times: number): Effect[] {
+  const self: RelicState = { id, counter: 0 };
+  const out: Effect[] = [];
+  const s = newRun({ runId: id, seed: 1 });
+  for (let i = 0; i < times; i += 1) getRelicDef(id).hooks.onShuffle?.(s, self, e => out.push(e));
+  return out;
+}
+
+describe("日晷：每 3 次洗牌 +2 能量", () => {
+  it("洗 3 次触发一次", () => {
+    expect(shuffleEmits("sundial", 3)).toEqual([{ kind: "gain_energy", amount: 2 }]);
+  });
+  it("洗 2 次不触发", () => {
+    expect(shuffleEmits("sundial", 2)).toEqual([]);
+  });
+});
+describe("算盘：每次洗牌 +6 格挡", () => {
+  it("洗 2 次 → 两次 +6 格挡", () => {
+    expect(shuffleEmits("the_abacus", 2)).toEqual([
+      { kind: "gain_block", amount: 6 },
+      { kind: "gain_block", amount: 6 },
+    ]);
+  });
+});


### PR DESCRIPTION
新 onShuffle 钩子（drawCards 洗牌处触发）+ 日晷(每3次洗牌+2能量)/算盘(每次+6格挡)。test/relics-shuffle.test.ts（3例）。spire 733 passed；四项检查全绿。