### PR TITLE
feat(metric): 查询能力 ne/in 过滤 + 百分位 + top-N SQL 下推（#475 P2）

### DIFF
--- a/apps/metric/src/metric/application/metric-chart.impl.service.ts
+++ b/apps/metric/src/metric/application/metric-chart.impl.service.ts
@@ -15,8 +15,6 @@ type DefaultMetricChartServiceDeps = {
 
 const UNGROUPED_SERIES_KEY = "__ungrouped__";
 const DEFAULT_SINGLE_SERIES_KEY = "__default__";
-/** 分组查询最多返回的 series 数：按总量取前 N，其余丢弃，防高基数 groupByTag 撑爆响应。 */
-const MAX_SERIES = 20;
 
 export class DefaultMetricChartService implements MetricChartService {
   private readonly metricDao: MetricDao;
@@ -130,7 +128,8 @@ function buildSeries(params: {
     rowsBySeriesKey.get(key)?.set(bucketStartMs, row.value);
   }
 
-  const keptKeys = selectTopSeriesKeys(rowsBySeriesKey);
+  // series top-N 已在 DAO 的 SQL 层下推截断（≤MAX_SERIES），此处按 DAO 返回顺序原样成线。
+  const keptKeys = [...rowsBySeriesKey.keys()];
 
   return keptKeys.map(key => {
     const pointsByBucket = rowsBySeriesKey.get(key) ?? new Map<number, number | null>();
@@ -143,31 +142,6 @@ function buildSeries(params: {
       })),
     };
   });
-}
-
-/** 分组结果按各 series 总量取前 MAX_SERIES；未超限则原样返回（保持插入 / 桶排序）。 */
-function selectTopSeriesKeys(rowsBySeriesKey: Map<string, Map<number, number | null>>): string[] {
-  const keys = [...rowsBySeriesKey.keys()];
-  if (keys.length <= MAX_SERIES) {
-    return keys;
-  }
-
-  // 按各 series 的「绝对量之和」排序取前 N。用 Math.abs：min/avg 等聚合下的负值 series 也按
-  // 量级排序（而非把负值排到最后误删）；跳过非有限值防脏数据污染 comparator。
-  const magnitudeByKey = new Map<string, number>();
-  for (const [key, pointsByBucket] of rowsBySeriesKey) {
-    let magnitude = 0;
-    for (const value of pointsByBucket.values()) {
-      if (value !== null && Number.isFinite(value)) {
-        magnitude += Math.abs(value);
-      }
-    }
-    magnitudeByKey.set(key, magnitude);
-  }
-
-  return [...keys]
-    .sort((left, right) => (magnitudeByKey.get(right) ?? 0) - (magnitudeByKey.get(left) ?? 0))
-    .slice(0, MAX_SERIES);
 }
 
 function resolveSeriesIdentity(params: {
@@ -219,10 +193,14 @@ function getMissingBucketValue(aggregator: MetricChartAggregator): number | null
     case "count":
     case "sum":
       return 0;
+    // 空桶无样本 → avg/min/max/last 及百分位均无定义，记 null（前端断线，不画成 0）。
     case "avg":
     case "max":
     case "min":
     case "last":
+    case "p50":
+    case "p95":
+    case "p99":
       return null;
   }
 }

--- a/apps/metric/src/metric/infra/impl/duckdb-metric.impl.dao.ts
+++ b/apps/metric/src/metric/infra/impl/duckdb-metric.impl.dao.ts
@@ -84,40 +84,70 @@ export class DuckDbMetricDao implements MetricDao {
       : `NULL`;
     const whereClause = buildWhereClause(input, params);
 
-    const sql =
+    // 每桶每序列压成一行 (bucketStart, seriesKey, value)。last 走 row_number 取桶内最新，
+    // 其余（含百分位）走 GROUP BY 聚合。
+    const bucketedCte =
       input.aggregator === "last"
         ? `
-      SELECT "bucketStart", "seriesKey", "value" FROM (
-        SELECT
-          ${bucketExpression} AS "bucketStart",
-          ${seriesKeyExpression} AS "seriesKey",
-          "value" AS "value",
-          row_number() OVER (
-            PARTITION BY ${bucketExpression}, ${seriesKeyExpression}
-            ORDER BY "occurred_at" DESC, "id" DESC
-          ) AS rn
-        FROM "metric"
-        ${whereClause}
-      )
-      WHERE rn = 1
-      ORDER BY "bucketStart" ASC, "seriesKey" ASC NULLS FIRST
-    `
+      bucketed AS (
+        SELECT "bucketStart", "seriesKey", "value" FROM (
+          SELECT
+            ${bucketExpression} AS "bucketStart",
+            ${seriesKeyExpression} AS "seriesKey",
+            "value" AS "value",
+            row_number() OVER (
+              PARTITION BY ${bucketExpression}, ${seriesKeyExpression}
+              ORDER BY "occurred_at" DESC, "id" DESC
+            ) AS rn
+          FROM "metric"
+          ${whereClause}
+        )
+        WHERE rn = 1
+      )`
         : `
-      WITH filtered AS (
+      filtered AS (
         SELECT
           ${bucketExpression} AS "bucketStart",
           ${seriesKeyExpression} AS "seriesKey",
           "value" AS "value"
         FROM "metric"
         ${whereClause}
+      ),
+      bucketed AS (
+        SELECT
+          "bucketStart" AS "bucketStart",
+          "seriesKey" AS "seriesKey",
+          ${buildAggregateExpression(input.aggregator)} AS "value"
+        FROM filtered
+        GROUP BY "bucketStart", "seriesKey"
+      )`;
+
+    const orderBy = `ORDER BY "bucketStart" ASC, "seriesKey" ASC NULLS FIRST`;
+
+    // 分组查询时把 series top-N 下推 SQL：按各 series「绝对量之和」排名，只留前 MAX_SERIES 条，
+    // DB 不物化高基数 groupByTag 的全量 series（#444 defer 的 DoS，本阶段修）。ORDER 带 seriesKey
+    // tiebreak 保证确定性。IS NOT DISTINCT FROM 让「未命中」的 NULL series 也参与排名、不被 JOIN 丢。
+    const sql = input.groupByTag
+      ? `
+      WITH ${bucketedCte},
+      series_rank AS (
+        SELECT
+          "seriesKey",
+          row_number() OVER (ORDER BY SUM(ABS("value")) DESC NULLS LAST, "seriesKey" ASC) AS srn
+        FROM bucketed
+        GROUP BY "seriesKey"
       )
-      SELECT
-        "bucketStart" AS "bucketStart",
-        "seriesKey" AS "seriesKey",
-        ${buildAggregateExpression(input.aggregator)} AS "value"
-      FROM filtered
-      GROUP BY "bucketStart", "seriesKey"
-      ORDER BY "bucketStart" ASC, "seriesKey" ASC NULLS FIRST
+      SELECT b."bucketStart", b."seriesKey", b."value"
+      FROM bucketed b
+      JOIN series_rank s ON b."seriesKey" IS NOT DISTINCT FROM s."seriesKey"
+      WHERE s.srn <= ${MAX_SERIES}
+      ${orderBy}
+    `
+      : `
+      WITH ${bucketedCte}
+      SELECT "bucketStart", "seriesKey", "value"
+      FROM bucketed
+      ${orderBy}
     `;
 
     const prepared = await this.connection.prepare(sql);
@@ -145,6 +175,9 @@ type RawMetricChartSeriesRow = {
   value: number | bigint | null;
 };
 
+/** 分组查询最多返回的 series 数：SQL 层按总量取前 N、其余丢弃，防高基数 groupByTag 撑爆响应。 */
+const MAX_SERIES = 20;
+
 /** 顺序累加 varchar 参数，返回 `$n` 占位符；同一 `$n` 可在 SQL 里被多处引用、只绑一次。 */
 class VarcharParams {
   private readonly values: string[] = [];
@@ -152,6 +185,11 @@ class VarcharParams {
   public add(value: string): string {
     this.values.push(value);
     return `$${this.values.length}`;
+  }
+
+  /** 绑一组值，返回逗号分隔的 `$a, $b, ...`（供 `IN (...)` 用）。 */
+  public addList(values: readonly string[]): string {
+    return values.map(value => this.add(value)).join(", ");
   }
 
   public bindAll(prepared: DuckDBPreparedStatement): void {
@@ -166,9 +204,21 @@ function buildWhereClause(input: QueryMetricChartSeriesInput, params: VarcharPar
     `"occurred_at" <= ${params.add(toDuckDbTimestamp(input.endAt))}::TIMESTAMP`,
   ];
 
-  for (const [key, value] of Object.entries(input.tagFilters ?? {})) {
-    // 括号必需：DuckDB `->>` 优先级低于 `=`，不加括号会被解析成 `tags ->> (key = value)`。
-    conditions.push(`("tags" ->> ${params.add(key)}) = ${params.add(value)}`);
+  for (const [key, filter] of Object.entries(input.tagFilters ?? {})) {
+    // 括号必需：DuckDB `->>` 优先级低于比较运算，不加括号会被解析成 `tags ->> (key <op> value)`。
+    const extracted = `("tags" ->> ${params.add(key)})`;
+    switch (filter.op) {
+      case "eq":
+        conditions.push(`${extracted} = ${params.add(filter.value)}`);
+        break;
+      case "ne":
+        // 补集语义：值不等于 target 即命中，含 tag 缺失（NULL）的行。IS DISTINCT FROM 把 NULL 当可比。
+        conditions.push(`${extracted} IS DISTINCT FROM ${params.add(filter.value)}`);
+        break;
+      case "in":
+        conditions.push(`${extracted} IN (${params.addList(filter.value)})`);
+        break;
+    }
   }
 
   return `WHERE ${conditions.join(" AND ")}`;
@@ -186,6 +236,13 @@ function buildAggregateExpression(aggregator: Exclude<MetricChartAggregator, "la
       return `MAX("value")`;
     case "min":
       return `MIN("value")`;
+    // 百分位从桶内原始样本连续插值现算（不可从已聚合值再聚合）。
+    case "p50":
+      return `quantile_cont("value", 0.5)`;
+    case "p95":
+      return `quantile_cont("value", 0.95)`;
+    case "p99":
+      return `quantile_cont("value", 0.99)`;
   }
 }
 

--- a/apps/metric/src/metric/infra/impl/duckdb-metric.impl.dao.ts
+++ b/apps/metric/src/metric/infra/impl/duckdb-metric.impl.dao.ts
@@ -133,7 +133,11 @@ export class DuckDbMetricDao implements MetricDao {
       series_rank AS (
         SELECT
           "seriesKey",
-          row_number() OVER (ORDER BY SUM(ABS("value")) DESC NULLS LAST, "seriesKey" ASC) AS srn
+          -- tiebreak 显式 NULLS FIRST：magnitude 打平时让「未分组」的 NULL series 排在前、优先保留
+          -- （对齐旧 service 端 stable sort + DAO NULLS FIRST 输出的语义，避免边界处静默丢它）。
+          row_number() OVER (
+            ORDER BY SUM(ABS("value")) DESC NULLS LAST, "seriesKey" ASC NULLS FIRST
+          ) AS srn
         FROM bucketed
         GROUP BY "seriesKey"
       )
@@ -205,6 +209,13 @@ function buildWhereClause(input: QueryMetricChartSeriesInput, params: VarcharPar
   ];
 
   for (const [key, filter] of Object.entries(input.tagFilters ?? {})) {
+    // 空 in 列表 = 空集恒不命中 → 直接 FALSE，避免生成非法的 `IN ()`。wire schema 的 min(1) 已挡
+    // HTTP 入口，此为 DAO 层对未来非 HTTP caller 的防御。放在最前，避免为它多绑一个不出现在 SQL
+    // 的 key 占位符（会让 DuckDB 参数编号错位）。
+    if (filter.op === "in" && filter.value.length === 0) {
+      conditions.push(`FALSE`);
+      continue;
+    }
     // 括号必需：DuckDB `->>` 优先级低于比较运算，不加括号会被解析成 `tags ->> (key <op> value)`。
     const extracted = `("tags" ->> ${params.add(key)})`;
     switch (filter.op) {

--- a/apps/metric/src/metric/infra/metric.dao.ts
+++ b/apps/metric/src/metric/infra/metric.dao.ts
@@ -1,8 +1,25 @@
 // 聚合器 / 时间桶枚举由存储层自持：与 metric-api 的 wire schema 取值一致但不共享（#279 PR0）。
-export type MetricChartAggregator = "sum" | "count" | "avg" | "min" | "max" | "last";
+export type MetricChartAggregator =
+  | "sum"
+  | "count"
+  | "avg"
+  | "min"
+  | "max"
+  | "last"
+  | "p50"
+  | "p95"
+  | "p99";
 export type MetricChartBucket = "10s" | "1m" | "5m" | "30m" | "1h";
 
 export type MetricTags = Record<string, string>;
+
+/** tag 过滤条件（#475 P2）：eq/ne 单值，in 多值。跨 key 取 AND。 */
+export type MetricTagFilter =
+  | { op: "eq"; value: string }
+  | { op: "ne"; value: string }
+  | { op: "in"; value: string[] };
+
+export type MetricTagFilters = Record<string, MetricTagFilter>;
 
 export type InsertMetricInput = {
   metricName: string;
@@ -14,7 +31,7 @@ export type InsertMetricInput = {
 export type QueryMetricChartSeriesInput = {
   metricName: string;
   aggregator: MetricChartAggregator;
-  tagFilters: MetricTags | null;
+  tagFilters: MetricTagFilters | null;
   groupByTag: string | null;
   startAt: Date;
   endAt: Date;

--- a/apps/metric/test/metric/metric-chart-query-schema.test.ts
+++ b/apps/metric/test/metric/metric-chart-query-schema.test.ts
@@ -37,14 +37,75 @@ describe("MetricChartQueryRequestSchema guards", () => {
   });
 
   it("rejects when tagFilters exceed the max key count", () => {
+    const eq = (value: string) => ({ op: "eq" as const, value });
     const result = MetricChartQueryRequestSchema.safeParse({
       metricName: "agent.tool.call",
       aggregator: "count",
       bucket: "1m",
       rangePreset: "10m",
-      tagFilters: { a: "1", b: "2", c: "3", d: "4", e: "5", f: "6" },
+      tagFilters: { a: eq("1"), b: eq("2"), c: eq("3"), d: eq("4"), e: eq("5"), f: eq("6") },
     });
     expect(result.success).toBe(false);
+  });
+
+  it("accepts eq / ne / in tag filters", () => {
+    const result = MetricChartQueryRequestSchema.safeParse({
+      metricName: "agent.tool.call",
+      aggregator: "p95",
+      bucket: "1m",
+      rangePreset: "10m",
+      tagFilters: {
+        tool: { op: "eq", value: "Wait" },
+        runtime: { op: "ne", value: "agent" },
+        model: { op: "in", value: ["gpt-4o", "sonnet"] },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an unknown tag filter op", () => {
+    const result = MetricChartQueryRequestSchema.safeParse({
+      metricName: "agent.tool.call",
+      aggregator: "count",
+      bucket: "1m",
+      rangePreset: "10m",
+      tagFilters: { tool: { op: "gt", value: "5" } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an in filter that is empty or exceeds the value cap", () => {
+    const empty = MetricChartQueryRequestSchema.safeParse({
+      metricName: "agent.tool.call",
+      aggregator: "count",
+      bucket: "1m",
+      rangePreset: "10m",
+      tagFilters: { tool: { op: "in", value: [] } },
+    });
+    expect(empty.success).toBe(false);
+
+    const tooMany = MetricChartQueryRequestSchema.safeParse({
+      metricName: "agent.tool.call",
+      aggregator: "count",
+      bucket: "1m",
+      rangePreset: "10m",
+      tagFilters: {
+        tool: { op: "in", value: Array.from({ length: 21 }, (_unused, i) => `v${i}`) },
+      },
+    });
+    expect(tooMany.success).toBe(false);
+  });
+
+  it("accepts percentile aggregators", () => {
+    for (const aggregator of ["p50", "p95", "p99"]) {
+      const result = MetricChartQueryRequestSchema.safeParse({
+        metricName: "llm.latency",
+        aggregator,
+        bucket: "1m",
+        rangePreset: "10m",
+      });
+      expect(result.success).toBe(true);
+    }
   });
 
   it("rejects a custom range wider than the max span", () => {

--- a/apps/metric/test/metric/metric-chart.impl.service.test.ts
+++ b/apps/metric/test/metric/metric-chart.impl.service.test.ts
@@ -48,7 +48,7 @@ describe("DefaultMetricChartService", () => {
       metricName: "llm.token.total",
       aggregator: "sum",
       bucket: "1m",
-      tagFilters: { provider: "openai" },
+      tagFilters: { provider: { op: "eq", value: "openai" } },
       groupByTag: "model",
       startAt: "2026-04-02T01:00:00.000Z",
       endAt: "2026-04-02T01:01:30.000Z",
@@ -57,7 +57,7 @@ describe("DefaultMetricChartService", () => {
     expect(queryChartSeries).toHaveBeenCalledWith({
       metricName: "llm.token.total",
       aggregator: "sum",
-      tagFilters: { provider: "openai" },
+      tagFilters: { provider: { op: "eq", value: "openai" } },
       groupByTag: "model",
       startAt: new Date("2026-04-02T01:00:00.000Z"),
       endAt: new Date("2026-04-02T01:01:30.000Z"),
@@ -116,13 +116,13 @@ describe("DefaultMetricChartService", () => {
     expect(response.series).toEqual([]);
   });
 
-  it("should cap grouped series to the top 20 by magnitude", async () => {
-    // 25 个分组，各占 1 个桶，总量 = 序号；期望保留总量最大的前 20 个（6..30）。
+  it("builds a series per DAO-returned key without re-trimming (top-N is the DAO's job now)", async () => {
+    // series top-N 已下推 DAO 的 SQL；service 只按 DAO 返回的 key 原样成线，不再二次裁剪。
     const bucketStart = new Date("2026-04-02T00:00:00.000Z");
-    const rows: MetricChartSeriesRow[] = Array.from({ length: 25 }, (_unused, index) => ({
+    const rows: MetricChartSeriesRow[] = Array.from({ length: 3 }, (_unused, index) => ({
       bucketStart,
       seriesKey: `series-${index + 1}`,
-      value: index + 6,
+      value: index + 1,
     }));
     const service = new DefaultMetricChartService({
       metricDao: createMetricDao({ queryChartSeries: vi.fn().mockResolvedValue(rows) }),
@@ -137,10 +137,7 @@ describe("DefaultMetricChartService", () => {
       endAt: "2026-04-02T00:00:30.000Z",
     });
 
-    expect(response.series).toHaveLength(20);
-    const totals = response.series.map(series => series.points[0]?.value ?? 0);
-    expect(Math.min(...(totals as number[]))).toBe(11); // 30..11 保留，10..6 被裁
-    expect(response.series.some(series => series.key === "series-1")).toBe(false);
+    expect(response.series.map(series => series.key)).toEqual(["series-1", "series-2", "series-3"]);
   });
 });
 

--- a/apps/metric/test/metric/metric.impl.dao.test.ts
+++ b/apps/metric/test/metric/metric.impl.dao.test.ts
@@ -217,6 +217,111 @@ describe("DuckDbMetricDao", () => {
     expect(keys.has("series-1")).toBe(false);
   });
 
+  it("keeps the NULL (未分组) series through top-N when grouping and some rows miss the tag", async () => {
+    // 分组查询下，tag 缺失的行汇成一条 NULL series；它必须参与排名、经 IS NOT DISTINCT FROM join 存活。
+    for (let n = 0; n < 3; n++) {
+      await dao.insert({
+        metricName: METRIC,
+        value: 1,
+        tags: { tool: "Read" },
+        occurredAt: iso("2026-07-06T10:00:10.000Z"),
+      });
+    }
+    await dao.insert({
+      metricName: METRIC,
+      value: 1,
+      tags: {},
+      occurredAt: iso("2026-07-06T10:00:20.000Z"),
+    });
+
+    const rows = await dao.queryChartSeries(baseQuery({ aggregator: "count", groupByTag: "tool" }));
+
+    expect(rows).toEqual([
+      { bucketStart: iso("2026-07-06T10:00:00.000Z"), seriesKey: null, value: 1 },
+      { bucketStart: iso("2026-07-06T10:00:00.000Z"), seriesKey: "Read", value: 3 },
+    ]);
+  });
+
+  it("keeps the NULL series over a magnitude-tied named series at the top-N boundary (NULLS FIRST)", async () => {
+    // 19 条大 series(各 10) + NULL(5) + 命名 "zzz"(5)：共 21 条、截到 20。NULL 与 zzz 在边界打平，
+    // series_rank 的 NULLS FIRST tiebreak 让 NULL 排前存活、zzz 被裁（对齐旧 stable-sort 语义）。
+    for (let index = 1; index <= 19; index++) {
+      const key = `aaa-${String(index).padStart(2, "0")}`;
+      for (let n = 0; n < 10; n++) {
+        await dao.insert({
+          metricName: METRIC,
+          value: 1,
+          tags: { tool: key },
+          occurredAt: iso("2026-07-06T10:00:10.000Z"),
+        });
+      }
+    }
+    for (let n = 0; n < 5; n++) {
+      await dao.insert({
+        metricName: METRIC,
+        value: 1,
+        tags: {},
+        occurredAt: iso("2026-07-06T10:00:10.000Z"),
+      });
+      await dao.insert({
+        metricName: METRIC,
+        value: 1,
+        tags: { tool: "zzz" },
+        occurredAt: iso("2026-07-06T10:00:10.000Z"),
+      });
+    }
+
+    const rows = await dao.queryChartSeries(baseQuery({ aggregator: "count", groupByTag: "tool" }));
+
+    const keys = new Set(rows.map(row => row.seriesKey));
+    expect(keys.size).toBe(20);
+    expect(keys.has(null)).toBe(true); // 未分组 NULL series 存活
+    expect(keys.has("zzz")).toBe(false); // 同分但字母序靠后的命名 series 被裁
+  });
+
+  it("treats an empty in list as no match (defensive: avoids illegal IN ())", async () => {
+    await dao.insert({
+      metricName: METRIC,
+      value: 1,
+      tags: { tool: "Read" },
+      occurredAt: iso("2026-07-06T10:00:10.000Z"),
+    });
+
+    const rows = await dao.queryChartSeries(
+      baseQuery({ aggregator: "count", tagFilters: { tool: { op: "in", value: [] } } }),
+    );
+
+    expect(rows).toEqual([]);
+  });
+
+  it("supports last aggregator combined with groupByTag (top-N CTE wraps the row_number pick)", async () => {
+    await dao.insert({
+      metricName: METRIC,
+      value: 10,
+      tags: { tool: "Read" },
+      occurredAt: iso("2026-07-06T10:00:10.000Z"),
+    });
+    await dao.insert({
+      metricName: METRIC,
+      value: 20,
+      tags: { tool: "Read" },
+      occurredAt: iso("2026-07-06T10:00:40.000Z"), // 桶内更晚 → last 取 20
+    });
+    await dao.insert({
+      metricName: METRIC,
+      value: 99,
+      tags: { tool: "Wait" },
+      occurredAt: iso("2026-07-06T10:00:30.000Z"),
+    });
+
+    const rows = await dao.queryChartSeries(baseQuery({ aggregator: "last", groupByTag: "tool" }));
+
+    expect(rows).toEqual([
+      { bucketStart: iso("2026-07-06T10:00:00.000Z"), seriesKey: "Read", value: 20 },
+      { bucketStart: iso("2026-07-06T10:00:00.000Z"), seriesKey: "Wait", value: 99 },
+    ]);
+  });
+
   it("computes sum / avg / max / min over value", async () => {
     for (const v of [2, 4, 6]) {
       await dao.insert({

--- a/apps/metric/test/metric/metric.impl.dao.test.ts
+++ b/apps/metric/test/metric/metric.impl.dao.test.ts
@@ -106,12 +106,115 @@ describe("DuckDbMetricDao", () => {
     });
 
     const rows = await dao.queryChartSeries(
-      baseQuery({ aggregator: "count", tagFilters: { tool: "Wait" } }),
+      baseQuery({ aggregator: "count", tagFilters: { tool: { op: "eq", value: "Wait" } } }),
     );
 
     expect(rows).toEqual([
       { bucketStart: iso("2026-07-06T10:00:00.000Z"), seriesKey: null, value: 1 },
     ]);
+  });
+
+  it("applies ne tag filters as a complement (includes rows missing the tag)", async () => {
+    await dao.insert({
+      metricName: METRIC,
+      value: 1,
+      tags: { tool: "Wait" },
+      occurredAt: iso("2026-07-06T10:00:10.000Z"),
+    });
+    await dao.insert({
+      metricName: METRIC,
+      value: 1,
+      tags: { tool: "Read" },
+      occurredAt: iso("2026-07-06T10:00:20.000Z"),
+    });
+    // tag 缺失的行也算「不等于 Wait」→ 补集语义命中。
+    await dao.insert({
+      metricName: METRIC,
+      value: 1,
+      tags: {},
+      occurredAt: iso("2026-07-06T10:00:30.000Z"),
+    });
+
+    const rows = await dao.queryChartSeries(
+      baseQuery({ aggregator: "count", tagFilters: { tool: { op: "ne", value: "Wait" } } }),
+    );
+
+    expect(rows).toEqual([
+      { bucketStart: iso("2026-07-06T10:00:00.000Z"), seriesKey: null, value: 2 },
+    ]);
+  });
+
+  it("applies in tag filters (membership, absent tag excluded)", async () => {
+    for (const tool of ["Read", "Write", "Wait"]) {
+      await dao.insert({
+        metricName: METRIC,
+        value: 1,
+        tags: { tool },
+        occurredAt: iso("2026-07-06T10:00:10.000Z"),
+      });
+    }
+    await dao.insert({
+      metricName: METRIC,
+      value: 1,
+      tags: {},
+      occurredAt: iso("2026-07-06T10:00:20.000Z"),
+    });
+
+    const rows = await dao.queryChartSeries(
+      baseQuery({
+        aggregator: "count",
+        tagFilters: { tool: { op: "in", value: ["Read", "Write"] } },
+      }),
+    );
+
+    expect(rows).toEqual([
+      { bucketStart: iso("2026-07-06T10:00:00.000Z"), seriesKey: null, value: 2 },
+    ]);
+  });
+
+  it("computes percentiles (p50 / p95 / p99) from raw samples in the bucket", async () => {
+    // 桶内样本 1..100；quantile_cont 连续插值：p50=50.5, p95≈95.05, p99≈99.01。
+    for (let v = 1; v <= 100; v++) {
+      await dao.insert({
+        metricName: METRIC,
+        value: v,
+        tags: {},
+        occurredAt: iso("2026-07-06T10:00:10.000Z"),
+      });
+    }
+    const at = iso("2026-07-06T10:00:00.000Z");
+
+    const [p50] = await dao.queryChartSeries(baseQuery({ aggregator: "p50" }));
+    const [p95] = await dao.queryChartSeries(baseQuery({ aggregator: "p95" }));
+    const [p99] = await dao.queryChartSeries(baseQuery({ aggregator: "p99" }));
+
+    expect(p50?.bucketStart).toEqual(at);
+    expect(p50?.value).toBeCloseTo(50.5, 5);
+    expect(p95?.value).toBeCloseTo(95.05, 5);
+    expect(p99?.value).toBeCloseTo(99.01, 5);
+  });
+
+  it("pushes series top-N down to SQL: caps a high-cardinality groupByTag to 20 by magnitude", async () => {
+    // 25 个 tool 分组，各占一个桶、总量 = 序号(6..30)；DAO 应在 SQL 层只留总量最大的前 20（11..30）。
+    for (let index = 1; index <= 25; index++) {
+      const magnitude = index + 5;
+      for (let n = 0; n < magnitude; n++) {
+        await dao.insert({
+          metricName: METRIC,
+          value: 1,
+          tags: { tool: `series-${index}` },
+          occurredAt: iso("2026-07-06T10:00:10.000Z"),
+        });
+      }
+    }
+
+    const rows = await dao.queryChartSeries(baseQuery({ aggregator: "count", groupByTag: "tool" }));
+
+    const keys = new Set(rows.map(row => row.seriesKey));
+    expect(keys.size).toBe(20);
+    expect(keys.has("series-6")).toBe(true); // 总量 11，最小的保留者
+    expect(keys.has("series-5")).toBe(false); // 总量 10，被裁
+    expect(keys.has("series-1")).toBe(false);
   });
 
   it("computes sum / avg / max / min over value", async () => {

--- a/packages/metric-api/src/chart.ts
+++ b/packages/metric-api/src/chart.ts
@@ -7,7 +7,18 @@ import { z } from "zod";
 // 规格聚合。为防一次请求把 SQLite / 进程拖死，schema 层带硬边界 guard（点数 / tagFilters 数 /
 // 时间跨度）；分组 series top-N 上限在服务端 buildSeries 后处理。
 
-export const MetricChartAggregatorSchema = z.enum(["sum", "count", "avg", "max", "min", "last"]);
+export const MetricChartAggregatorSchema = z.enum([
+  "sum",
+  "count",
+  "avg",
+  "max",
+  "min",
+  "last",
+  // 百分位（p50/p95/p99）：桶内原始样本现算（DuckDB quantile_cont）。延迟看均值会骗人，观测刚需。
+  "p50",
+  "p95",
+  "p99",
+]);
 
 export type MetricChartAggregator = z.infer<typeof MetricChartAggregatorSchema>;
 
@@ -33,11 +44,28 @@ export type MetricChartRangePreset = z.infer<typeof MetricChartRangePresetSchema
 export const METRIC_CHART_MAX_POINTS = 2000;
 /** tagFilters 最多键数。 */
 export const METRIC_CHART_MAX_TAG_FILTERS = 5;
+/** 单个 `in` 过滤的取值上限（防超长 in 列表撑爆 SQL / DoS）。 */
+export const METRIC_CHART_MAX_TAG_FILTER_VALUES = 20;
 /** 时间跨度上限（2 天，与 rangePreset 上限一致）。 */
 export const METRIC_CHART_MAX_RANGE_MS = 2 * 24 * 60 * 60 * 1000;
 
+// tag 过滤从「等值 AND」扩到 op 判别联合（#475 P2）：eq/ne 单值、in 多值。同一 key 一个过滤，
+// 跨 key 取 AND。「Wait vs 非Wait」用两条查询（各带一条 eq / ne 过滤），不做派生分组 DSL。
+export const MetricChartTagFilterSchema = z.discriminatedUnion("op", [
+  z.object({ op: z.literal("eq"), value: z.string() }).strict(),
+  z.object({ op: z.literal("ne"), value: z.string() }).strict(),
+  z
+    .object({
+      op: z.literal("in"),
+      value: z.array(z.string().min(1)).min(1).max(METRIC_CHART_MAX_TAG_FILTER_VALUES),
+    })
+    .strict(),
+]);
+
+export type MetricChartTagFilter = z.infer<typeof MetricChartTagFilterSchema>;
+
 export const MetricChartTagFiltersSchema = z
-  .record(z.string().min(1), z.string())
+  .record(z.string().min(1), MetricChartTagFilterSchema)
   .refine(value => Object.keys(value).length <= METRIC_CHART_MAX_TAG_FILTERS, {
     message: `tagFilters 最多 ${METRIC_CHART_MAX_TAG_FILTERS} 个`,
   });


### PR DESCRIPTION
## 背景

Epic [#475](https://github.com/KisinTheFlame/kagami/issues/475) P2。承接 P1（[#477](https://github.com/KisinTheFlame/kagami/pull/477)，存储迁 DuckDB、行为等价）后，本 PR 补足查询能力——都是 P1 引擎已 spike 验证过的 DuckDB 原生特性。

## 改动

**1. tagFilters 扩 ne/in（op 判别联合）**
- wire 从 `Record<key, string>`（等值 AND）改 `Record<key, {op: eq|ne|in, value}>`。eq/ne 单值、in 多值。跨 key 仍取 AND。
- `ne` 用 `IS DISTINCT FROM` 走**补集语义**（含 tag 缺失的行也算「不等于 X」），与 eq 对称、最不意外。
- `in` 加 ≤20 取值上限防超长列表 DoS。
- 「Wait vs 非Wait」用两条查询（各带 eq/ne 一条过滤），不做派生分组 DSL。

**2. 百分位 p50/p95/p99**
- aggregator 加三档，DuckDB `quantile_cont` 从**桶内原始样本**连续插值现算（不可从已聚合值再聚合）。
- 空桶记 `null`（同 avg/min/max，前端断线不画成 0）。

**3. series top-N 下推 SQL**
- 分组查询按各 series「绝对量之和」在 SQL 层排名、只留前 20，DB 不再物化高基数 `groupByTag` 全量 series —— 修 #444 defer 的 DoS（旧实现查完全量再在 service 裁）。
- 移除 service 端 `selectTopSeriesKeys`；`IS NOT DISTINCT FROM` join 保证「未命中」的 NULL series 也参与排名、不被丢。

## 测试
- DAO 真·内存 DuckDB：ne 补集 / in 成员 / p50·p95·p99（对 1..100 样本验插值）/ top-N 25→20 截断。
- wire schema：eq·ne·in 形状、in 空/超限、非法 op、百分位聚合器。
- 五件套 + 全量 2062 测试全绿。

## 边界
- 不动 agent 上下文/prompt/工具集（KV 红线）。纯查询侧增量，无迁移、无新依赖。
- 派生（ratio/diff）是 P3、图表适配器是 P4，本 PR 不含。

Refs #475