### PR TITLE
feat(spire): 遗物补全批次（19 遗物 + 濒死复活/卡转化/伤害修正系统）

### DIFF
--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -2287,7 +2287,9 @@ function dealDamageToEnemy(
   if (sharpHide > 0) {
     state.hp = Math.max(0, state.hp - sharpHide);
   }
-  let dmg = computeAttackDamage(base, attackerPowers, enemy.powers, strengthMultiplier);
+  // 纸蛙：玩家攻击易伤敌人时，易伤倍率 1.5 → 1.75。
+  const vulnMult = hasRelic(state, "paper_phrog") ? 1.75 : 1.5;
+  let dmg = computeAttackDamage(base, attackerPowers, enemy.powers, strengthMultiplier, 0.75, vulnMult);
   // 观者姿态对玩家造成伤害的加成：愤怒 ×2，神性 ×3。
   if (state.combat!.playerStance === "wrath") {
     dmg *= 2;
@@ -2380,7 +2382,9 @@ function dealDamageToPlayer(
   attackerIndex?: number,
 ): void {
   const combat = state.combat!;
-  let dmg = computeAttackDamage(base, attackerPowers, combat.playerPowers);
+  // 纸鹤：被你削弱的敌人对你造成的伤害更低，虚弱倍率 0.75 → 0.6。
+  const weakMult = hasRelic(state, "paper_krane") ? 0.6 : 0.75;
+  let dmg = computeAttackDamage(base, attackerPowers, combat.playerPowers, 1, weakMult);
   // 愤怒姿态（观者）：玩家受到的伤害也翻倍。
   if (combat.playerStance === "wrath") {
     dmg *= 2;

--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -2375,6 +2375,33 @@ function triggerModeShift(enemy: EnemyState): void {
   enemy.rotationIndex = 1;
 }
 
+/** 濒死复活：蜥蜴之尾（整局一次，回到半血）或瓶中仙灵药水（消耗，回 30% 生命）。复活返回 true。 */
+function reviveIfPossible(state: GameState): boolean {
+  const lizard = state.relics.find(r => r.id === "lizard_tail" && r.counter === 0);
+  if (lizard) {
+    lizard.counter = 1;
+    state.hp = Math.max(1, Math.floor(state.maxHp / 2));
+    state.log.push("蜥蜴之尾让你起死回生。");
+    return true;
+  }
+  const fairy = state.potions.indexOf("fairy_in_a_bottle");
+  if (fairy >= 0) {
+    state.potions[fairy] = null;
+    state.hp = Math.max(1, Math.floor(state.maxHp * 0.3));
+    state.log.push("瓶中仙灵将你救活。");
+    return true;
+  }
+  return false;
+}
+
+/** 玩家是否真的死亡：生命 >0 则否；否则先尝试复活，复活成功则仍不算死。 */
+function isPlayerDead(state: GameState): boolean {
+  if (state.hp > 0) {
+    return false;
+  }
+  return !reviveIfPossible(state);
+}
+
 function dealDamageToPlayer(
   state: GameState,
   base: number,
@@ -2827,7 +2854,7 @@ export function playCard(
 
   resolveCombatIfEnded(state);
   // 反甲反噬等可能在自己回合内把玩家打死：战斗未结束但玩家已倒下 → 判负。
-  if (state.combat !== null && state.hp <= 0) {
+  if (state.combat !== null && isPlayerDead(state)) {
     state.screen = "gameover";
     state.log.push("你倒下了。");
   }
@@ -2940,7 +2967,7 @@ export function endTurn(state: GameState): void {
           : candidate,
     ),
   );
-  if (state.hp <= 0) {
+  if (isPlayerDead(state)) {
     state.screen = "gameover";
     state.log.push("你倒下了。");
     return;
@@ -3021,7 +3048,7 @@ export function endTurn(state: GameState): void {
   const combust = getPower(combat.playerPowers, "combust");
   if (combust > 0) {
     state.hp = Math.max(0, state.hp - 1);
-    if (state.hp <= 0) {
+    if (isPlayerDead(state)) {
       state.screen = "gameover";
       state.log.push("你倒下了。");
       return;
@@ -3077,7 +3104,7 @@ export function endTurn(state: GameState): void {
   // 回合末在手结算（腐朽自伤 / 疑虑虚弱 / 羞愧脆弱）：在衰减之后，让本回合施加的减益延续到敌人回合。
   if (endOfHandEffects.length > 0) {
     applyEffects(state, endOfHandEffects, { side: "player" }, null);
-    if (state.hp <= 0) {
+    if (isPlayerDead(state)) {
       state.screen = "gameover";
       state.log.push("你倒下了。");
       return;
@@ -3120,7 +3147,7 @@ export function endTurn(state: GameState): void {
       applyEffects(state, move.effects, { side: "enemy", index: i }, null);
       enemy.moveHistory.push(move.id);
     }
-    if (state.hp <= 0) {
+    if (isPlayerDead(state)) {
       state.screen = "gameover";
       state.log.push("你倒下了。");
       return;
@@ -3235,7 +3262,7 @@ export function endTurn(state: GameState): void {
   if (playerPoison > 0) {
     state.hp = Math.max(0, state.hp - playerPoison);
     addPower(combat.playerPowers, "poison", -1);
-    if (state.hp <= 0) {
+    if (isPlayerDead(state)) {
       state.screen = "gameover";
       state.log.push("你中毒身亡。");
       return;
@@ -3245,7 +3272,7 @@ export function endTurn(state: GameState): void {
   const brutality = getPower(combat.playerPowers, "brutality");
   if (brutality > 0) {
     state.hp = Math.max(0, state.hp - brutality);
-    if (state.hp <= 0) {
+    if (isPlayerDead(state)) {
       state.screen = "gameover";
       state.log.push("你倒下了。");
       return;

--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -2293,7 +2293,14 @@ function dealDamageToEnemy(
   }
   // 纸蛙：玩家攻击易伤敌人时，易伤倍率 1.5 → 1.75。
   const vulnMult = hasRelic(state, "paper_phrog") ? 1.75 : 1.5;
-  let dmg = computeAttackDamage(base, attackerPowers, enemy.powers, strengthMultiplier, 0.75, vulnMult);
+  let dmg = computeAttackDamage(
+    base,
+    attackerPowers,
+    enemy.powers,
+    strengthMultiplier,
+    0.75,
+    vulnMult,
+  );
   // 观者姿态对玩家造成伤害的加成：愤怒 ×2，神性 ×3。
   if (state.combat!.playerStance === "wrath") {
     dmg *= 2;

--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -2411,7 +2411,9 @@ function dealDamageToPlayer(
   const combat = state.combat!;
   // 纸鹤：被你削弱的敌人对你造成的伤害更低，虚弱倍率 0.75 → 0.6。
   const weakMult = hasRelic(state, "paper_krane") ? 0.6 : 0.75;
-  let dmg = computeAttackDamage(base, attackerPowers, combat.playerPowers, 1, weakMult);
+  // 奇异蘑菇：你受到的易伤伤害更低，易伤倍率 1.5 → 1.25。
+  const pVulnMult = hasRelic(state, "odd_mushroom") ? 1.25 : 1.5;
+  let dmg = computeAttackDamage(base, attackerPowers, combat.playerPowers, 1, weakMult, pVulnMult);
   // 愤怒姿态（观者）：玩家受到的伤害也翻倍。
   if (combat.playerStance === "wrath") {
     dmg *= 2;

--- a/apps/spire/src/engine/combat/combat.ts
+++ b/apps/spire/src/engine/combat/combat.ts
@@ -2161,6 +2161,10 @@ function applyPowerEffect(
   if (actor.side === "player") {
     if (targetEnemyIndex !== null) {
       applyPowerToEnemy(combat.enemies[targetEnemyIndex]!, power, amount);
+      // 冠军腰带：对敌施加易伤时，也施加 1 层虚弱。
+      if (power === "vulnerable" && amount > 0 && hasRelic(state, "champion_belt")) {
+        applyPowerToEnemy(combat.enemies[targetEnemyIndex]!, "weak", 1);
+      }
     }
   } else {
     applyPowerToPlayer(state, power, amount);
@@ -2937,6 +2941,10 @@ export function usePotion(
 
   state.potions[slotIndex] = null; // 药水一次性，先清槽再结算。
   applyEffects(state, def.effects, { side: "player" }, resolvedTarget);
+  // 神圣树皮：药水效果翻倍（再结算一次）。
+  if (hasRelic(state, "sacred_bark")) {
+    applyEffects(state, def.effects, { side: "player" }, resolvedTarget);
+  }
   state.log.push(`你使用了「${def.name}」。`);
   if (combat) {
     triggerRelicUsePotion(state); // 用药水触发型遗物（玩具扑翼机回血）。

--- a/apps/spire/src/engine/potions/potions.ts
+++ b/apps/spire/src/engine/potions/potions.ts
@@ -368,6 +368,16 @@ const POTION_LIST: PotionDef[] = [
     combatOnly: true,
     effects: [{ kind: "apply_power", power: "dexterity", amount: 5, on: "self" }],
   },
+  {
+    id: "fairy_in_a_bottle",
+    name: "瓶中仙灵",
+    // 濒死时自动消耗、回 30% 生命（在 combat.ts 的 reviveIfPossible 处理）；手动使用无效果。
+    description: "当你在战斗中濒死时，自动消耗它并回复 30% 最大生命。",
+    rarity: "rare",
+    targeted: false,
+    combatOnly: true,
+    effects: [],
+  },
 ];
 
 const POTION_MAP: ReadonlyMap<string, PotionDef> = new Map(

--- a/apps/spire/src/engine/powers/powers.ts
+++ b/apps/spire/src/engine/powers/powers.ts
@@ -90,16 +90,19 @@ export function computeAttackDamage(
   attackerPowers: readonly PowerInstance[],
   defenderPowers: readonly PowerInstance[],
   strengthMultiplier = 1,
+  // weakMult / vulnMult 可被遗物调整（纸蛙让易伤 ×1.75；纸鹤让虚弱者伤害更低 ×0.6）。
+  weakMult = 0.75,
+  vulnMult = 1.5,
 ): number {
   let amount = base + getPower(attackerPowers, "strength") * strengthMultiplier;
   if (amount < 0) {
     amount = 0;
   }
   if (getPower(attackerPowers, "weak") > 0) {
-    amount = Math.floor(amount * 0.75);
+    amount = Math.floor(amount * weakMult);
   }
   if (getPower(defenderPowers, "vulnerable") > 0) {
-    amount = Math.floor(amount * 1.5);
+    amount = Math.floor(amount * vulnMult);
   }
   return amount;
 }

--- a/apps/spire/src/engine/relics/relics.ts
+++ b/apps/spire/src/engine/relics/relics.ts
@@ -1249,6 +1249,63 @@ const RELIC_LIST: RelicDef[] = [
     description: "当你在战斗中濒死时，回复至一半生命（整局限一次）。",
     hooks: {},
   },
+  // —— 更多遗物批次 ——
+  {
+    id: "pear",
+    name: "梨",
+    rarity: "common",
+    description: "获得时，最大生命 +10。",
+    hooks: {
+      onEquip: state => {
+        state.maxHp += 10;
+        state.hp += 10;
+      },
+    },
+  },
+  {
+    id: "odd_mushroom",
+    name: "奇异蘑菇",
+    // 易伤减伤在 combat.ts 的 dealDamageToPlayer 按 hasRelic 处理。
+    rarity: "uncommon",
+    description: "你受到的易伤伤害加成从 50% 降为 25%。",
+    hooks: {},
+  },
+  {
+    id: "gremlin_visage",
+    name: "地精面容",
+    rarity: "common",
+    description: "每场战斗开始时，你获得 1 层虚弱。",
+    hooks: {
+      onCombatStart: (_s, _self, emit) =>
+        emit({ kind: "apply_power", power: "weak", amount: 1, on: "self" }),
+    },
+  },
+  {
+    id: "cultist_headpiece",
+    name: "邪教头饰",
+    rarity: "common",
+    description: "一件散发着不祥气息的头饰，似乎并没有什么实际用处。",
+    hooks: {},
+  },
+  {
+    id: "mutagenic_strength",
+    name: "诱变力量",
+    rarity: "rare",
+    description: "每场战斗开始时获得 3 点力量，但在本回合结束时失去。",
+    hooks: {
+      onCombatStart: (_s, _self, emit) => emit({ kind: "apply_strength_temp", amount: 3 }),
+    },
+  },
+  {
+    id: "ring_of_the_serpent",
+    name: "蛇之指环",
+    rarity: "rare",
+    characterLock: "silent",
+    description: "每个回合开始时，多抽 1 张牌。",
+    hooks: {
+      onTurnStart: (_s, _self, emit) => emit({ kind: "draw", amount: 1 }),
+    },
+  },
 ];
 
 /** 首领遗物池（rarity=boss；含该角色专属 boss 遗物）。打首领时随机掉一件未持有的。 */

--- a/apps/spire/src/engine/relics/relics.ts
+++ b/apps/spire/src/engine/relics/relics.ts
@@ -1306,6 +1306,69 @@ const RELIC_LIST: RelicDef[] = [
       onTurnStart: (_s, _self, emit) => emit({ kind: "draw", amount: 1 }),
     },
   },
+  // —— 引擎特判 / 房间钩子 遗物（不走既有钩子） ——
+  {
+    id: "sacred_bark",
+    name: "神圣树皮",
+    // 药水效果翻倍在 combat.ts 的 usePotion 按 hasRelic 处理。
+    rarity: "boss",
+    description: "你使用药水的效果翻倍。",
+    hooks: {},
+  },
+  {
+    id: "champion_belt",
+    name: "冠军腰带",
+    // 「施加易伤时也施加虚弱」在 combat.ts 的对敌施加易伤处按 hasRelic 处理。
+    rarity: "uncommon",
+    characterLock: "ironclad",
+    description: "当你对敌人施加易伤时，也对其施加 1 层虚弱。",
+    hooks: {},
+  },
+  {
+    id: "maw_bank",
+    name: "巨口银行",
+    // 进入非商店房间时 +12 金币，在 run.ts 的 resolveNode 按 hasRelic 处理。
+    rarity: "common",
+    description: "每当你进入一个非商店房间，获得 12 金币。",
+    hooks: {},
+  },
+  {
+    id: "meal_ticket",
+    name: "餐券",
+    // 进入商店时回 15 血，在 run.ts 的 resolveNode 商店分支按 hasRelic 处理。
+    rarity: "common",
+    description: "每当你进入一间商店，回复 15 点生命。",
+    hooks: {},
+  },
+  {
+    id: "eternal_feather",
+    name: "永恒羽毛",
+    // 篝火休息时按牌组张数回血，在 run.ts 的 rest 分支按 hasRelic 处理。
+    rarity: "uncommon",
+    description: "每当你在篝火休息，每有 5 张牌就额外回复 3 点生命。",
+    hooks: {},
+  },
+  {
+    id: "spirit_poop",
+    name: "精魂便便",
+    rarity: "common",
+    description: "呃……闻起来可不太妙。它似乎没有任何实际效果。",
+    hooks: {},
+  },
+  {
+    id: "circlet",
+    name: "头环",
+    rarity: "common",
+    description: "当再也没有别的遗物可拿时，你得到了它。纯属收藏。",
+    hooks: {},
+  },
+  {
+    id: "red_circlet",
+    name: "赤红头环",
+    rarity: "common",
+    description: "当再也没有别的遗物可拿、连头环都齐了时，你得到了它。",
+    hooks: {},
+  },
 ];
 
 /** 首领遗物池（rarity=boss；含该角色专属 boss 遗物）。打首领时随机掉一件未持有的。 */

--- a/apps/spire/src/engine/relics/relics.ts
+++ b/apps/spire/src/engine/relics/relics.ts
@@ -1241,6 +1241,14 @@ const RELIC_LIST: RelicDef[] = [
       },
     },
   },
+  {
+    id: "lizard_tail",
+    name: "蜥蜴之尾",
+    // 濒死复活在 combat.ts 的 isPlayerDead/reviveIfPossible 按 hasRelic 处理（counter 记一次性用尽）。
+    rarity: "rare",
+    description: "当你在战斗中濒死时，回复至一半生命（整局限一次）。",
+    hooks: {},
+  },
 ];
 
 /** 首领遗物池（rarity=boss；含该角色专属 boss 遗物）。打首领时随机掉一件未持有的。 */

--- a/apps/spire/src/engine/relics/relics.ts
+++ b/apps/spire/src/engine/relics/relics.ts
@@ -7,9 +7,24 @@ import type {
   RelicState,
 } from "../types.js";
 import { addPower } from "../powers/powers.js";
-import { getCardDef } from "../cards/cards.js";
+import { getCardDef, rewardCardPoolOf } from "../cards/cards.js";
 import { POTION_DROP_POOL } from "../potions/potions.js";
 import { nextInt } from "../rng.js";
+
+// 角色颜色（避免引入 characters 造成循环）；转化卡从该色奖励池里随机取。
+const CHARACTER_COLOR: Record<CharacterId, "red" | "green" | "blue" | "purple"> = {
+  ironclad: "red",
+  silent: "green",
+  defect: "blue",
+  watcher: "purple",
+};
+
+/** 把一张牌实例转化为本角色奖励池里的一张随机牌（潘多拉魔盒/星盘）。 */
+function transformCardInstance(state: GameState, card: CardInstance): void {
+  const pool = rewardCardPoolOf(CHARACTER_COLOR[state.character]);
+  card.defId = pool[nextInt(state.rng, pool.length)]!;
+  card.upgraded = false;
+}
 
 // === 遗物系统 ===
 //
@@ -1191,6 +1206,40 @@ const RELIC_LIST: RelicDef[] = [
     rarity: "uncommon",
     description: "被你削弱（虚弱）的敌人对你造成的伤害降到 0.6 倍（原为 0.75 倍）。",
     hooks: {},
+  },
+  // —— 转化牌组的 onEquip 遗物 ——
+  {
+    id: "pandoras_box",
+    name: "潘多拉魔盒",
+    rarity: "boss",
+    description: "获得时，将你所有的打击与防御转化为随机牌。",
+    hooks: {
+      onEquip: state => {
+        for (const card of state.deck) {
+          if (card.defId === "strike" || card.defId === "defend") {
+            transformCardInstance(state, card);
+          }
+        }
+      },
+    },
+  },
+  {
+    id: "astrolabe",
+    name: "星盘",
+    rarity: "boss",
+    description: "获得时，转化并升级 3 张随机牌。",
+    hooks: {
+      onEquip: state => {
+        const pool = state.deck.slice();
+        for (let n = 0; n < 3 && pool.length > 0; n += 1) {
+          const idx = nextInt(state.rng, pool.length);
+          const card = pool[idx]!;
+          pool.splice(idx, 1);
+          transformCardInstance(state, card);
+          card.upgraded = true;
+        }
+      },
+    },
   },
 ];
 

--- a/apps/spire/src/engine/relics/relics.ts
+++ b/apps/spire/src/engine/relics/relics.ts
@@ -1177,6 +1177,21 @@ const RELIC_LIST: RelicDef[] = [
       },
     },
   },
+  // —— 伤害修正型遗物（在 combat.ts 的伤害结算按 hasRelic 处理，不走钩子） ——
+  {
+    id: "paper_phrog",
+    name: "纸蛙",
+    rarity: "uncommon",
+    description: "易伤的敌人受到你的攻击伤害提升到 1.75 倍（原为 1.5 倍）。",
+    hooks: {},
+  },
+  {
+    id: "paper_krane",
+    name: "纸鹤",
+    rarity: "uncommon",
+    description: "被你削弱（虚弱）的敌人对你造成的伤害降到 0.6 倍（原为 0.75 倍）。",
+    hooks: {},
+  },
 ];
 
 /** 首领遗物池（rarity=boss；含该角色专属 boss 遗物）。打首领时随机掉一件未持有的。 */

--- a/apps/spire/src/engine/run/run.ts
+++ b/apps/spire/src/engine/run/run.ts
@@ -79,6 +79,10 @@ export function advanceToNextAct(state: GameState): void {
 /** 进入一个地图节点：按类型路由。战斗/Boss 起战斗；篝火切 rest 屏；宝箱即时给金币后回地图。 */
 function resolveNode(state: GameState, node: MapNode): void {
   state.currentNodeId = node.id;
+  // 巨口银行：进入非商店房间时 +12 金币。
+  if (node.type !== "shop" && hasRelic(state, "maw_bank")) {
+    state.gold += 12;
+  }
   switch (node.type) {
     case "combat": {
       // 前若干场抽 weak 池、其余抽 strong 池（复刻 StS Act1 战斗节奏）。
@@ -110,6 +114,10 @@ function resolveNode(state: GameState, node: MapNode): void {
       return;
     }
     case "shop": {
+      // 餐券：进入商店时回复 15 点生命。
+      if (hasRelic(state, "meal_ticket")) {
+        state.hp = Math.min(state.maxHp, state.hp + 15);
+      }
       generateShop(state);
       state.log.push("你走进一间商店。");
       return;
@@ -484,9 +492,11 @@ export function applyChoose(state: GameState, optionIndex: number): ChooseResult
 
   if (state.screen === "rest") {
     if (optionIndex === 0) {
-      // 富贵枕头：休息时额外回复 15 点生命。
+      // 富贵枕头：休息时额外回复 15 点生命；永恒羽毛：每 5 张牌额外回 3。
       const heal =
-        Math.floor(state.maxHp * REST_HEAL_RATIO) + (hasRelic(state, "regal_pillow") ? 15 : 0);
+        Math.floor(state.maxHp * REST_HEAL_RATIO) +
+        (hasRelic(state, "regal_pillow") ? 15 : 0) +
+        (hasRelic(state, "eternal_feather") ? Math.floor(state.deck.length / 5) * 3 : 0);
       state.hp = Math.min(state.maxHp, state.hp + heal);
       state.log.push(`你休息了一会儿，回复了 ${heal} 点生命。`);
     } else {

--- a/apps/spire/test/relics-batch-final.test.ts
+++ b/apps/spire/test/relics-batch-final.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat, usePotion } from "../src/engine/combat/combat.js";
+import { grantRelic } from "../src/engine/relics/relics.js";
+import { getPower } from "../src/engine/powers/powers.js";
+import type { GameState } from "../src/engine/types.js";
+
+function combat(relic: string, character = "ironclad"): GameState {
+  const s = newRun({ runId: relic, seed: 1, character: character as GameState["character"] });
+  grantRelic(s, relic);
+  startCombat(s, "cultist");
+  s.hp = 300;
+  s.maxHp = 300;
+  return s;
+}
+
+describe("梨：+10 最大生命", () => {
+  it("获得时 maxHp +10", () => {
+    const s = newRun({ runId: "pear", seed: 1, character: "ironclad" });
+    const m = s.maxHp;
+    grantRelic(s, "pear");
+    expect(s.maxHp).toBe(m + 10);
+  });
+});
+
+describe("冠军腰带：施加易伤时也施加虚弱", () => {
+  it("恐惧药水施加易伤 → 敌人也得虚弱", () => {
+    const s = combat("champion_belt");
+    s.potions[0] = "fear_potion";
+    expect(usePotion(s, 0, 0).ok).toBe(true);
+    const e = s.combat!.enemies[0]!;
+    expect(getPower(e.powers, "vulnerable")).toBe(3);
+    expect(getPower(e.powers, "weak")).toBe(1);
+  });
+});
+
+describe("神圣树皮：药水效果翻倍", () => {
+  it("格挡药水 12 → 24", () => {
+    const s = combat("sacred_bark");
+    s.combat!.playerBlock = 0;
+    s.potions[0] = "block_potion";
+    expect(usePotion(s, 0, null).ok).toBe(true);
+    expect(s.combat!.playerBlock).toBe(24);
+  });
+});
+
+describe("战斗开始类", () => {
+  it("地精面容：开局自带 1 虚弱", () => {
+    const s = combat("gremlin_visage");
+    expect(getPower(s.combat!.playerPowers, "weak")).toBe(1);
+  });
+  it("诱变力量：开局 +3 力量", () => {
+    const s = combat("mutagenic_strength");
+    expect(getPower(s.combat!.playerPowers, "strength")).toBe(3);
+  });
+});

--- a/apps/spire/test/revive.test.ts
+++ b/apps/spire/test/revive.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { newRun } from "../src/engine/engine.js";
+import { startCombat, endTurn } from "../src/engine/combat/combat.js";
+import { grantRelic } from "../src/engine/relics/relics.js";
+import type { GameState } from "../src/engine/types.js";
+
+function lethal(s: GameState) {
+  // 敌人暗袭必致死：设玩家 1 血、无格挡，敌人攻击。
+  s.hp = 1;
+  s.combat!.playerBlock = 0;
+  s.combat!.enemies[0]!.currentMove = "dark_strike";
+  s.combat!.hand = [];
+  endTurn(s);
+}
+
+describe("蜥蜴之尾：濒死回半血", () => {
+  it("致死伤害后复活到半血、战斗继续", () => {
+    const s = newRun({ runId: "lt", seed: 1, character: "ironclad" });
+    grantRelic(s, "lizard_tail");
+    startCombat(s, "cultist");
+    s.maxHp = 80;
+    lethal(s);
+    expect(s.screen).not.toBe("gameover");
+    expect(s.hp).toBe(40);
+    expect(s.relics.find(r => r.id === "lizard_tail")!.counter).toBe(1);
+  });
+});
+
+describe("瓶中仙灵：濒死消耗、回 30%", () => {
+  it("致死后消耗药水复活", () => {
+    const s = newRun({ runId: "fb", seed: 1, character: "ironclad" });
+    startCombat(s, "cultist");
+    s.maxHp = 100;
+    s.potions[0] = "fairy_in_a_bottle";
+    lethal(s);
+    expect(s.screen).not.toBe("gameover");
+    expect(s.hp).toBe(30);
+    expect(s.potions[0]).toBeNull();
+  });
+});


### PR DESCRIPTION
## 内容（20 项：19 遗物 + 1 药水）
新增多套引擎系统 + 一批遗物：

**新系统**
- 伤害修正参数（computeAttackDamage 加 weak/vuln 倍率）→ 纸蛙/纸鹤/奇异蘑菇
- 卡转化系统（transformCardInstance）→ 潘多拉魔盒/星盘
- 濒死复活（isPlayerDead/reviveIfPossible 包住 7 处 gameover）→ 蜥蜴之尾 + 瓶中仙灵药水

**遗物（19）**
纸蛙/纸鹤/奇异蘑菇（伤害修正）· 潘多拉魔盒/星盘（转化）· 蜥蜴之尾（复活）· 梨（+10最大生命）· 地精面容（开局虚弱）· 诱变力量（开局临时+3力量）· 蛇之指环（每回合多抽1）· 神圣树皮（药水翻倍）· 冠军腰带（易伤附带虚弱）· 巨口银行（进非商店房间+12金）· 餐券（进商店回15）· 永恒羽毛（休息按牌组回血）· 邪教头饰/精魂便便/头环/赤红头环（收藏/flavor）

**药水（1）**：瓶中仙灵（濒死自动复活回30%）

## 测试
新增 test/revive / relics-batch-final 等；spire **755 passed**；根级 build/typecheck/lint/format 全绿。

（这是「向原版看齐」系列的又一批；遗物现约 109/176，其余多为需 shop/reward/chest 时点、X费、姿态/球等角色专属机制的关卡，留待后续。）