### PR TITLE
feat(spire): 补全批次 恢复（onAddCard钩子+18项遗物/事件/药水）

### DIFF
--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -768,7 +768,11 @@ function applyEffect(
     }
     case "heal": {
       if (actor.side === "player") {
-        state.hp = Math.min(state.maxHp, state.hp + effect.amount);
+        // 魔法花：回复生命时多回复 50%。
+        const amount = hasRelic(state, "magic_flower")
+          ? Math.floor(effect.amount * 1.5)
+          : effect.amount;
+        state.hp = Math.min(state.maxHp, state.hp + amount);
       }
       break;
     }
@@ -2641,6 +2645,10 @@ export function playCard(
   // 常态（诅咒）：手牌里有常态时，本回合最多打出 3 张牌。
   if (combat.cardsPlayedThisTurn >= 3 && combat.hand.some(card => card.defId === "normality")) {
     return { ok: false, reason: "常态诅咒让你本回合无法再打出牌了。" };
+  }
+  // 天鹅绒项圈：本回合最多打出 6 张牌。
+  if (combat.cardsPlayedThisTurn >= 6 && hasRelic(state, "velvet_choker")) {
+    return { ok: false, reason: "天鹅绒项圈让你本回合最多只能打出 6 张牌。" };
   }
   const rawCost = costOf(def, instance.upgraded);
   if (rawCost === null) {

--- a/apps/spire/src/engine/events/events.ts
+++ b/apps/spire/src/engine/events/events.ts
@@ -769,6 +769,86 @@ const EVENT_LIST: EventDef[] = [
       },
     ],
   },
+  // —— 补全批次 5：交易 / 博弈 / 献祭 ——
+  {
+    id: "the_joust",
+    description: "斗技场边一名庄家招呼你下注：押上 50 金，赌你看好的骑士能赢——赢了翻倍还本。",
+    choices: [
+      {
+        label: "押注邪教骑士（稳，回报低）",
+        resultText: "骑士险胜，庄家不情愿地数出你的彩金。",
+        outcomes: [{ kind: "lose_gold", amount: 50 }, { kind: "gain_gold", amount: 100 }],
+      },
+      {
+        label: "押注黑马（险，回报高）",
+        resultText: "黑马一骑绝尘，赔率惊人，你赚得盆满钵满。",
+        outcomes: [{ kind: "lose_gold", amount: 50 }, { kind: "gain_gold", amount: 250 }],
+      },
+      {
+        label: "不赌，走人",
+        resultText: "你摇摇头，挤出了喧闹的人群。",
+        outcomes: [{ kind: "nothing" }],
+      },
+    ],
+  },
+  {
+    id: "the_woman_in_blue",
+    description: "一位蓝衣妇人守着一箱药水，笑意不达眼底：挑一瓶吧，价钱好商量——只是别想空手离开。",
+    choices: [
+      {
+        label: "花 20 金买一瓶",
+        resultText: "你付了钱，妇人递来一瓶还温着的药水。",
+        outcomes: [{ kind: "lose_gold", amount: 20 }, { kind: "gain_potion" }],
+      },
+      {
+        label: "转身就走（她可不高兴）",
+        resultText: "妇人的脸沉了下来，你后背挨了记冷箭般的刺痛。",
+        outcomes: [{ kind: "lose_hp", amount: 6 }],
+      },
+    ],
+  },
+  {
+    id: "augmenter",
+    description: "一名炼金术士守着咕嘟冒泡的坩埚，说能把你不要的东西熔了，重铸成更趁手的家伙。",
+    choices: [
+      {
+        label: "熔炼旧物，换一件遗物",
+        resultText: "坩埚翻涌，浮起一件成色更好的器物。",
+        outcomes: [{ kind: "gain_relic" }],
+      },
+      {
+        label: "让他帮你磨砺兵刃（升 2 张牌）",
+        resultText: "两件家伙在炉火里淬得更利了。",
+        outcomes: [{ kind: "upgrade_random_card", count: 2 }],
+      },
+      {
+        label: "谢绝，离开",
+        resultText: "你不放心把东西交给他，退了出去。",
+        outcomes: [{ kind: "nothing" }],
+      },
+    ],
+  },
+  {
+    id: "an_offering",
+    description: "一方古朴的祭坛静候供奉，石面刻着：以血、以金、或以牌相赠者，必得回响。",
+    choices: [
+      {
+        label: "以血为祭（换一件遗物）",
+        resultText: "血渗入石纹，祭坛回赠一件器物。",
+        outcomes: [{ kind: "lose_hp", amount: 8 }, { kind: "gain_relic" }],
+      },
+      {
+        label: "以牌为祭（涤除一张牌 + 少许金币）",
+        resultText: "一张牌化作灰烬，祭坛拨还你几枚薄酬。",
+        outcomes: [{ kind: "remove_random_card" }, { kind: "gain_gold", amount: 30 }],
+      },
+      {
+        label: "不作供奉，离开",
+        resultText: "你向祭坛欠身，转身离去。",
+        outcomes: [{ kind: "nothing" }],
+      },
+    ],
+  },
 ];
 
 const EVENT_MAP: ReadonlyMap<string, EventDef> = new Map(

--- a/apps/spire/src/engine/events/events.ts
+++ b/apps/spire/src/engine/events/events.ts
@@ -777,12 +777,18 @@ const EVENT_LIST: EventDef[] = [
       {
         label: "押注邪教骑士（稳，回报低）",
         resultText: "骑士险胜，庄家不情愿地数出你的彩金。",
-        outcomes: [{ kind: "lose_gold", amount: 50 }, { kind: "gain_gold", amount: 100 }],
+        outcomes: [
+          { kind: "lose_gold", amount: 50 },
+          { kind: "gain_gold", amount: 100 },
+        ],
       },
       {
         label: "押注黑马（险，回报高）",
         resultText: "黑马一骑绝尘，赔率惊人，你赚得盆满钵满。",
-        outcomes: [{ kind: "lose_gold", amount: 50 }, { kind: "gain_gold", amount: 250 }],
+        outcomes: [
+          { kind: "lose_gold", amount: 50 },
+          { kind: "gain_gold", amount: 250 },
+        ],
       },
       {
         label: "不赌，走人",

--- a/apps/spire/src/engine/potions/potions.ts
+++ b/apps/spire/src/engine/potions/potions.ts
@@ -359,6 +359,15 @@ const POTION_LIST: PotionDef[] = [
     characterLock: "defect",
     effects: [{ kind: "channel_orb_per_slot", orbType: "dark" }],
   },
+  {
+    id: "speed_potion",
+    name: "迅捷药水",
+    description: "获得 5 点敏捷。",
+    rarity: "common",
+    targeted: false,
+    combatOnly: true,
+    effects: [{ kind: "apply_power", power: "dexterity", amount: 5, on: "self" }],
+  },
 ];
 
 const POTION_MAP: ReadonlyMap<string, PotionDef> = new Map(

--- a/apps/spire/src/engine/relics/relics.ts
+++ b/apps/spire/src/engine/relics/relics.ts
@@ -1110,6 +1110,73 @@ const RELIC_LIST: RelicDef[] = [
     description: "战斗中回复生命时，多回复 50%。",
     hooks: {},
   },
+  // —— onAddCard 诅咒联动 ——
+  {
+    id: "darkstone_periapt",
+    name: "暗石护符",
+    rarity: "uncommon",
+    description: "每当你获得一张诅咒牌，最大生命 +6。",
+    hooks: {
+      onAddCard: (state, _self, card) => {
+        if (getCardDef(card.defId).type === "curse") {
+          state.maxHp += 6;
+          state.hp += 6;
+        }
+      },
+    },
+  },
+  {
+    id: "omamori",
+    name: "御守",
+    rarity: "common",
+    description: "抵消接下来加入你牌组的 2 张诅咒牌。",
+    hooks: {
+      onAddCard: (state, self, card) => {
+        if (self.counter < 2 && getCardDef(card.defId).type === "curse") {
+          const idx = state.deck.findIndex(c => c.uid === card.uid);
+          if (idx >= 0) {
+            state.deck.splice(idx, 1);
+            self.counter += 1;
+          }
+        }
+      },
+    },
+  },
+  // —— 更多 +1 能量类 boss 遗物（代价近似/略） ——
+  {
+    id: "ectoplasm",
+    name: "灵质",
+    rarity: "boss",
+    description: "每回合开始时多获得 1 点能量（代价：无法获得金币）。",
+    hooks: { onCombatStart: (_s, _self, emit) => emit({ kind: "change_max_energy", delta: 1 }) },
+  },
+  {
+    id: "cursed_key",
+    name: "诅咒之钥",
+    rarity: "boss",
+    description: "每回合开始时多获得 1 点能量（代价：打开宝箱时会附带一张诅咒）。",
+    hooks: { onCombatStart: (_s, _self, emit) => emit({ kind: "change_max_energy", delta: 1 }) },
+  },
+  {
+    id: "busted_crown",
+    name: "破损王冠",
+    rarity: "boss",
+    description: "每回合开始时多获得 1 点能量（代价：战斗奖励的卡牌选项减少）。",
+    hooks: { onCombatStart: (_s, _self, emit) => emit({ kind: "change_max_energy", delta: 1 }) },
+  },
+  {
+    id: "slavers_collar",
+    name: "奴隶主项圈",
+    rarity: "boss",
+    description: "在精英或首领战中，每回合开始时多获得 1 点能量。",
+    hooks: {
+      onCombatStart: (state, _self, emit) => {
+        if (state.combat?.isBoss) {
+          emit({ kind: "change_max_energy", delta: 1 });
+        }
+      },
+    },
+  },
 ];
 
 /** 首领遗物池（rarity=boss；含该角色专属 boss 遗物）。打首领时随机掉一件未持有的。 */

--- a/apps/spire/src/engine/relics/relics.ts
+++ b/apps/spire/src/engine/relics/relics.ts
@@ -1084,6 +1084,32 @@ const RELIC_LIST: RelicDef[] = [
       },
     },
   },
+  // —— 引擎特判型遗物（不走钩子） ——
+  {
+    id: "regal_pillow",
+    name: "富贵枕头",
+    // 篝火休息回血 +15 在 run.ts 的 rest 分支按 hasRelic 处理。
+    rarity: "common",
+    description: "在篝火休息时，额外回复 15 点生命。",
+    hooks: {},
+  },
+  {
+    id: "velvet_choker",
+    name: "天鹅绒项圈",
+    // 每回合出牌上限 6 在 combat.ts 的 playCard 按 hasRelic 拦截。
+    rarity: "boss",
+    description: "每回合开始时多获得 1 点能量；但每回合最多只能打出 6 张牌。",
+    hooks: { onCombatStart: (_s, _self, emit) => emit({ kind: "change_max_energy", delta: 1 }) },
+  },
+  {
+    id: "magic_flower",
+    name: "魔法花",
+    // 回复量 +50% 在 combat.ts 的 heal 效果按 hasRelic 处理。
+    rarity: "rare",
+    characterLock: "ironclad",
+    description: "战斗中回复生命时，多回复 50%。",
+    hooks: {},
+  },
 ];
 
 /** 首领遗物池（rarity=boss；含该角色专属 boss 遗物）。打首领时随机掉一件未持有的。 */

--- a/apps/spire/src/engine/relics/relics.ts
+++ b/apps/spire/src/engine/relics/relics.ts
@@ -1,4 +1,11 @@
-import type { CardType, CharacterId, Effect, GameState, RelicState } from "../types.js";
+import type {
+  CardInstance,
+  CardType,
+  CharacterId,
+  Effect,
+  GameState,
+  RelicState,
+} from "../types.js";
 import { addPower } from "../powers/powers.js";
 import { getCardDef } from "../cards/cards.js";
 import { POTION_DROP_POOL } from "../potions/potions.js";
@@ -43,6 +50,8 @@ type RelicHooks = {
   onUsePotion?: (state: GameState, self: RelicState, emit: Emit) => void;
   /** 每当抽牌堆被洗牌（弃牌堆洗回抽牌堆）后结算（日晷每 3 次 +能量、算盘 +格挡）。 */
   onShuffle?: (state: GameState, self: RelicState, emit: Emit) => void;
+  /** 每当一张牌被加入牌组（奖励/商店/事件）后结算（陶瓷鱼 +金币、各色蛋升级加入的牌）。局外，无 emit；card 为刚加入的实例。 */
+  onAddCard?: (state: GameState, self: RelicState, card: CardInstance) => void;
 };
 
 /** 计数型遗物：自增 self.counter，达到 every 则归零并返回 true（触发效果）。 */
@@ -1023,6 +1032,57 @@ const RELIC_LIST: RelicDef[] = [
     rarity: "boss",
     description: "回合结束时不再弃掉手牌。",
     hooks: {},
+  },
+  // —— onAddCard 触发型遗物（加牌进牌组时） ——
+  {
+    id: "ceramic_fish",
+    name: "陶瓷鱼",
+    rarity: "common",
+    description: "每当一张牌被加入你的牌组，获得 9 金币。",
+    hooks: {
+      onAddCard: state => {
+        state.gold += 9;
+      },
+    },
+  },
+  {
+    id: "molten_egg",
+    name: "熔岩蛋",
+    rarity: "uncommon",
+    description: "每当一张攻击牌被加入你的牌组，它会自动升级。",
+    hooks: {
+      onAddCard: (_state, _self, card) => {
+        if (!card.upgraded && getCardDef(card.defId).type === "attack") {
+          card.upgraded = true;
+        }
+      },
+    },
+  },
+  {
+    id: "toxic_egg",
+    name: "剧毒蛋",
+    rarity: "uncommon",
+    description: "每当一张技能牌被加入你的牌组，它会自动升级。",
+    hooks: {
+      onAddCard: (_state, _self, card) => {
+        if (!card.upgraded && getCardDef(card.defId).type === "skill") {
+          card.upgraded = true;
+        }
+      },
+    },
+  },
+  {
+    id: "frozen_egg",
+    name: "冰冻蛋",
+    rarity: "uncommon",
+    description: "每当一张能力牌被加入你的牌组，它会自动升级。",
+    hooks: {
+      onAddCard: (_state, _self, card) => {
+        if (!card.upgraded && getCardDef(card.defId).type === "power") {
+          card.upgraded = true;
+        }
+      },
+    },
   },
 ];
 

--- a/apps/spire/src/engine/run/run.ts
+++ b/apps/spire/src/engine/run/run.ts
@@ -150,6 +150,15 @@ function backToMap(state: GameState): void {
   state.screen = "map";
 }
 
+/** 把一张牌加入大牌组，并触发遗物 onAddCard（陶瓷鱼给金币、各色蛋升级加入的牌）。 */
+function addCardToDeck(state: GameState, defId: string, upgraded: boolean): void {
+  const card = { uid: state.nextUid++, defId, upgraded };
+  state.deck.push(card);
+  for (const relic of state.relics) {
+    getRelicDef(relic.id).hooks.onAddCard?.(state, relic, card);
+  }
+}
+
 /** 战斗后按概率掉药水（基础 40%，未掉逐场 +10、掉了 -10；槽满则不掉不调整）。 */
 function rollPotionDrop(state: GameState): void {
   const emptySlot = state.potions.indexOf(null);
@@ -302,7 +311,7 @@ function applyEventOutcome(state: GameState, outcome: EventOutcome): void {
       state.hp += outcome.amount;
       break;
     case "add_card":
-      state.deck.push({ uid: state.nextUid++, defId: outcome.cardId, upgraded: false });
+      addCardToDeck(state, outcome.cardId, false);
       break;
     case "gain_relic":
       grantTreasure(state);
@@ -374,7 +383,7 @@ function buyShopItem(
   state.gold -= item.cost;
   item.sold = true;
   if (item.kind === "card") {
-    state.deck.push({ uid: state.nextUid++, defId: item.defId, upgraded: false });
+    addCardToDeck(state, item.defId, false);
     state.log.push(`你买下了牌「${getCardDef(item.defId).name}」。`);
   } else if (item.kind === "relic") {
     grantRelic(state, item.id);
@@ -403,7 +412,7 @@ export function applyChoose(state: GameState, optionIndex: number): ChooseResult
       state.log.push("你跳过了卡奖励。");
     } else if (optionIndex >= 0 && optionIndex < choices.length) {
       const pick = choices[optionIndex]!;
-      state.deck.push({ uid: state.nextUid++, defId: pick.defId, upgraded: pick.upgraded });
+      addCardToDeck(state, pick.defId, pick.upgraded);
       state.log.push(`你获得了「${getCardDef(pick.defId).name}」。`);
     } else {
       return { ok: false, reason: `选项 ${optionIndex} 无效。` };

--- a/apps/spire/src/engine/run/run.ts
+++ b/apps/spire/src/engine/run/run.ts
@@ -484,7 +484,9 @@ export function applyChoose(state: GameState, optionIndex: number): ChooseResult
 
   if (state.screen === "rest") {
     if (optionIndex === 0) {
-      const heal = Math.floor(state.maxHp * REST_HEAL_RATIO);
+      // 富贵枕头：休息时额外回复 15 点生命。
+      const heal =
+        Math.floor(state.maxHp * REST_HEAL_RATIO) + (hasRelic(state, "regal_pillow") ? 15 : 0);
       state.hp = Math.min(state.maxHp, state.hp + heal);
       state.log.push(`你休息了一会儿，回复了 ${heal} 点生命。`);
     } else {

--- a/apps/spire/test/act2-bosses.test.ts
+++ b/apps/spire/test/act2-bosses.test.ts
@@ -77,7 +77,9 @@ describe("击败第二幕 Boss 掉金币 ~100", () => {
     s.combat!.energy = 9;
     playCard(s, 0, 0);
     expect(s.screen).toBe("victory");
-    expect(s.gold).toBeGreaterThanOrEqual(95);
-    expect(s.gold).toBeLessThanOrEqual(105);
+    // 首领金币掉落固定 95-105；首领遗物奖励可能另加金币（如小屋 +50），故按掉落日志校验。
+    const dropped = Number(s.log.find(l => l.includes("击败首领，获得"))?.match(/(\d+)/)?.[1]);
+    expect(dropped).toBeGreaterThanOrEqual(95);
+    expect(dropped).toBeLessThanOrEqual(105);
   });
 });

--- a/apps/spire/test/relics-events-batch.test.ts
+++ b/apps/spire/test/relics-events-batch.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat, playCard, usePotion } from "../src/engine/combat/combat.js";
+import { grantRelic, getRelicDef } from "../src/engine/relics/relics.js";
+import { getPower } from "../src/engine/powers/powers.js";
+import type { CardInstance, GameState, RelicState } from "../src/engine/types.js";
+
+function card(s: GameState, defId: string): CardInstance {
+  return { uid: s.nextUid++, defId, upgraded: false };
+}
+
+describe("onAddCard 遗物钩子", () => {
+  it("陶瓷鱼：加牌 +9 金币", () => {
+    const s = newRun({ runId: "cf", seed: 1, character: "ironclad" });
+    const self: RelicState = { id: "ceramic_fish", counter: 0 };
+    const g = s.gold;
+    getRelicDef("ceramic_fish").hooks.onAddCard!(s, self, card(s, "strike"));
+    expect(s.gold).toBe(g + 9);
+  });
+  it("熔岩蛋：加入的攻击牌自动升级", () => {
+    const s = newRun({ runId: "me", seed: 1, character: "ironclad" });
+    const self: RelicState = { id: "molten_egg", counter: 0 };
+    const c = card(s, "strike");
+    getRelicDef("molten_egg").hooks.onAddCard!(s, self, c);
+    expect(c.upgraded).toBe(true);
+  });
+  it("暗石护符：加入诅咒牌 +6 最大生命", () => {
+    const s = newRun({ runId: "dp", seed: 1, character: "ironclad" });
+    const self: RelicState = { id: "darkstone_periapt", counter: 0 };
+    const m = s.maxHp;
+    getRelicDef("darkstone_periapt").hooks.onAddCard!(s, self, card(s, "regret"));
+    expect(s.maxHp).toBe(m + 6);
+  });
+  it("御守：抵消 2 张诅咒后失效", () => {
+    const s = newRun({ runId: "om", seed: 1, character: "ironclad" });
+    const self: RelicState = { id: "omamori", counter: 0 };
+    const hook = getRelicDef("omamori").hooks.onAddCard!;
+    for (let i = 0; i < 3; i += 1) {
+      const c = card(s, "injury");
+      s.deck.push(c);
+      hook(s, self, c);
+    }
+    // 前两张被抵消（移除），第三张留下。
+    expect(s.deck.filter(c => c.defId === "injury")).toHaveLength(1);
+    expect(self.counter).toBe(2);
+  });
+});
+
+describe("boss +1 能量遗物", () => {
+  it("灵质：战斗开始能量与上限 +1", () => {
+    const s = newRun({ runId: "ec", seed: 1, character: "ironclad" });
+    grantRelic(s, "ectoplasm");
+    startCombat(s, "cultist");
+    expect(s.combat!.maxEnergy).toBe(4);
+  });
+});
+
+describe("天鹅绒项圈：每回合最多 6 张牌", () => {
+  it("第 7 张被拒", () => {
+    const s = newRun({ runId: "vc", seed: 1, character: "ironclad" });
+    grantRelic(s, "velvet_choker");
+    startCombat(s, "cultist");
+    s.hp = 300;
+    s.combat!.hand = Array.from({ length: 7 }, () => card(s, "defend"));
+    s.combat!.energy = 99;
+    for (let i = 0; i < 6; i += 1) expect(playCard(s, 0, null).ok).toBe(true);
+    expect(playCard(s, 0, null).ok).toBe(false);
+  });
+});
+
+describe("迅捷药水：+5 敏捷", () => {
+  it("使用后敏捷 5", () => {
+    const s = newRun({ runId: "sp", seed: 1, character: "ironclad" });
+    startCombat(s, "cultist");
+    s.potions[0] = "speed_potion";
+    expect(usePotion(s, 0, null).ok).toBe(true);
+    expect(getPower(s.combat!.playerPowers, "dexterity")).toBe(5);
+  });
+});


### PR DESCRIPTION
## 背景
PR #472 因推送与 auto-merge 的竞态，只合并了首个 commit（卡钳/符文金字塔），其余 18 项在推送传播前就被 auto-merge 落下了。本 PR 恢复这些内容（原分支 commit 2-8）。

## 内容（18 项）
- **遗物 onAddCard 钩子**（新 addCardToDeck 统一加牌入口）：陶瓷鱼、熔岩/剧毒/冰冻蛋、暗石护符、御守
- **引擎特判遗物**：富贵枕头（休息+15）、天鹅绒项圈（+1能量/限6张）、魔法花（回血+50%）
- **boss +1能量遗物**：灵质/诅咒之钥/破损王冠/奴隶主项圈
- **事件（+4）**：斗技场/蓝衣妇人/炼金术士/献祭
- **药水（+1）**：迅捷药水（+5敏捷）
- 修 combat-gold / act2-bosses 首领金币断言（按掉落日志，避免与首领遗物金币混淆）

## 测试
spire **748 passed**；根级 build/typecheck/lint/format 全绿。