### PR TITLE
feat(spire): 遗物/事件/药水补全批次（20 项）

### DIFF
--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -2944,8 +2944,8 @@ export function endTurn(state: GameState): void {
       retained.push(instance);
     } else if (cardDef.ethereal) {
       combat.exhaustPile.push(instance);
-    } else if (combat.retainHandThisTurn) {
-      // 平衡：本回合保留全部手牌（虚无牌仍按上面消耗）。
+    } else if (combat.retainHandThisTurn || hasRelic(state, "runic_pyramid")) {
+      // 平衡 / 符文金字塔：保留全部手牌（虚无牌仍按上面消耗）。
       retained.push(instance);
     } else if (wellLaidPlans > 0) {
       retained.push(instance);
@@ -3181,9 +3181,10 @@ export function endTurn(state: GameState): void {
     removePower(combat.playerPowers, "no_draw");
   }
   // 壁垒 / 疾影：格挡不在回合开始清空（否则清零）。判定后疾影 -1（只保留一回合）。
+  // 卡钳（calipers）：回合开始只失去 15 点格挡而非全部。
   const blur = getPower(combat.playerPowers, "blur");
   if (getPower(combat.playerPowers, "barricade") === 0 && blur === 0) {
-    combat.playerBlock = 0;
+    combat.playerBlock = hasRelic(state, "calipers") ? Math.max(0, combat.playerBlock - 15) : 0;
   }
   if (blur > 0) {
     addPower(combat.playerPowers, "blur", -1);

--- a/apps/spire/src/engine/relics/relics.ts
+++ b/apps/spire/src/engine/relics/relics.ts
@@ -1008,6 +1008,22 @@ const RELIC_LIST: RelicDef[] = [
       },
     },
   },
+  {
+    id: "calipers",
+    name: "卡钳",
+    // 格挡保留在 combat.ts 的回合开始处按 hasRelic 处理（不走钩子）。
+    rarity: "rare",
+    description: "回合开始时只失去 15 点格挡，而非全部。",
+    hooks: {},
+  },
+  {
+    id: "runic_pyramid",
+    name: "符文金字塔",
+    // 保留手牌在 combat.ts 的 endTurn 保留循环按 hasRelic 处理（不走钩子）。
+    rarity: "boss",
+    description: "回合结束时不再弃掉手牌。",
+    hooks: {},
+  },
 ];
 
 /** 首领遗物池（rarity=boss；含该角色专属 boss 遗物）。打首领时随机掉一件未持有的。 */

--- a/apps/spire/test/relics-retain.test.ts
+++ b/apps/spire/test/relics-retain.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat, endTurn } from "../src/engine/combat/combat.js";
+import { grantRelic } from "../src/engine/relics/relics.js";
+import type { GameState } from "../src/engine/types.js";
+
+function combat(relic: string): GameState {
+  const s = newRun({ runId: relic, seed: 1, character: "ironclad" });
+  grantRelic(s, relic);
+  startCombat(s, "cultist");
+  s.hp = 300;
+  s.maxHp = 300;
+  s.combat!.drawPile = []; // 隔离：下回合不抽新牌
+  return s;
+}
+
+describe("卡钳：回合开始只失 15 格挡", () => {
+  it("40 格挡 → 下回合剩 25", () => {
+    const s = combat("calipers");
+    s.combat!.playerBlock = 40;
+    s.combat!.hand = [];
+    endTurn(s);
+    expect(s.combat!.playerBlock).toBe(25);
+  });
+});
+
+describe("符文金字塔：回合结束保留手牌", () => {
+  it("手牌不进弃牌堆", () => {
+    const s = combat("runic_pyramid");
+    s.combat!.hand = [
+      { uid: s.nextUid++, defId: "strike", upgraded: false },
+      { uid: s.nextUid++, defId: "defend", upgraded: false },
+    ];
+    endTurn(s);
+    expect(s.combat!.hand.some(c => c.defId === "strike")).toBe(true);
+    expect(s.combat!.discardPile.some(c => c.defId === "strike")).toBe(false);
+  });
+});


### PR DESCRIPTION
## 背景
按「每 PR ≥20 项」的新节奏，一次性攒够 20 个新内容项（15 遗物 + 4 事件 + 1 药水），含多个 commit。

## 遗物（+15，新增 onAddCard/onShuffle 之外的多处特判与钩子）
- **保留类**：卡钳（回合始只失 15 格挡）、符文金字塔（回合末保留手牌）
- **onAddCard 钩子**（新）：陶瓷鱼（加牌+9金）、熔岩/剧毒/冰冻蛋（加入攻击/技能/能力牌自动升级）、暗石护符（加诅咒+6最大生命）、御守（抵消 2 张诅咒）
- **引擎特判**：富贵枕头（休息+15回血）、天鹅绒项圈（+1能量/每回合限6张）、魔法花（回血+50%）
- **boss +1 能量**：灵质/诅咒之钥/破损王冠/奴隶主项圈（代价近似/略）

## 事件（+4）
斗技场（下注博彩）、蓝衣妇人（买药水/翻脸）、炼金术士（熔炼换遗物/升牌）、献祭（血/牌换遗物）。

## 药水（+1）
迅捷药水（+5 敏捷）。

## 基建
新增 `addCardToDeck` 统一加牌入口（奖励/商店/事件）触发 onAddCard；新增 `onAddCard` 钩子。修 combat-gold / act2-bosses 首领金币断言（改按掉落日志，避免与首领遗物金币混淆）。

## 测试
新增 test/relics-retain / relics-events-batch 等，覆盖各新机制。spire **748 passed**；根级 build/typecheck/lint/format 全绿。