### PR TITLE
feat(metric): 派生查询原语 ratio/diff（#475 P3）

### DIFF
--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -28,9 +28,10 @@ const CONSOLE_PATH_PREFIXES = [
 ];
 // 这些前缀路由到 kagami-llm 进程（OAuth 凭据中心）：认证管理端点已随 LLM 服务外移。
 const LLM_PATH_PREFIXES = ["/auth"];
-// metric 图表查询（POST /metric/query）走独立的 metric 进程（@kagami/metric）；摄取端点
-// /metric/record 不经网关（agent 直连），故这里只收 /metric/query 而非整个 /metric 前缀（#444）。
-const METRIC_PATH_PREFIXES = ["/metric/query"];
+// metric 图表查询（POST /metric/query）与派生查询（POST /metric/derive，#475 P3）走独立的 metric
+// 进程（@kagami/metric）；摄取端点 /metric/record 不经网关（agent 直连），故这里只逐个列查询/派生
+// 端点而非整个 /metric 前缀（#444）。
+const METRIC_PATH_PREFIXES = ["/metric/query", "/metric/derive"];
 // 管理台对象浏览器只读面路由到 kagami-oss 进程。仅 /oss-object（列表 / 统计 / 预览字节）过网关；
 // 写操作前缀 /objects（put/delete）刻意不在此，浏览器经网关够不到 OSS 的任何写路由。
 const OSS_PATH_PREFIXES = ["/oss-object"];

--- a/apps/metric/src/app/metric-runtime.ts
+++ b/apps/metric/src/app/metric-runtime.ts
@@ -6,8 +6,10 @@ import { AppLogger } from "@kagami/kernel/logger/logger";
 import { createServiceApp } from "@kagami/kernel/http/service-app";
 import { HealthHandler } from "@kagami/kernel/http/health.handler";
 import { MetricChartHandler } from "../metric/http/metric-chart.handler.js";
+import { MetricDeriveHandler } from "../metric/http/metric-derive.handler.js";
 import { MetricRecordHandler } from "../metric/http/metric-record.handler.js";
 import { DefaultMetricChartService } from "../metric/application/metric-chart.impl.service.js";
+import { DefaultMetricDeriveService } from "../metric/application/metric-derive.impl.service.js";
 import { DefaultMetricRecordService } from "../metric/application/metric-record.impl.service.js";
 import { openMetricDuckDb } from "../metric/infra/impl/duckdb-metric.impl.dao.js";
 
@@ -34,6 +36,7 @@ export async function buildMetricRuntime(): Promise<MetricRuntime> {
 
   const metricRecordService = new DefaultMetricRecordService({ metricDao });
   const metricChartService = new DefaultMetricChartService({ metricDao });
+  const metricDeriveService = new DefaultMetricDeriveService({ metricDao });
 
   // 面向前端查询 + agent 摄取：traceId / 默认错误三分支由公共装配壳提供。
   const app = createServiceApp({
@@ -42,6 +45,7 @@ export async function buildMetricRuntime(): Promise<MetricRuntime> {
       new HealthHandler(),
       new MetricRecordHandler({ metricRecordService }),
       new MetricChartHandler({ metricChartService }),
+      new MetricDeriveHandler({ metricDeriveService }),
     ],
   });
 

--- a/apps/metric/src/metric/application/bucket-time.ts
+++ b/apps/metric/src/metric/application/bucket-time.ts
@@ -1,0 +1,36 @@
+import type { MetricChartBucket } from "@kagami/metric-api/chart";
+
+// 桶时间轴共享助手：单指标查询（buildSeries 补空桶）与派生查询（对齐补 null）共用同一套桶对齐，
+// 避免两处各写一份、漂移出不一致的桶边界。
+
+export function bucketToMilliseconds(bucket: MetricChartBucket): number {
+  switch (bucket) {
+    case "10s":
+      return 10 * 1000;
+    case "1m":
+      return 60 * 1000;
+    case "5m":
+      return 5 * 60 * 1000;
+    case "30m":
+      return 30 * 60 * 1000;
+    case "1h":
+      return 60 * 60 * 1000;
+  }
+}
+
+/** 闭区间列出范围内每个桶的起点（含首尾对齐桶）；与 DAO 的 epoch 分桶同口径。 */
+export function listBucketStarts(startAt: Date, endAt: Date, bucketMs: number): Date[] {
+  const alignedStartAt = new Date(Math.floor(startAt.getTime() / bucketMs) * bucketMs);
+  const alignedEndAt = new Date(Math.floor(endAt.getTime() / bucketMs) * bucketMs);
+  const buckets: Date[] = [];
+
+  for (
+    let current = alignedStartAt.getTime();
+    current <= alignedEndAt.getTime();
+    current += bucketMs
+  ) {
+    buckets.push(new Date(current));
+  }
+
+  return buckets;
+}

--- a/apps/metric/src/metric/application/metric-chart.impl.service.ts
+++ b/apps/metric/src/metric/application/metric-chart.impl.service.ts
@@ -7,6 +7,7 @@ import type {
 } from "@kagami/metric-api/chart";
 import { BizError } from "@kagami/kernel/errors/biz-error";
 import type { MetricChartSeriesRow, MetricDao } from "../infra/metric.dao.js";
+import { bucketToMilliseconds, listBucketStarts } from "./bucket-time.js";
 import type { MetricChartService } from "./metric-chart.service.js";
 
 type DefaultMetricChartServiceDeps = {
@@ -172,22 +173,6 @@ function resolveSeriesIdentity(params: {
   };
 }
 
-function listBucketStarts(startAt: Date, endAt: Date, bucketMs: number): Date[] {
-  const alignedStartAt = new Date(Math.floor(startAt.getTime() / bucketMs) * bucketMs);
-  const alignedEndAt = new Date(Math.floor(endAt.getTime() / bucketMs) * bucketMs);
-  const buckets: Date[] = [];
-
-  for (
-    let current = alignedStartAt.getTime();
-    current <= alignedEndAt.getTime();
-    current += bucketMs
-  ) {
-    buckets.push(new Date(current));
-  }
-
-  return buckets;
-}
-
 function getMissingBucketValue(aggregator: MetricChartAggregator): number | null {
   switch (aggregator) {
     case "count":
@@ -202,20 +187,5 @@ function getMissingBucketValue(aggregator: MetricChartAggregator): number | null
     case "p95":
     case "p99":
       return null;
-  }
-}
-
-function bucketToMilliseconds(bucket: MetricChartQueryRequest["bucket"]): number {
-  switch (bucket) {
-    case "10s":
-      return 10 * 1000;
-    case "1m":
-      return 60 * 1000;
-    case "5m":
-      return 5 * 60 * 1000;
-    case "30m":
-      return 30 * 60 * 1000;
-    case "1h":
-      return 60 * 60 * 1000;
   }
 }

--- a/apps/metric/src/metric/application/metric-derive.impl.service.ts
+++ b/apps/metric/src/metric/application/metric-derive.impl.service.ts
@@ -35,6 +35,17 @@ export class DefaultMetricDeriveService implements MetricDeriveService {
       bucket: request.bucket,
     });
 
+    // 两侧在整段范围都无数据 → 空序列（与 /metric/query 的「无数据 → series: []」一致，前端出
+    // 「没有数据」占位而非一条全 null 的孤线）。有数据但某些桶除零/缺侧 → 保留序列、那些桶记 null。
+    if (rows.length === 0) {
+      return {
+        bucket: request.bucket,
+        startAt: startAt.toISOString(),
+        endAt: endAt.toISOString(),
+        series: [],
+      };
+    }
+
     const bucketMs = bucketToMilliseconds(request.bucket);
     const bucketStarts = listBucketStarts(startAt, endAt, bucketMs);
     const valueByBucket = new Map<number, number | null>();

--- a/apps/metric/src/metric/application/metric-derive.impl.service.ts
+++ b/apps/metric/src/metric/application/metric-derive.impl.service.ts
@@ -1,0 +1,70 @@
+import type { MetricChartQueryResponse } from "@kagami/metric-api/chart";
+import type {
+  MetricDeriveOp,
+  MetricDeriveOperand as WireDeriveOperand,
+  MetricDeriveRequest,
+} from "@kagami/metric-api/derive";
+import type { MetricDao, MetricDeriveOperand } from "../infra/metric.dao.js";
+import { bucketToMilliseconds, listBucketStarts } from "./bucket-time.js";
+import type { MetricDeriveService } from "./metric-derive.service.js";
+
+type DefaultMetricDeriveServiceDeps = {
+  metricDao: MetricDao;
+};
+
+/** 派生序列的稳定 key；展示 label / 颜色归前端，后端只给一个中性兜底 label。 */
+const DERIVED_SERIES_KEY = "derived";
+
+export class DefaultMetricDeriveService implements MetricDeriveService {
+  private readonly metricDao: MetricDao;
+
+  public constructor({ metricDao }: DefaultMetricDeriveServiceDeps) {
+    this.metricDao = metricDao;
+  }
+
+  public async derive(request: MetricDeriveRequest): Promise<MetricChartQueryResponse> {
+    const startAt = new Date(request.startAt);
+    const endAt = new Date(request.endAt);
+
+    const rows = await this.metricDao.queryDerivedSeries({
+      numerator: toDaoOperand(request.numerator),
+      denominator: toDaoOperand(request.denominator),
+      op: request.op,
+      startAt,
+      endAt,
+      bucket: request.bucket,
+    });
+
+    const bucketMs = bucketToMilliseconds(request.bucket);
+    const bucketStarts = listBucketStarts(startAt, endAt, bucketMs);
+    const valueByBucket = new Map<number, number | null>();
+    for (const row of rows) {
+      valueByBucket.set(row.bucketStart.getTime(), row.value);
+    }
+
+    // 派生缺桶恒 null（ratio/diff 任一侧无数据即无定义），前端断线、不臆造 0。
+    const points = bucketStarts.map(bucketStart => ({
+      bucketStart: bucketStart.toISOString(),
+      value: valueByBucket.get(bucketStart.getTime()) ?? null,
+    }));
+
+    return {
+      bucket: request.bucket,
+      startAt: startAt.toISOString(),
+      endAt: endAt.toISOString(),
+      series: [{ key: DERIVED_SERIES_KEY, label: deriveFallbackLabel(request.op), points }],
+    };
+  }
+}
+
+function toDaoOperand(operand: WireDeriveOperand): MetricDeriveOperand {
+  return {
+    metricName: operand.metricName,
+    aggregator: operand.aggregator,
+    tagFilters: operand.tagFilters ?? null,
+  };
+}
+
+function deriveFallbackLabel(op: MetricDeriveOp): string {
+  return op === "ratio" ? "比率" : "差值";
+}

--- a/apps/metric/src/metric/application/metric-derive.service.ts
+++ b/apps/metric/src/metric/application/metric-derive.service.ts
@@ -1,0 +1,6 @@
+import type { MetricChartQueryResponse } from "@kagami/metric-api/chart";
+import type { MetricDeriveRequest } from "@kagami/metric-api/derive";
+
+export interface MetricDeriveService {
+  derive(request: MetricDeriveRequest): Promise<MetricChartQueryResponse>;
+}

--- a/apps/metric/src/metric/http/metric-derive.handler.ts
+++ b/apps/metric/src/metric/http/metric-derive.handler.ts
@@ -1,0 +1,23 @@
+import type { FastifyInstance } from "fastify";
+import { registerJsonRoute } from "@kagami/http/register";
+import { metricApiContract } from "@kagami/metric-api/contract";
+import type { MetricDeriveService } from "../application/metric-derive.service.js";
+
+type MetricDeriveHandlerDeps = {
+  metricDeriveService: MetricDeriveService;
+};
+
+/** 派生查询路由（#475 P3）：分子/分母两份规格算 ratio/diff，出单条派生线。 */
+export class MetricDeriveHandler {
+  private readonly metricDeriveService: MetricDeriveService;
+
+  public constructor({ metricDeriveService }: MetricDeriveHandlerDeps) {
+    this.metricDeriveService = metricDeriveService;
+  }
+
+  public register(app: FastifyInstance): void {
+    registerJsonRoute(app, metricApiContract.derive, ({ input }) =>
+      this.metricDeriveService.derive(input),
+    );
+  }
+}

--- a/apps/metric/src/metric/infra/impl/duckdb-metric.impl.dao.ts
+++ b/apps/metric/src/metric/infra/impl/duckdb-metric.impl.dao.ts
@@ -8,6 +8,10 @@ import type {
   MetricChartAggregator,
   MetricChartSeriesRow,
   MetricDao,
+  MetricDeriveOperand,
+  MetricDerivedSeriesRow,
+  MetricTagFilters,
+  QueryDerivedSeriesInput,
   QueryMetricChartSeriesInput,
 } from "../metric.dao.js";
 
@@ -75,10 +79,7 @@ export class DuckDbMetricDao implements MetricDao {
   ): Promise<MetricChartSeriesRow[]> {
     const params = new VarcharParams();
     const bucketSeconds = bucketToSeconds(input.bucket);
-    // epoch(occurred_at) 得 UTC 秒（DOUBLE，带亚秒小数）；先 floor 截断到整秒——对齐旧 SQLite
-    // unixepoch 的截断语义，而非 DuckDB `CAST(DOUBLE AS BIGINT)` 的四舍五入（.5xx 秒会被顶进下一个
-    // 桶）。再整除（//）对齐桶乘回 = 桶起点 epoch 秒。
-    const bucketExpression = `(CAST(floor(epoch("occurred_at")) AS BIGINT) // ${bucketSeconds}) * ${bucketSeconds}`;
+    const bucketExpression = bucketStartExpression(bucketSeconds);
     const seriesKeyExpression = input.groupByTag
       ? `NULLIF("tags" ->> ${params.add(input.groupByTag)}, '')`
       : `NULL`;
@@ -166,6 +167,43 @@ export class DuckDbMetricDao implements MetricDao {
     }));
   }
 
+  public async queryDerivedSeries(
+    input: QueryDerivedSeriesInput,
+  ): Promise<MetricDerivedSeriesRow[]> {
+    const params = new VarcharParams();
+    const bucketSeconds = bucketToSeconds(input.bucket);
+    const range = { startAt: input.startAt, endAt: input.endAt };
+    // 分子/分母各自压成「每桶一个标量」的 CTE（无分组、无 top-N）。
+    const numeratorCte = buildOperandCte("num", input.numerator, range, bucketSeconds, params);
+    const denominatorCte = buildOperandCte("den", input.denominator, range, bucketSeconds, params);
+
+    // 缺桶 / 除零语义在这一条表达式里定死：ratio 用 NULLIF 挡除零，diff 直接相减；两者都靠 SQL 的
+    // NULL 传播——任一侧该桶无数据（FULL OUTER JOIN 补 NULL）时结果即 NULL，前端断线不臆造 0。
+    const valueExpression =
+      input.op === "ratio" ? `num."value" / NULLIF(den."value", 0)` : `num."value" - den."value"`;
+
+    const sql = `
+      WITH ${numeratorCte},
+      ${denominatorCte}
+      SELECT
+        COALESCE(num."bucketStart", den."bucketStart") AS "bucketStart",
+        ${valueExpression} AS "value"
+      FROM num
+      FULL OUTER JOIN den ON num."bucketStart" = den."bucketStart"
+      ORDER BY "bucketStart" ASC
+    `;
+
+    const prepared = await this.connection.prepare(sql);
+    params.bindAll(prepared);
+    const reader = await prepared.runAndReadAll();
+    const rows = reader.getRowObjects() as RawMetricDerivedSeriesRow[];
+
+    return rows.map(row => ({
+      bucketStart: new Date(Number(row.bucketStart) * 1000),
+      value: row.value === null ? null : Number(row.value),
+    }));
+  }
+
   public close(): void {
     this.connection.closeSync();
     this.instance.closeSync();
@@ -178,6 +216,66 @@ type RawMetricChartSeriesRow = {
   seriesKey: string | null;
   value: number | bigint | null;
 };
+
+type RawMetricDerivedSeriesRow = {
+  bucketStart: number | bigint;
+  value: number | bigint | null;
+};
+
+/**
+ * 桶起点 epoch 秒表达式。epoch(occurred_at) 得 UTC 秒（DOUBLE，带亚秒小数）；先 floor 截断到整秒
+ * ——对齐旧 SQLite unixepoch 的截断语义，而非 DuckDB `CAST(DOUBLE AS BIGINT)` 的四舍五入（.5xx 秒
+ * 会被顶进下一个桶）。再整除（//）对齐桶乘回。
+ */
+function bucketStartExpression(bucketSeconds: number): string {
+  return `(CAST(floor(epoch("occurred_at")) AS BIGINT) // ${bucketSeconds}) * ${bucketSeconds}`;
+}
+
+/** 派生查询的单个操作数 → 「每桶一个标量值」的具名 CTE（无分组、无 top-N）。 */
+function buildOperandCte(
+  name: string,
+  operand: MetricDeriveOperand,
+  range: { startAt: Date; endAt: Date },
+  bucketSeconds: number,
+  params: VarcharParams,
+): string {
+  const bucketExpression = bucketStartExpression(bucketSeconds);
+  const whereClause = buildWhereClause(
+    {
+      metricName: operand.metricName,
+      startAt: range.startAt,
+      endAt: range.endAt,
+      tagFilters: operand.tagFilters,
+    },
+    params,
+  );
+
+  if (operand.aggregator === "last") {
+    return `${name} AS (
+      SELECT "bucketStart", "value" FROM (
+        SELECT
+          ${bucketExpression} AS "bucketStart",
+          "value" AS "value",
+          row_number() OVER (
+            PARTITION BY ${bucketExpression}
+            ORDER BY "occurred_at" DESC, "id" DESC
+          ) AS rn
+        FROM "metric"
+        ${whereClause}
+      )
+      WHERE rn = 1
+    )`;
+  }
+
+  return `${name} AS (
+    SELECT
+      ${bucketExpression} AS "bucketStart",
+      ${buildAggregateExpression(operand.aggregator)} AS "value"
+    FROM "metric"
+    ${whereClause}
+    GROUP BY "bucketStart"
+  )`;
+}
 
 /** 分组查询最多返回的 series 数：SQL 层按总量取前 N、其余丢弃，防高基数 groupByTag 撑爆响应。 */
 const MAX_SERIES = 20;
@@ -201,7 +299,15 @@ class VarcharParams {
   }
 }
 
-function buildWhereClause(input: QueryMetricChartSeriesInput, params: VarcharParams): string {
+/** buildWhereClause 只需这几项：单查询与派生查询的操作数都套得上。 */
+type MetricWhereInput = {
+  metricName: string;
+  startAt: Date;
+  endAt: Date;
+  tagFilters: MetricTagFilters | null;
+};
+
+function buildWhereClause(input: MetricWhereInput, params: VarcharParams): string {
   const conditions = [
     `"metric_name" = ${params.add(input.metricName)}`,
     `"occurred_at" >= ${params.add(toDuckDbTimestamp(input.startAt))}::TIMESTAMP`,

--- a/apps/metric/src/metric/infra/metric.dao.ts
+++ b/apps/metric/src/metric/infra/metric.dao.ts
@@ -44,9 +44,34 @@ export type MetricChartSeriesRow = {
   value: number | null;
 };
 
+// 派生查询（#475 P3）：分子/分母各一份「无分组」聚合规格，共享 range/bucket。
+export type MetricDeriveOp = "ratio" | "diff";
+
+export type MetricDeriveOperand = {
+  metricName: string;
+  aggregator: MetricChartAggregator;
+  tagFilters: MetricTagFilters | null;
+};
+
+export type QueryDerivedSeriesInput = {
+  numerator: MetricDeriveOperand;
+  denominator: MetricDeriveOperand;
+  op: MetricDeriveOp;
+  startAt: Date;
+  endAt: Date;
+  bucket: MetricChartBucket;
+};
+
+export type MetricDerivedSeriesRow = {
+  bucketStart: Date;
+  value: number | null;
+};
+
 export interface MetricDao {
   insert(input: InsertMetricInput): Promise<void>;
   queryChartSeries(input: QueryMetricChartSeriesInput): Promise<MetricChartSeriesRow[]>;
+  /** 派生查询：一条 SQL 按桶对齐分子/分母算 ratio/diff，出单条派生线（#475 P3）。 */
+  queryDerivedSeries(input: QueryDerivedSeriesInput): Promise<MetricDerivedSeriesRow[]>;
   /** 关停时释放 DuckDB 连接与实例。 */
   close(): void;
 }

--- a/apps/metric/test/metric/metric-chart-query-schema.test.ts
+++ b/apps/metric/test/metric/metric-chart-query-schema.test.ts
@@ -108,6 +108,18 @@ describe("MetricChartQueryRequestSchema guards", () => {
     }
   });
 
+  it("counts points by the aligned bucket axis, not (end-start)/bucket (off-by-one guard)", () => {
+    // start/end 都不落桶边界：对齐补桶得 2001 个，旧的 floor(range/bucket)+1 只算 2000 会误放行。
+    const result = MetricChartQueryRequestSchema.safeParse({
+      metricName: "agent.tool.call",
+      aggregator: "count",
+      bucket: "10s",
+      startAt: "2026-01-01T00:00:09.999Z",
+      endAt: "2026-01-01T05:33:28.999Z",
+    });
+    expect(result.success).toBe(false);
+  });
+
   it("rejects a custom range wider than the max span", () => {
     const result = MetricChartQueryRequestSchema.safeParse({
       metricName: "agent.tool.call",

--- a/apps/metric/test/metric/metric-chart.impl.service.test.ts
+++ b/apps/metric/test/metric/metric-chart.impl.service.test.ts
@@ -145,6 +145,7 @@ function createMetricDao(overrides?: Partial<MetricDao>): MetricDao {
   return {
     insert: vi.fn().mockResolvedValue(undefined),
     queryChartSeries: vi.fn().mockResolvedValue([]),
+    queryDerivedSeries: vi.fn().mockResolvedValue([]),
     close: vi.fn(),
     ...overrides,
   };

--- a/apps/metric/test/metric/metric-derive-schema.test.ts
+++ b/apps/metric/test/metric/metric-derive-schema.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { MetricDeriveRequestSchema } from "@kagami/metric-api/derive";
+
+// 派生查询的硬边界 guard 全落在这份 wire schema 上（#475 P3）：显式范围必填、禁 rangePreset、
+// 算子只 ratio/diff、范围/点数上限复用 chart 的常量。
+
+const numerator = { metricName: "agent.tool.call", aggregator: "count" as const };
+const denominator = { metricName: "agent.tool.call", aggregator: "count" as const };
+
+function baseRequest(over: Record<string, unknown> = {}) {
+  return {
+    numerator,
+    denominator,
+    op: "ratio",
+    bucket: "1m",
+    startAt: "2026-04-02T00:00:00.000Z",
+    endAt: "2026-04-02T01:00:00.000Z",
+    ...over,
+  };
+}
+
+describe("MetricDeriveRequestSchema guards", () => {
+  it("accepts a valid ratio request with per-operand tag filters", () => {
+    const result = MetricDeriveRequestSchema.safeParse(
+      baseRequest({
+        numerator: {
+          metricName: "agent.tool.call",
+          aggregator: "count",
+          tagFilters: { tool: { op: "eq", value: "Wait" } },
+        },
+        op: "ratio",
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts diff and percentile operands", () => {
+    const result = MetricDeriveRequestSchema.safeParse(
+      baseRequest({
+        numerator: { metricName: "llm.latency", aggregator: "p95" },
+        denominator: { metricName: "llm.latency", aggregator: "p50" },
+        op: "diff",
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a rangePreset field (derive requires an explicit shared range)", () => {
+    const result = MetricDeriveRequestSchema.safeParse(baseRequest({ rangePreset: "1h" }));
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects when startAt / endAt is missing", () => {
+    const noStart = MetricDeriveRequestSchema.safeParse(baseRequest({ startAt: undefined }));
+    expect(noStart.success).toBe(false);
+  });
+
+  it("rejects an unknown op", () => {
+    const result = MetricDeriveRequestSchema.safeParse(baseRequest({ op: "product" }));
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects startAt after endAt", () => {
+    const result = MetricDeriveRequestSchema.safeParse(
+      baseRequest({
+        startAt: "2026-04-02T01:00:00.000Z",
+        endAt: "2026-04-02T00:00:00.000Z",
+      }),
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a range wider than the max span", () => {
+    const result = MetricDeriveRequestSchema.safeParse(
+      baseRequest({
+        bucket: "1h",
+        startAt: "2026-04-01T00:00:00.000Z",
+        endAt: "2026-04-04T00:00:00.000Z",
+      }),
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects when the point count exceeds the cap (2d @ 10s)", () => {
+    const result = MetricDeriveRequestSchema.safeParse(
+      baseRequest({
+        bucket: "10s",
+        startAt: "2026-04-02T00:00:00.000Z",
+        endAt: "2026-04-04T00:00:00.000Z",
+      }),
+    );
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/metric/test/metric/metric-derive-schema.test.ts
+++ b/apps/metric/test/metric/metric-derive-schema.test.ts
@@ -91,4 +91,16 @@ describe("MetricDeriveRequestSchema guards", () => {
     );
     expect(result.success).toBe(false);
   });
+
+  it("counts points by the aligned bucket axis, not (end-start)/bucket (off-by-one guard)", () => {
+    // start/end 都不落桶边界：对齐补桶得 2001 个，旧的 floor(range/bucket)+1 只算 2000 会误放行。
+    const result = MetricDeriveRequestSchema.safeParse(
+      baseRequest({
+        bucket: "10s",
+        startAt: "2026-01-01T00:00:09.999Z",
+        endAt: "2026-01-01T05:33:28.999Z",
+      }),
+    );
+    expect(result.success).toBe(false);
+  });
 });

--- a/apps/metric/test/metric/metric-derive.impl.service.test.ts
+++ b/apps/metric/test/metric/metric-derive.impl.service.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+import type { MetricDao, MetricDerivedSeriesRow } from "../../src/metric/infra/metric.dao.js";
+import { DefaultMetricDeriveService } from "../../src/metric/application/metric-derive.impl.service.js";
+
+// 派生服务纵切片：真实 buildSeries 补桶逻辑 + 打桩 DAO。验证 DAO 的每桶派生值被填进完整桶轴、
+// 缺桶补 null、出单条派生线。
+
+function createMetricDao(overrides?: Partial<MetricDao>): MetricDao {
+  return {
+    insert: vi.fn().mockResolvedValue(undefined),
+    queryChartSeries: vi.fn().mockResolvedValue([]),
+    queryDerivedSeries: vi.fn().mockResolvedValue([]),
+    close: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("DefaultMetricDeriveService", () => {
+  it("fills the full bucket axis and leaves gaps null as one derived series", async () => {
+    const rows: MetricDerivedSeriesRow[] = [
+      { bucketStart: new Date("2026-04-02T00:00:00.000Z"), value: 0.4 },
+      // 10:01 桶缺（DAO 未返回）→ 应补 null
+      { bucketStart: new Date("2026-04-02T00:02:00.000Z"), value: null }, // divzero → null
+    ];
+    const queryDerivedSeries = vi.fn().mockResolvedValue(rows);
+    const service = new DefaultMetricDeriveService({
+      metricDao: createMetricDao({ queryDerivedSeries }),
+    });
+
+    const response = await service.derive({
+      numerator: { metricName: "agent.tool.call", aggregator: "count" },
+      denominator: { metricName: "agent.tool.call", aggregator: "count" },
+      op: "ratio",
+      bucket: "1m",
+      startAt: "2026-04-02T00:00:00.000Z",
+      endAt: "2026-04-02T00:02:30.000Z",
+    });
+
+    expect(response.series).toHaveLength(1);
+    expect(response.series[0]?.points).toEqual([
+      { bucketStart: "2026-04-02T00:00:00.000Z", value: 0.4 },
+      { bucketStart: "2026-04-02T00:01:00.000Z", value: null },
+      { bucketStart: "2026-04-02T00:02:00.000Z", value: null },
+    ]);
+  });
+
+  it("passes the inline derive spec straight to the DAO with parsed dates and null tag filters", async () => {
+    const queryDerivedSeries = vi.fn().mockResolvedValue([]);
+    const service = new DefaultMetricDeriveService({
+      metricDao: createMetricDao({ queryDerivedSeries }),
+    });
+
+    await service.derive({
+      numerator: {
+        metricName: "agent.tool.call",
+        aggregator: "count",
+        tagFilters: { tool: { op: "eq", value: "Wait" } },
+      },
+      denominator: { metricName: "agent.tool.call", aggregator: "count" },
+      op: "ratio",
+      bucket: "1m",
+      startAt: "2026-04-02T00:00:00.000Z",
+      endAt: "2026-04-02T00:01:00.000Z",
+    });
+
+    expect(queryDerivedSeries).toHaveBeenCalledWith({
+      numerator: {
+        metricName: "agent.tool.call",
+        aggregator: "count",
+        tagFilters: { tool: { op: "eq", value: "Wait" } },
+      },
+      denominator: { metricName: "agent.tool.call", aggregator: "count", tagFilters: null },
+      op: "ratio",
+      startAt: new Date("2026-04-02T00:00:00.000Z"),
+      endAt: new Date("2026-04-02T00:01:00.000Z"),
+      bucket: "1m",
+    });
+  });
+});

--- a/apps/metric/test/metric/metric-derive.impl.service.test.ts
+++ b/apps/metric/test/metric/metric-derive.impl.service.test.ts
@@ -44,6 +44,23 @@ describe("DefaultMetricDeriveService", () => {
     ]);
   });
 
+  it("returns an empty series list when the DAO yields no rows (no data either side)", async () => {
+    const service = new DefaultMetricDeriveService({
+      metricDao: createMetricDao({ queryDerivedSeries: vi.fn().mockResolvedValue([]) }),
+    });
+
+    const response = await service.derive({
+      numerator: { metricName: "agent.tool.call", aggregator: "count" },
+      denominator: { metricName: "agent.tool.call", aggregator: "count" },
+      op: "ratio",
+      bucket: "1m",
+      startAt: "2026-04-02T00:00:00.000Z",
+      endAt: "2026-04-02T00:10:00.000Z",
+    });
+
+    expect(response.series).toEqual([]);
+  });
+
   it("passes the inline derive spec straight to the DAO with parsed dates and null tag filters", async () => {
     const queryDerivedSeries = vi.fn().mockResolvedValue([]);
     const service = new DefaultMetricDeriveService({

--- a/apps/metric/test/metric/metric.impl.dao.test.ts
+++ b/apps/metric/test/metric/metric.impl.dao.test.ts
@@ -3,7 +3,10 @@ import {
   DuckDbMetricDao,
   openMetricDuckDb,
 } from "../../src/metric/infra/impl/duckdb-metric.impl.dao.js";
-import type { QueryMetricChartSeriesInput } from "../../src/metric/infra/metric.dao.js";
+import type {
+  QueryDerivedSeriesInput,
+  QueryMetricChartSeriesInput,
+} from "../../src/metric/infra/metric.dao.js";
 
 // 用真·内存 DuckDB 端到端验证 DAO：插入 → queryChartSeries → 逐点断言输出，
 // 即「从 SQLite/Prisma 迁到 DuckDB」的行为等价保证（#475 P1）。
@@ -461,5 +464,156 @@ describe("DuckDbMetricDao", () => {
     expect(rows).toEqual([
       { bucketStart: iso("2026-07-06T10:00:00.000Z"), seriesKey: null, value: 1 },
     ]);
+  });
+
+  describe("queryDerivedSeries", () => {
+    const eq = (value: string) => ({ op: "eq" as const, value });
+    function baseDerive(over: Partial<QueryDerivedSeriesInput>): QueryDerivedSeriesInput {
+      return {
+        numerator: { metricName: METRIC, aggregator: "count", tagFilters: null },
+        denominator: { metricName: METRIC, aggregator: "count", tagFilters: null },
+        op: "ratio",
+        startAt: iso("2026-07-06T10:00:00.000Z"),
+        endAt: iso("2026-07-06T10:05:00.000Z"),
+        bucket: "1m",
+        ...over,
+      };
+    }
+
+    it("computes a ratio per bucket (Wait count / total count)", async () => {
+      for (const tool of ["Wait", "Wait", "Read", "Read", "Read"]) {
+        await dao.insert({
+          metricName: METRIC,
+          value: 1,
+          tags: { tool },
+          occurredAt: iso("2026-07-06T10:00:10.000Z"),
+        });
+      }
+
+      const rows = await dao.queryDerivedSeries(
+        baseDerive({
+          numerator: { metricName: METRIC, aggregator: "count", tagFilters: { tool: eq("Wait") } },
+          denominator: { metricName: METRIC, aggregator: "count", tagFilters: null },
+          op: "ratio",
+        }),
+      );
+
+      expect(rows).toEqual([{ bucketStart: iso("2026-07-06T10:00:00.000Z"), value: 0.4 }]);
+    });
+
+    it("computes a diff per bucket (total - Wait)", async () => {
+      for (const tool of ["Wait", "Wait", "Read", "Read", "Read"]) {
+        await dao.insert({
+          metricName: METRIC,
+          value: 1,
+          tags: { tool },
+          occurredAt: iso("2026-07-06T10:00:10.000Z"),
+        });
+      }
+
+      const rows = await dao.queryDerivedSeries(
+        baseDerive({
+          numerator: { metricName: METRIC, aggregator: "count", tagFilters: null },
+          denominator: {
+            metricName: METRIC,
+            aggregator: "count",
+            tagFilters: { tool: eq("Wait") },
+          },
+          op: "diff",
+        }),
+      );
+
+      expect(rows).toEqual([{ bucketStart: iso("2026-07-06T10:00:00.000Z"), value: 3 }]);
+    });
+
+    it("yields null on division by zero (NULLIF guards the denominator)", async () => {
+      // 分母 sum = +7 + (-7) = 0；分子 count = 2。ratio 该桶应为 null，而非 Infinity / 报错。
+      await dao.insert({
+        metricName: METRIC,
+        value: 7,
+        tags: {},
+        occurredAt: iso("2026-07-06T10:00:10.000Z"),
+      });
+      await dao.insert({
+        metricName: METRIC,
+        value: -7,
+        tags: {},
+        occurredAt: iso("2026-07-06T10:00:20.000Z"),
+      });
+
+      const rows = await dao.queryDerivedSeries(
+        baseDerive({
+          numerator: { metricName: METRIC, aggregator: "count", tagFilters: null },
+          denominator: { metricName: METRIC, aggregator: "sum", tagFilters: null },
+          op: "ratio",
+        }),
+      );
+
+      expect(rows).toEqual([{ bucketStart: iso("2026-07-06T10:00:00.000Z"), value: null }]);
+    });
+
+    it("yields null for a bucket where only one side has data (NULL propagation)", async () => {
+      // 分子在 10:00 桶、分母在 10:02 桶：FULL OUTER JOIN 出两桶，各有一侧 NULL → 两桶都 null。
+      await dao.insert({
+        metricName: METRIC,
+        value: 1,
+        tags: { tool: "Wait" },
+        occurredAt: iso("2026-07-06T10:00:10.000Z"),
+      });
+      await dao.insert({
+        metricName: METRIC,
+        value: 1,
+        tags: { tool: "Read" },
+        occurredAt: iso("2026-07-06T10:02:10.000Z"),
+      });
+
+      const rows = await dao.queryDerivedSeries(
+        baseDerive({
+          numerator: { metricName: METRIC, aggregator: "count", tagFilters: { tool: eq("Wait") } },
+          denominator: {
+            metricName: METRIC,
+            aggregator: "count",
+            tagFilters: { tool: eq("Read") },
+          },
+          op: "ratio",
+        }),
+      );
+
+      expect(rows).toEqual([
+        { bucketStart: iso("2026-07-06T10:00:00.000Z"), value: null },
+        { bucketStart: iso("2026-07-06T10:02:00.000Z"), value: null },
+      ]);
+    });
+
+    it("supports last aggregator operands", async () => {
+      await dao.insert({
+        metricName: METRIC,
+        value: 8,
+        tags: { kind: "num" },
+        occurredAt: iso("2026-07-06T10:00:10.000Z"),
+      });
+      await dao.insert({
+        metricName: METRIC,
+        value: 20,
+        tags: { kind: "num" },
+        occurredAt: iso("2026-07-06T10:00:50.000Z"), // last num = 20
+      });
+      await dao.insert({
+        metricName: METRIC,
+        value: 4,
+        tags: { kind: "den" },
+        occurredAt: iso("2026-07-06T10:00:50.000Z"), // last den = 4
+      });
+
+      const rows = await dao.queryDerivedSeries(
+        baseDerive({
+          numerator: { metricName: METRIC, aggregator: "last", tagFilters: { kind: eq("num") } },
+          denominator: { metricName: METRIC, aggregator: "last", tagFilters: { kind: eq("den") } },
+          op: "ratio",
+        }),
+      );
+
+      expect(rows).toEqual([{ bucketStart: iso("2026-07-06T10:00:00.000Z"), value: 5 }]);
+    });
   });
 });

--- a/apps/web/src/components/metric/useMetricDerivedData.ts
+++ b/apps/web/src/components/metric/useMetricDerivedData.ts
@@ -1,0 +1,26 @@
+import { MetricChartQueryResponseSchema } from "@kagami/metric-api/chart";
+import { metricApiContract } from "@kagami/metric-api/contract";
+import { type MetricDeriveRequest } from "@kagami/metric-api/derive";
+import { contractUrl } from "@kagami/http/url";
+import { useQuery } from "@tanstack/react-query";
+import { apiPostWithSchema } from "@/lib/api";
+import { queryKeys } from "@/lib/query";
+
+// === 派生取数层（#475 P3）===
+//
+// 与 useMetricChartData 同构：把内联的「分子/分母 + 算子」派生规格 POST 给 /metric/derive，出单条
+// 派生线（复用 query 的整洁序列响应），交给同一套 <MetricChartView> 展示。派生线的 label / 颜色由
+// 使用处（recipe）就近声明覆盖，后端只给中性兜底 label。
+
+export function useMetricDerivedData(request: MetricDeriveRequest, enabled = true) {
+  return useQuery({
+    queryKey: queryKeys.metricChart.derived(request),
+    queryFn: () =>
+      apiPostWithSchema(
+        contractUrl(metricApiContract.derive),
+        request,
+        MetricChartQueryResponseSchema,
+      ),
+    enabled,
+  });
+}

--- a/apps/web/src/lib/query.ts
+++ b/apps/web/src/lib/query.ts
@@ -52,6 +52,7 @@ export const queryKeys = {
   },
   metricChart: {
     data: (request: unknown) => ["metric-chart", "data", request] as const,
+    derived: (request: unknown) => ["metric-chart", "derived", request] as const,
   },
   mainAgentContext: {
     recent: () => ["main-agent-context", "recent"] as const,

--- a/packages/metric-api/src/chart.ts
+++ b/packages/metric-api/src/chart.ts
@@ -80,9 +80,17 @@ const BUCKET_MILLISECONDS: Record<MetricChartBucket, number> = {
   "1h": 60 * 60 * 1000,
 };
 
-/** bucket 枚举 → 毫秒。供派生查询（#475 P3）等复用同一份点数 guard。 */
-export function metricChartBucketToMilliseconds(bucket: MetricChartBucket): number {
-  return BUCKET_MILLISECONDS[bucket];
+/**
+ * start / end 各向下对齐到桶边界后的闭区间桶数（= 服务端 listBucketStarts 的长度）。点数 guard 必须
+ * 用这个而非 `floor((end-start)/bucket)+1`：后者在 start/end 未对齐桶边界时会少算 1，放过越界请求。
+ */
+export function metricChartAlignedBucketCount(
+  startMs: number,
+  endMs: number,
+  bucket: MetricChartBucket,
+): number {
+  const bucketMs = BUCKET_MILLISECONDS[bucket];
+  return Math.floor(endMs / bucketMs) - Math.floor(startMs / bucketMs) + 1;
 }
 
 const RANGE_PRESET_MILLISECONDS: Record<MetricChartRangePreset, number> = {
@@ -142,8 +150,12 @@ export const MetricChartQueryRequestSchema = z
     }
 
     let rangeMs: number;
+    let points: number;
     if (value.rangePreset) {
       rangeMs = RANGE_PRESET_MILLISECONDS[value.rangePreset];
+      // preset 的实际 start/end 在查询时才定（now()），此处无法对齐桶边界；用 range 近似（+1 容差无害，
+      // 且会超 2000 的 preset×bucket 组合本就被拒）。
+      points = Math.floor(rangeMs / BUCKET_MILLISECONDS[value.bucket]) + 1;
     } else if (value.startAt && value.endAt) {
       const startAt = new Date(value.startAt).getTime();
       const endAt = new Date(value.endAt).getTime();
@@ -156,6 +168,7 @@ export const MetricChartQueryRequestSchema = z
         return;
       }
       rangeMs = endAt - startAt;
+      points = metricChartAlignedBucketCount(startAt, endAt, value.bucket);
     } else {
       return;
     }
@@ -169,8 +182,6 @@ export const MetricChartQueryRequestSchema = z
       return;
     }
 
-    // 与服务端 listBucketStarts 的闭区间桶数对齐（floor(range/b)+1），避免 guard 比实际桶数少算 1。
-    const points = Math.floor(rangeMs / BUCKET_MILLISECONDS[value.bucket]) + 1;
     if (points > METRIC_CHART_MAX_POINTS) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,

--- a/packages/metric-api/src/chart.ts
+++ b/packages/metric-api/src/chart.ts
@@ -80,6 +80,11 @@ const BUCKET_MILLISECONDS: Record<MetricChartBucket, number> = {
   "1h": 60 * 60 * 1000,
 };
 
+/** bucket 枚举 → 毫秒。供派生查询（#475 P3）等复用同一份点数 guard。 */
+export function metricChartBucketToMilliseconds(bucket: MetricChartBucket): number {
+  return BUCKET_MILLISECONDS[bucket];
+}
+
 const RANGE_PRESET_MILLISECONDS: Record<MetricChartRangePreset, number> = {
   "1m": 60 * 1000,
   "10m": 10 * 60 * 1000,

--- a/packages/metric-api/src/contract.ts
+++ b/packages/metric-api/src/contract.ts
@@ -1,5 +1,6 @@
 import { defineJsonRoute } from "@kagami/http/contract";
 import { MetricChartQueryRequestSchema, MetricChartQueryResponseSchema } from "./chart.js";
+import { MetricDeriveRequestSchema } from "./derive.js";
 import { RecordMetricRequestSchema, RecordMetricResponseSchema } from "./record.js";
 
 // === @kagami/metric-api：kagami-metric 服务的 HTTP 契约（issue #279 PR3 / #444） ===
@@ -22,6 +23,13 @@ export const metricApiContract = {
     method: "POST",
     path: "/metric/query",
     input: MetricChartQueryRequestSchema,
+    output: MetricChartQueryResponseSchema,
+  }),
+  // 派生查询（#475 P3）：分子/分母两份规格算 ratio/diff，出单条派生线（复用 query 的整洁序列响应）。
+  derive: defineJsonRoute({
+    method: "POST",
+    path: "/metric/derive",
+    input: MetricDeriveRequestSchema,
     output: MetricChartQueryResponseSchema,
   }),
 } as const;

--- a/packages/metric-api/src/derive.ts
+++ b/packages/metric-api/src/derive.ts
@@ -1,0 +1,91 @@
+import { z } from "zod";
+import {
+  MetricChartAggregatorSchema,
+  MetricChartBucketSchema,
+  MetricChartTagFiltersSchema,
+  METRIC_CHART_MAX_POINTS,
+  METRIC_CHART_MAX_RANGE_MS,
+  metricChartBucketToMilliseconds,
+} from "./chart.js";
+
+// === Metric 派生查询 wire schema（#475 P3）===
+//
+// 单指标查询物理上出不了「两个数相除」（Wait 占全部调用的比例、错误率）。派生原语补这一层：
+// 分子 / 分母各一份聚合规格，**共享 bucket + 显式时间范围**，后端一条 DuckDB SQL 按桶对齐算
+// ratio / diff（NULLIF 除零、缺桶→null，语义在一条 SQL 里定死一次）。
+//
+// 硬边界：
+// - 算子只 `ratio` / `diff` 两个枚举，永不长成表达式 DSL（YAGNI 红线）。
+// - **禁用 rangePreset**：分子分母必须落在同一 range，服务端两次 `new Date()` 会错位（对抗审查
+//   catch），故只接显式 startAt / endAt。
+// - 出「整洁序列」单条派生线，复用 MetricChartQueryResponse（series 恰一条）；派生线的 label /
+//   颜色归前端，wire 不加 color。
+
+export const MetricDeriveOperandSchema = z
+  .object({
+    metricName: z.string().trim().min(1),
+    aggregator: MetricChartAggregatorSchema,
+    tagFilters: MetricChartTagFiltersSchema.optional(),
+  })
+  .strict();
+
+export type MetricDeriveOperand = z.infer<typeof MetricDeriveOperandSchema>;
+
+export const MetricDeriveOpSchema = z.enum(["ratio", "diff"]);
+
+export type MetricDeriveOp = z.infer<typeof MetricDeriveOpSchema>;
+
+export const MetricDeriveRequestSchema = z
+  .object({
+    numerator: MetricDeriveOperandSchema,
+    denominator: MetricDeriveOperandSchema,
+    op: MetricDeriveOpSchema,
+    bucket: MetricChartBucketSchema,
+    // 仅显式范围，无 rangePreset（分子分母共享同一 range）。
+    startAt: z.string().datetime({ offset: true }),
+    endAt: z.string().datetime({ offset: true }),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    const startAt = new Date(value.startAt).getTime();
+    const endAt = new Date(value.endAt).getTime();
+    // datetime({offset}) 通常已挡，这里兜住 `new Date` 得到 Invalid 的越界偏移（如 +99:00）。
+    if (Number.isNaN(startAt) || Number.isNaN(endAt)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["startAt"],
+        message: "startAt / endAt 不是合法时间",
+      });
+      return;
+    }
+
+    if (startAt > endAt) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["startAt"],
+        message: "startAt must be less than or equal to endAt",
+      });
+      return;
+    }
+
+    const rangeMs = endAt - startAt;
+    if (rangeMs > METRIC_CHART_MAX_RANGE_MS) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["startAt"],
+        message: `时间跨度不能超过 ${METRIC_CHART_MAX_RANGE_MS / (24 * 60 * 60 * 1000)} 天`,
+      });
+      return;
+    }
+
+    const points = Math.floor(rangeMs / metricChartBucketToMilliseconds(value.bucket)) + 1;
+    if (points > METRIC_CHART_MAX_POINTS) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["bucket"],
+        message: `点数超限（${points} > ${METRIC_CHART_MAX_POINTS}），请增大 bucket 或缩短范围`,
+      });
+    }
+  });
+
+export type MetricDeriveRequest = z.infer<typeof MetricDeriveRequestSchema>;

--- a/packages/metric-api/src/derive.ts
+++ b/packages/metric-api/src/derive.ts
@@ -5,7 +5,7 @@ import {
   MetricChartTagFiltersSchema,
   METRIC_CHART_MAX_POINTS,
   METRIC_CHART_MAX_RANGE_MS,
-  metricChartBucketToMilliseconds,
+  metricChartAlignedBucketCount,
 } from "./chart.js";
 
 // === Metric 派生查询 wire schema（#475 P3）===
@@ -78,7 +78,7 @@ export const MetricDeriveRequestSchema = z
       return;
     }
 
-    const points = Math.floor(rangeMs / metricChartBucketToMilliseconds(value.bucket)) + 1;
+    const points = metricChartAlignedBucketCount(startAt, endAt, value.bucket);
     if (points > METRIC_CHART_MAX_POINTS) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,


### PR DESCRIPTION
## 背景

Epic [#475](https://github.com/KisinTheFlame/kagami/issues/475) P3。单指标查询（P1/P2）物理上出不了「两个数相除」——Wait 占全部调用的比例、错误率、p95-p50 差。派生原语补这一层。

## 改动

**新端点 `POST /metric/derive`**：入 `{ numerator, denominator, op, bucket, startAt, endAt }`，分子/分母各一份聚合规格（metricName / aggregator / tagFilters），**共享 bucket + 显式时间范围**，出单条派生线（复用 `MetricChartQueryResponse` 整洁序列，P4 适配器可直接吃）。

**一条 DuckDB SQL 定死对齐/缺桶/除零语义**：
- 两操作数各压成 per-bucket 标量 CTE（复用 P1/P2 的 where / 聚合 / last row_number 逻辑）。
- `FULL OUTER JOIN` 按桶对齐；`ratio` = `num / NULLIF(den, 0)`（挡除零），`diff` = `num - den`。
- 两者都靠 SQL 的 NULL 传播：任一侧该桶无数据即结果 null，前端断线、不臆造 0。

**硬边界（对齐 spec 红线）**：
- 算子只 `ratio` / `diff` 枚举，永不长成表达式 DSL。
- **禁 rangePreset**：分子分母必须落同一 range，服务端两次 `new Date()` 会错位（对抗审查早先 catch），故只接显式 startAt/endAt。范围/点数 guard 复用 chart 常量。
- 派生线 label/颜色归前端，wire 不加 color；后端只给中性兜底 label。

**接线 / 复用**：
- 抽 `bucket-time.ts` 共享桶轴助手（chart 与 derive 同口径补桶，避免漂移）；generalize `buildWhereClause` 到单查询/操作数通用。
- gateway `METRIC_PATH_PREFIXES` 加 `/metric/derive`（防 #444 类前缀漏配 404）。
- 前端 `useMetricDerivedData` hook（与 useMetricChartData 同构）。

## 测试
- DAO 真·DuckDB：ratio（Wait 占比 0.4）/ diff / 除零→null / 单侧缺桶→null / last 操作数。
- wire schema：禁 rangePreset、必填范围、算子枚举、范围/点数上限。
- service：DAO 每桶派生值填进完整桶轴、缺桶补 null、出单线。
- 五件套 + 全量 201 文件全绿。

## 边界
- 不动 agent 上下文（KV 红线）。纯查询增量、无迁移无新依赖 → 部署可单服务 `app:deploy metric`。
- 图表适配器（bar/pie/stacked）是 P4，本 PR 不含。

Refs #475