### PR TITLE
fix(llm): Claude 图片上传按 sha256 单飞，杜绝并发重复上传产生的孤儿文件

### DIFF
--- a/packages/llm-client/src/providers/claude-file-upload.ts
+++ b/packages/llm-client/src/providers/claude-file-upload.ts
@@ -75,6 +75,22 @@ function collectUniqueImageParts(request: LlmChatRequest): Map<string, LlmImageC
   return uniqueImages;
 }
 
+/**
+ * 进程内单飞：把「同一图片内容(sha256)的解析——查缓存命中 / 或上传+落缓存」在整个进程里
+ * 合并成一次，直到它 settle。
+ *
+ * 堵住的核心竞态：跨并发请求（主 Agent + task agent、或连续轮次）带同一张**新**图时，各自
+ * findByHash miss → 各自 uploadClaudeFile 拿到**不同** file_id → save 覆盖后，先落的那个
+ * file_id 成永久孤儿——它从不进 claude_file_cache，LRU GC 的 findIdle 永远扫不到它，只增不减
+ * 撞组织存储配额。把整段解析按 sha256 单飞后，同一内容的并发解析复用同一个在飞 Promise，只
+ * 上传一次。顺带也关掉「A 上传中、B 的 findByHash 恰在 A save 落库前返回 miss」这个更窄的窗口
+ * ——只要该 sha256 有在飞解析，B 直接复用、绝不第二次上传。
+ *
+ * settle 后即从表移除：失败不缓存 → 下轮重试；成功后再来的走 findByHash 命中、不再进单飞。
+ * 进程级 Map，正是我们要的合并粒度（kagami-llm 单进程、所有上传都过这里）。
+ */
+const inFlightResolutions = new Map<string, Promise<string>>();
+
 async function resolveSingleImage(params: {
   part: LlmImageContentPart;
   fileCacheDao: ClaudeFileCacheDao;
@@ -94,48 +110,91 @@ async function resolveSingleImage(params: {
     }
 
     const contentSha256 = createHash("sha256").update(bytes).digest("hex");
-
-    const cached = await params.fileCacheDao.findByHash(contentSha256);
-    if (cached) {
-      // 刷新最近使用时间（GC 判据）。best-effort：DAO 内部已节流成"每图最多 TOUCH_THROTTLE 一次真写"，
-      // 此处再兜一层 try/catch——刷新失败绝不拖垮图片解析 / LLM 主请求（最坏 last_used_at 滞后，
-      // 该图稍早被 GC → 下轮命中 miss 自动重传，自愈）。
-      //
-      // KV 安全的关键（#433）：消息列表持久化的是 base64 原文（见 root-agent-runtime-snapshot），
-      // file_id 只在 wire 层每轮现拼。故一张图只要还在活上下文，每轮 chat 都会重新走到这里被 touch
-      // → last_used_at 恒新（≤TOUCH_THROTTLE）→ 永远到不了 idle cutoff → GC 永不删它 → 不会因重传
-      // 换 file_id 撞前缀漂移。只有连续 idleDays 天零轮次的图才会被回收，那时 provider 侧 KV cache
-      // 早已过期，冷重建重传不额外损失。
-      try {
-        await params.fileCacheDao.touch(contentSha256);
-      } catch (error) {
-        logTouchFailure(error);
-      }
-      return cached.fileId;
-    }
-
-    const fileId = await uploadClaudeFile({
-      bytes,
-      mimeType: params.part.mimeType,
-      filename: params.part.filename,
-      baseUrl: params.baseUrl,
-      anthropicBeta: params.anthropicBeta,
-      accessToken: await params.getAccessToken(),
-      timeoutMs: params.timeoutMs,
-    });
-
-    await params.fileCacheDao.save({
-      contentSha256,
-      fileId,
-      mimeType: params.part.mimeType,
-      sizeBytes: bytes.byteLength,
-    });
-
-    return fileId;
+    return await resolveFileIdSingleFlight({ ...params, bytes, contentSha256 });
   } catch (error) {
     logUploadFailure(error);
     return null;
   }
+}
+
+/** 单飞入口：同一 sha256 已有在飞解析则复用它，否则起一个并登记，settle 后清表。 */
+function resolveFileIdSingleFlight(params: {
+  part: LlmImageContentPart;
+  bytes: Buffer;
+  contentSha256: string;
+  fileCacheDao: ClaudeFileCacheDao;
+  baseUrl: string;
+  anthropicBeta: string;
+  getAccessToken: () => Promise<string>;
+  timeoutMs: number;
+}): Promise<string> {
+  // 原子性铁律：get(miss) → 起 Promise → set 这三步之间**绝不能有 await**。resolveFileIdOnce
+  // 是 async，被调用时同步执行到它第一个 await（findByHash）才让出，返回一个 pending Promise；
+  // 我们在同一同步块内 set。单线程 event loop 下这是不可中断的整体，故并发两个调用不可能都 miss
+  // 都 set。任何人日后在这里插入 await 都会重新打开并发重复上传的窗口。
+  const existing = inFlightResolutions.get(params.contentSha256);
+  if (existing) {
+    return existing;
+  }
+
+  const resolution = resolveFileIdOnce(params);
+  inFlightResolutions.set(params.contentSha256, resolution);
+  // 成功/失败都清表。winner / loser 各自 await 这个 Promise（其 rejection 由它们的 try/catch
+  // 消费），这里再挂一个只做清理的消费者；两个分支都返回 void、绝不重抛，故不产生 unhandled。
+  const cleanup = (): void => {
+    inFlightResolutions.delete(params.contentSha256);
+  };
+  resolution.then(cleanup, cleanup);
+  return resolution;
+}
+
+async function resolveFileIdOnce(params: {
+  part: LlmImageContentPart;
+  bytes: Buffer;
+  contentSha256: string;
+  fileCacheDao: ClaudeFileCacheDao;
+  baseUrl: string;
+  anthropicBeta: string;
+  getAccessToken: () => Promise<string>;
+  timeoutMs: number;
+}): Promise<string> {
+  const cached = await params.fileCacheDao.findByHash(params.contentSha256);
+  if (cached) {
+    // 刷新最近使用时间（GC 判据）。best-effort：DAO 内部已节流成"每图最多 TOUCH_THROTTLE 一次真写"，
+    // 此处再兜一层 try/catch——刷新失败绝不拖垮图片解析 / LLM 主请求（最坏 last_used_at 滞后，
+    // 该图稍早被 GC → 下轮命中 miss 自动重传，自愈）。
+    //
+    // KV 安全的关键（#433）：消息列表持久化的是 base64 原文（见 root-agent-runtime-snapshot），
+    // file_id 只在 wire 层每轮现拼。故一张图只要还在活上下文，每轮 chat 都会重新走到这里被 touch
+    // → last_used_at 恒新（≤TOUCH_THROTTLE）→ 永远到不了 idle cutoff → GC 永不删它 → 不会因重传
+    // 换 file_id 撞前缀漂移。只有连续 idleDays 天零轮次的图才会被回收，那时 provider 侧 KV cache
+    // 早已过期，冷重建重传不额外损失。
+    try {
+      await params.fileCacheDao.touch(params.contentSha256);
+    } catch (error) {
+      logTouchFailure(error);
+    }
+    return cached.fileId;
+  }
+
+  const fileId = await uploadClaudeFile({
+    bytes: params.bytes,
+    mimeType: params.part.mimeType,
+    filename: params.part.filename,
+    baseUrl: params.baseUrl,
+    anthropicBeta: params.anthropicBeta,
+    accessToken: await params.getAccessToken(),
+    timeoutMs: params.timeoutMs,
+  });
+
+  await params.fileCacheDao.save({
+    contentSha256: params.contentSha256,
+    fileId,
+    mimeType: params.part.mimeType,
+    sizeBytes: params.bytes.byteLength,
+  });
+
+  return fileId;
 }
 
 async function uploadClaudeFile(params: {

--- a/packages/llm-client/test/claude-file-upload.test.ts
+++ b/packages/llm-client/test/claude-file-upload.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveClaudeImageFileIds } from "../src/providers/claude-file-upload.js";
+import type {
+  ClaudeFileCacheDao,
+  ClaudeFileCacheRecord,
+  ClaudeFileCacheSaveInput,
+} from "../src/providers/claude-file-cache.dao.js";
+import type { LlmChatRequest } from "../src/types.js";
+
+/** 内存版缓存 DAO：save 落库、findByHash 读库，供跨调用的命中路径验证。 */
+function createFakeDao(): ClaudeFileCacheDao & {
+  findByHash: ReturnType<typeof vi.fn>;
+  save: ReturnType<typeof vi.fn>;
+  touch: ReturnType<typeof vi.fn>;
+} {
+  const store = new Map<string, ClaudeFileCacheRecord>();
+  return {
+    findByHash: vi.fn(async (contentSha256: string) => store.get(contentSha256) ?? null),
+    save: vi.fn(async (input: ClaudeFileCacheSaveInput) => {
+      store.set(input.contentSha256, { ...input, lastUsedAt: new Date() });
+    }),
+    touch: vi.fn(async () => {}),
+    findIdle: vi.fn(async () => []),
+    deleteByContentHashes: vi.fn(async () => 0),
+  };
+}
+
+/** 每次上传返回**不同** file id：若发生重复上传，孤儿（第二个 id）会在断言中暴露。 */
+function stubUploadFetch(): { fetchMock: ReturnType<typeof vi.fn>; uploadCount: () => number } {
+  let count = 0;
+  const fetchMock = vi.fn(async () => {
+    count += 1;
+    return new Response(JSON.stringify({ id: `file_${count}` }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return { fetchMock, uploadCount: () => count };
+}
+
+function imageRequest(base64: string): LlmChatRequest {
+  return {
+    messages: [
+      {
+        role: "user",
+        content: [{ type: "image", content: base64, mimeType: "image/png", filename: "x.png" }],
+      },
+    ],
+    tools: [],
+    toolChoice: "auto",
+  };
+}
+
+function base64Of(text: string): string {
+  return Buffer.from(text).toString("base64");
+}
+
+const baseParams = {
+  baseUrl: "https://api.anthropic.com",
+  anthropicBeta: "files-api-2025-04-14",
+  timeoutMs: 10_000,
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("resolveClaudeImageFileIds — 并发单飞（防孤儿）", () => {
+  it("同一张新图的并发解析只上传一次、只落缓存一次，双方拿到同一个 file_id", async () => {
+    const dao = createFakeDao();
+    const { fetchMock, uploadCount } = stubUploadFetch();
+    const base64 = base64Of("同一张图-并发");
+    const getAccessToken = vi.fn(async () => "token");
+
+    // 两个独立的 resolve 调用（模拟主 Agent + task agent 同轮并发），带同一张新图。
+    const [a, b] = await Promise.all([
+      resolveClaudeImageFileIds({
+        request: imageRequest(base64),
+        fileCacheDao: dao,
+        getAccessToken,
+        ...baseParams,
+      }),
+      resolveClaudeImageFileIds({
+        request: imageRequest(base64),
+        fileCacheDao: dao,
+        getAccessToken,
+        ...baseParams,
+      }),
+    ]);
+
+    // 只上传一次 → 不产生孤儿；只 save 一次 → 缓存无覆盖竞态。
+    expect(uploadCount()).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(dao.save).toHaveBeenCalledTimes(1);
+    // 双方拿到同一个（唯一被落库的）file_id。
+    expect(a.get(base64)).toBe("file_1");
+    expect(b.get(base64)).toBe("file_1");
+  });
+
+  it("首次上传落库后，后续解析走缓存命中、不再上传（单飞 settle 后正确释放）", async () => {
+    const dao = createFakeDao();
+    const { fetchMock } = stubUploadFetch();
+    const base64 = base64Of("先传后命中");
+    const getAccessToken = vi.fn(async () => "token");
+
+    const first = await resolveClaudeImageFileIds({
+      request: imageRequest(base64),
+      fileCacheDao: dao,
+      getAccessToken,
+      ...baseParams,
+    });
+    const second = await resolveClaudeImageFileIds({
+      request: imageRequest(base64),
+      fileCacheDao: dao,
+      getAccessToken,
+      ...baseParams,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1); // 仅首次上传
+    expect(dao.touch).toHaveBeenCalled(); // 第二次走命中刷新
+    expect(first.get(base64)).toBe("file_1");
+    expect(second.get(base64)).toBe("file_1");
+  });
+
+  it("并发同图上传失败：winner 与复用者都回退 base64（不写入 fileId、不落缓存）", async () => {
+    const dao = createFakeDao();
+    // 上传恒失败（HTTP 500）→ uploadClaudeFile 抛错 → 单飞 Promise reject。
+    const fetchMock = vi.fn(async () => new Response("boom", { status: 500 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const base64 = base64Of("并发失败");
+    const getAccessToken = vi.fn(async () => "token");
+
+    const [a, b] = await Promise.all([
+      resolveClaudeImageFileIds({
+        request: imageRequest(base64),
+        fileCacheDao: dao,
+        getAccessToken,
+        ...baseParams,
+      }),
+      resolveClaudeImageFileIds({
+        request: imageRequest(base64),
+        fileCacheDao: dao,
+        getAccessToken,
+        ...baseParams,
+      }),
+    ]);
+
+    // 仍只尝试上传一次（并发合并），失败不落缓存；双方都回退 base64 → map 不含该图。
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(dao.save).not.toHaveBeenCalled();
+    expect(a.has(base64)).toBe(false);
+    expect(b.has(base64)).toBe(false);
+  });
+
+  it("不同图片内容各自上传（单飞按 sha256 隔离，不误合并）", async () => {
+    const dao = createFakeDao();
+    const { fetchMock } = stubUploadFetch();
+    const a64 = base64Of("图A");
+    const b64 = base64Of("图B");
+    const getAccessToken = vi.fn(async () => "token");
+
+    const resolved = await Promise.all([
+      resolveClaudeImageFileIds({
+        request: imageRequest(a64),
+        fileCacheDao: dao,
+        getAccessToken,
+        ...baseParams,
+      }),
+      resolveClaudeImageFileIds({
+        request: imageRequest(b64),
+        fileCacheDao: dao,
+        getAccessToken,
+        ...baseParams,
+      }),
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(resolved[0].get(a64)).not.toBe(resolved[1].get(b64));
+  });
+});


### PR DESCRIPTION
## 背景
全仓审查挑出的一处结构性缺陷:跨并发请求(主 Agent + task agent、或连续轮次)带同一张**新**图时,各自 `findByHash` miss → 各自 `uploadClaudeFile` 拿到**不同** file_id → `save` 覆盖后先落的那个成**永久孤儿**——它从不进 `claude_file_cache`,#433 的 LRU GC(`findIdle` 只扫本地表)永远回收不到,只增不减撞组织存储配额。

## 修复(预防)
把「同一图片内容(sha256)的解析——查缓存命中 / 或上传+落缓存」在**进程内按 sha256 单飞**:并发同内容复用同一个在飞 Promise、只上传一次。顺带也关掉「A 上传中、B 的 `findByHash` 恰在 A `save` 落库前返回 miss」这个更窄的窗口。

- `get(miss)→起 Promise→set` 三步**严格同步**(无 await),单线程 event loop 下原子,并发两个调用不可能都 miss 都 set(已加显式不变量注释)。
- settle 后即清表:失败不缓存 → 下轮重试;成功后再来的走 `findByHash` 命中、不再进单飞。
- kagami-llm 单进程、所有上传都过这里,进程级 Map 正是需要的合并粒度。

## KV 安全
纯 wire 层内部实现,`resolveClaudeImageFileIds` 对外签名/返回(`Map<content, fileId>`)不变,不触消息列表持久化(仍存 base64 原文、file_id 每轮现拼)。同内容→同 file_id 映射因此比改前**更稳定**(并发不再分叉出多个 id),反而增强前缀稳定性。

## 测试
`packages/llm-client/test/claude-file-upload.test.ts` 新增:并发同图只上传一次(不产孤儿)、settle 后走缓存命中、不同 sha256 不误合并、**并发上传失败时 winner 与复用者都回退 base64**。

## 审查
Codex + 3 subagent 全仓审查发现此问题;实现后 2 个 opus finder 交叉审并发正确性(unhandled rejection / cleanup 时序窗口 / set-get 原子性 / 孤儿 / 异常传播 / map 泄漏)+ 跨文件/约定/KV,**无 CONFIRMED 真 bug**;采纳其两条加固建议(同步不变量注释 + 失败回退测试)。

## 范围
本次**只做预防**(不再产新孤儿)。**回收已存在孤儿**——Files API 有 `GET /v1/files` 列表端点,可列远端 ∖ 本地 cache 对账删孤儿——因涉及删远端文件的不可逆动作(需确认账号是否 kagami 专用 + dry-run-first),另开 spec 处理。

无 DB 迁移。