### PR TITLE
feat(web): metric 图表类型适配器 line/bar/stacked/pie（#475 P4）

### DIFF
--- a/apps/web/src/components/metric/MetricChart.tsx
+++ b/apps/web/src/components/metric/MetricChart.tsx
@@ -16,7 +16,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { getApiErrorMessage } from "@/lib/api";
-import { MetricChartView } from "./MetricChartView";
+import { MetricChartView, type MetricChartType } from "./MetricChartView";
 import { useMetricChartData } from "./useMetricChartData";
 
 // === 组合层：拥有 range / bucket 控件 + 手动刷新，调 hook 取数、渲染 View（#444）===
@@ -35,6 +35,8 @@ type MetricChartProps = {
   defaultRangePreset?: MetricChartRangePreset;
   /** 缺省按 range 自动选桶。 */
   defaultBucket?: MetricChartBucket;
+  /** 画法，默认折线（#475 P4）。饼图/堆叠构成宜配单桶（bucket 覆盖整段范围）。 */
+  chartType?: MetricChartType;
   height?: number;
 };
 
@@ -79,6 +81,7 @@ export function MetricChart({
   groupByTag,
   defaultRangePreset = "1h",
   defaultBucket,
+  chartType,
   height,
 }: MetricChartProps) {
   const [rangePreset, setRangePreset] = useState<MetricChartRangePreset>(defaultRangePreset);
@@ -123,6 +126,7 @@ export function MetricChart({
       isError={query.isError}
       errorMessage={query.isError ? getApiErrorMessage(query.error) : undefined}
       data={query.data}
+      chartType={chartType}
       height={height}
       headerRight={
         <div className="flex flex-wrap items-center gap-2">

--- a/apps/web/src/components/metric/MetricChartView.tsx
+++ b/apps/web/src/components/metric/MetricChartView.tsx
@@ -1,6 +1,17 @@
 import { type MetricChartQueryResponse, type MetricChartSeries } from "@kagami/metric-api/chart";
 import { useMemo } from "react";
-import { CartesianGrid, Line, LineChart, XAxis, YAxis } from "recharts";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Line,
+  LineChart,
+  Pie,
+  PieChart,
+  XAxis,
+  YAxis,
+} from "recharts";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   ChartContainer,
@@ -12,6 +23,13 @@ import {
 } from "@/components/ui/chart";
 
 // === 纯展示层：只吃 data / 查询状态 + 展示 props，不发请求、不持控件状态（#444）===
+//
+// 图表类型适配器（#475 P4）：同一份「整洁序列」按 chartType 换画法——line/bar/stacked 走「桶 × 序列」
+// 矩阵（x=时间），pie 走单值构成（每序列塌成一个切片，x=类别）。查询侧不变；pie/stacked 的构成语义
+// 由使用处用「单桶查询」（bucket 覆盖整段范围）喂进来，这里只负责渲染。
+
+/** 图表画法。line/bar/stacked = 时序（x=桶）；pie = 构成（每序列一片）。 */
+export type MetricChartType = "line" | "bar" | "stacked" | "pie";
 
 type MetricChartViewProps = {
   title: string;
@@ -21,6 +39,8 @@ type MetricChartViewProps = {
   isError: boolean;
   errorMessage?: string;
   data?: MetricChartQueryResponse;
+  /** 画法，默认折线。 */
+  chartType?: MetricChartType;
   /** 图表区高度（px），默认 288（h-72）。 */
   height?: number;
 };
@@ -30,7 +50,7 @@ type ChartRow = {
   bucketStart: string;
 } & Record<string, number | string | null>;
 
-type RenderSeries = MetricChartSeries & {
+export type RenderSeries = MetricChartSeries & {
   dataKey: string;
 };
 
@@ -55,6 +75,7 @@ export function MetricChartView({
   isError,
   errorMessage,
   data,
+  chartType = "line",
   height = 288,
 }: MetricChartViewProps) {
   const renderSeries = useMemo<RenderSeries[]>(
@@ -63,6 +84,7 @@ export function MetricChartView({
   );
   const chartConfig = useMemo(() => buildChartConfig(renderSeries), [renderSeries]);
   const rows = useMemo(() => buildChartRows(renderSeries), [renderSeries]);
+  const pieData = useMemo(() => buildPieData(renderSeries), [renderSeries]);
   const hasSeries = (data?.series.length ?? 0) > 0;
   const placeholderClassName = "flex items-center justify-center rounded-none border border-dashed";
   const placeholderStyle = { height };
@@ -100,46 +122,102 @@ export function MetricChartView({
         {!isLoading && !isError && hasSeries && data ? (
           <>
             <ChartContainer className="w-full" style={{ height }} config={chartConfig}>
-              <LineChart data={rows} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
-                <CartesianGrid vertical={false} />
-                <XAxis dataKey="bucketLabel" tickLine={false} axisLine={false} minTickGap={24} />
-                <YAxis
-                  width={56}
-                  tickLine={false}
-                  axisLine={false}
-                  tickFormatter={(value: number | string) => formatMetricValue(value)}
-                />
-                <ChartTooltip
-                  content={
-                    <ChartTooltipContent
-                      indicator="line"
-                      labelFormatter={(_label, payload) => {
-                        const entry = payload?.[0]?.payload as
-                          | { bucketStart?: unknown }
-                          | undefined;
-                        const bucketStart = entry?.bucketStart;
-                        return typeof bucketStart === "string"
-                          ? formatFullDateTime(bucketStart)
-                          : "未知时间";
-                      }}
-                    />
-                  }
-                />
-                <ChartLegend content={<ChartLegendContent />} />
-                {renderSeries.map(series => (
-                  <Line
-                    key={series.key}
-                    type="monotone"
-                    dataKey={series.dataKey}
-                    name={series.label}
-                    stroke={`var(--color-${series.dataKey})`}
-                    strokeWidth={2}
-                    dot={false}
-                    connectNulls={false}
+              {chartType === "pie" ? (
+                <PieChart>
+                  <ChartTooltip content={<ChartTooltipContent nameKey="name" />} />
+                  <ChartLegend content={<ChartLegendContent nameKey="name" />} />
+                  <Pie
+                    data={pieData}
+                    dataKey="value"
+                    nameKey="name"
+                    outerRadius="80%"
                     isAnimationActive={false}
+                  >
+                    {pieData.map(slice => (
+                      <Cell key={slice.name} fill={slice.fill} />
+                    ))}
+                  </Pie>
+                </PieChart>
+              ) : chartType === "bar" || chartType === "stacked" ? (
+                <BarChart data={rows} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+                  <CartesianGrid vertical={false} />
+                  <XAxis dataKey="bucketLabel" tickLine={false} axisLine={false} minTickGap={24} />
+                  <YAxis
+                    width={56}
+                    tickLine={false}
+                    axisLine={false}
+                    tickFormatter={(value: number | string) => formatMetricValue(value)}
                   />
-                ))}
-              </LineChart>
+                  <ChartTooltip
+                    content={
+                      <ChartTooltipContent
+                        labelFormatter={(_label, payload) => {
+                          const entry = payload?.[0]?.payload as
+                            | { bucketStart?: unknown }
+                            | undefined;
+                          const bucketStart = entry?.bucketStart;
+                          return typeof bucketStart === "string"
+                            ? formatFullDateTime(bucketStart)
+                            : "未知时间";
+                        }}
+                      />
+                    }
+                  />
+                  <ChartLegend content={<ChartLegendContent />} />
+                  {renderSeries.map(series => (
+                    <Bar
+                      key={series.key}
+                      dataKey={series.dataKey}
+                      name={series.label}
+                      fill={`var(--color-${series.dataKey})`}
+                      // stacked：所有序列共用一个 stackId 叠成构成条；bar：各自成组。
+                      stackId={chartType === "stacked" ? "stack" : undefined}
+                      isAnimationActive={false}
+                    />
+                  ))}
+                </BarChart>
+              ) : (
+                <LineChart data={rows} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+                  <CartesianGrid vertical={false} />
+                  <XAxis dataKey="bucketLabel" tickLine={false} axisLine={false} minTickGap={24} />
+                  <YAxis
+                    width={56}
+                    tickLine={false}
+                    axisLine={false}
+                    tickFormatter={(value: number | string) => formatMetricValue(value)}
+                  />
+                  <ChartTooltip
+                    content={
+                      <ChartTooltipContent
+                        indicator="line"
+                        labelFormatter={(_label, payload) => {
+                          const entry = payload?.[0]?.payload as
+                            | { bucketStart?: unknown }
+                            | undefined;
+                          const bucketStart = entry?.bucketStart;
+                          return typeof bucketStart === "string"
+                            ? formatFullDateTime(bucketStart)
+                            : "未知时间";
+                        }}
+                      />
+                    }
+                  />
+                  <ChartLegend content={<ChartLegendContent />} />
+                  {renderSeries.map(series => (
+                    <Line
+                      key={series.key}
+                      type="monotone"
+                      dataKey={series.dataKey}
+                      name={series.label}
+                      stroke={`var(--color-${series.dataKey})`}
+                      strokeWidth={2}
+                      dot={false}
+                      connectNulls={false}
+                      isAnimationActive={false}
+                    />
+                  ))}
+                </LineChart>
+              )}
             </ChartContainer>
 
             <div className="flex flex-wrap justify-between gap-3 text-xs text-muted-foreground">
@@ -169,7 +247,21 @@ function buildChartConfig(series: RenderSeries[]): ChartConfig {
   );
 }
 
-function buildChartRows(series: RenderSeries[]): ChartRow[] {
+type PieSlice = { name: string; value: number; fill: string };
+
+/**
+ * pie 构成数据：每序列塌成一个切片，值 = 其各点之和（null 记 0）。饼图走「单桶查询」（bucket 覆盖
+ * 整段范围）时每序列恰一个点，求和即那个值；多桶数据传进来则等价于对整段求和。
+ */
+export function buildPieData(series: RenderSeries[]): PieSlice[] {
+  return series.map((item, index) => ({
+    name: item.label,
+    value: item.points.reduce((sum, point) => sum + (point.value ?? 0), 0),
+    fill: seriesColors[index % seriesColors.length],
+  }));
+}
+
+export function buildChartRows(series: RenderSeries[]): ChartRow[] {
   const rowsByBucketStart = new Map<string, ChartRow>();
 
   for (const item of series) {

--- a/apps/web/src/components/metric/MetricChartView.tsx
+++ b/apps/web/src/components/metric/MetricChartView.tsx
@@ -85,7 +85,17 @@ export function MetricChartView({
   const chartConfig = useMemo(() => buildChartConfig(renderSeries), [renderSeries]);
   const rows = useMemo(() => buildChartRows(renderSeries), [renderSeries]);
   const pieData = useMemo(() => buildPieData(renderSeries), [renderSeries]);
-  const hasSeries = (data?.series.length ?? 0) > 0;
+  // 饼图图例经 chartConfig[name].label 取字（config 按 slice name 键控，非 dataKey）；颜色仍走 Cell fill。
+  const pieChartConfig = useMemo<ChartConfig>(
+    () =>
+      Object.fromEntries(
+        pieData.map(slice => [slice.name, { label: slice.name, color: slice.fill }]),
+      ),
+    [pieData],
+  );
+  const pieTotal = pieData.reduce((sum, slice) => sum + slice.value, 0);
+  // 饼图额外要求构成总量 > 0（全 0 会让 recharts 角度算成 NaN、画出空白饼图但 series 非空）。
+  const hasRenderable = chartType === "pie" ? pieTotal > 0 : (data?.series.length ?? 0) > 0;
   const placeholderClassName = "flex items-center justify-center rounded-none border border-dashed";
   const placeholderStyle = { height };
 
@@ -113,15 +123,19 @@ export function MetricChartView({
           </div>
         ) : null}
 
-        {!isLoading && !isError && !hasSeries ? (
+        {!isLoading && !isError && !hasRenderable ? (
           <div className={placeholderClassName} style={placeholderStyle}>
             <p className="text-sm text-muted-foreground">当前时间范围内没有数据。</p>
           </div>
         ) : null}
 
-        {!isLoading && !isError && hasSeries && data ? (
+        {!isLoading && !isError && hasRenderable && data ? (
           <>
-            <ChartContainer className="w-full" style={{ height }} config={chartConfig}>
+            <ChartContainer
+              className="w-full"
+              style={{ height }}
+              config={chartType === "pie" ? pieChartConfig : chartConfig}
+            >
               {chartType === "pie" ? (
                 <PieChart>
                   <ChartTooltip content={<ChartTooltipContent nameKey="name" />} />
@@ -134,12 +148,18 @@ export function MetricChartView({
                     isAnimationActive={false}
                   >
                     {pieData.map(slice => (
-                      <Cell key={slice.name} fill={slice.fill} />
+                      <Cell key={slice.dataKey} fill={slice.fill} />
                     ))}
                   </Pie>
                 </PieChart>
               ) : chartType === "bar" || chartType === "stacked" ? (
-                <BarChart data={rows} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+                <BarChart
+                  data={rows}
+                  margin={{ top: 8, right: 16, left: 0, bottom: 0 }}
+                  // stacked 用 sign offset：负值（min/avg/diff 派生可产生）按 0 轴上下分离，不在同一
+                  // 累计基线回退画错。grouped bar 不堆叠，offset 无影响。
+                  stackOffset={chartType === "stacked" ? "sign" : "none"}
+                >
                   <CartesianGrid vertical={false} />
                   <XAxis dataKey="bucketLabel" tickLine={false} axisLine={false} minTickGap={24} />
                   <YAxis
@@ -247,16 +267,19 @@ function buildChartConfig(series: RenderSeries[]): ChartConfig {
   );
 }
 
-type PieSlice = { name: string; value: number; fill: string };
+type PieSlice = { dataKey: string; name: string; value: number; fill: string };
 
 /**
- * pie 构成数据：每序列塌成一个切片，值 = 其各点之和（null 记 0）。饼图走「单桶查询」（bucket 覆盖
- * 整段范围）时每序列恰一个点，求和即那个值；多桶数据传进来则等价于对整段求和。
+ * pie 构成数据：每序列塌成一个切片，值 = 其各点之和的**绝对量**（null 记 0）。饼图走「单桶查询」
+ * （bucket 覆盖整段范围）时每序列恰一个点，求和即那个值。取绝对量是因为饼图表达「部分占整体」，
+ * 负值（min/avg 聚合或 P3 diff 派生可产生）无构成语义——recharts 会把负值画成负角度/反向切片、且把
+ * 负值计入分母扭曲占比。饼图应配非负 metric，这里对误用做兜底。dataKey 供稳定 React key（label 不保唯一）。
  */
 export function buildPieData(series: RenderSeries[]): PieSlice[] {
   return series.map((item, index) => ({
+    dataKey: item.dataKey,
     name: item.label,
-    value: item.points.reduce((sum, point) => sum + (point.value ?? 0), 0),
+    value: Math.abs(item.points.reduce((sum, point) => sum + (point.value ?? 0), 0)),
     fill: seriesColors[index % seriesColors.length],
   }));
 }

--- a/apps/web/test/metric-chart-data.test.ts
+++ b/apps/web/test/metric-chart-data.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildChartRows,
+  buildPieData,
+  type RenderSeries,
+} from "@/components/metric/MetricChartView";
+
+// 图表类型适配器的纯数据变换（#475 P4）：line/bar/stacked 共用「桶 × 序列」矩阵，pie 塌成每序列一值。
+
+const series: RenderSeries[] = [
+  {
+    key: "Read",
+    label: "Read",
+    dataKey: "series_0",
+    points: [
+      { bucketStart: "2026-04-02T00:00:00.000Z", value: 2 },
+      { bucketStart: "2026-04-02T00:01:00.000Z", value: 3 },
+    ],
+  },
+  {
+    key: "Wait",
+    label: "Wait",
+    dataKey: "series_1",
+    points: [
+      { bucketStart: "2026-04-02T00:00:00.000Z", value: 5 },
+      { bucketStart: "2026-04-02T00:01:00.000Z", value: null },
+    ],
+  },
+];
+
+describe("buildPieData", () => {
+  it("collapses each series to the sum of its points (null counted as 0)", () => {
+    const slices = buildPieData(series);
+    expect(slices.map(slice => ({ name: slice.name, value: slice.value }))).toEqual([
+      { name: "Read", value: 5 },
+      { name: "Wait", value: 5 },
+    ]);
+  });
+
+  it("assigns a distinct fill per slice from the series palette", () => {
+    const slices = buildPieData(series);
+    expect(slices[0]?.fill).toBe("hsl(var(--llm))");
+    expect(slices[1]?.fill).toBe("hsl(var(--signal))");
+    expect(slices[0]?.fill).not.toBe(slices[1]?.fill);
+  });
+});
+
+describe("buildChartRows", () => {
+  it("pivots series into per-bucket rows keyed by dataKey, sorted by bucketStart", () => {
+    const rows = buildChartRows(series);
+    expect(rows).toEqual([
+      {
+        bucketLabel: rows[0]?.bucketLabel,
+        bucketStart: "2026-04-02T00:00:00.000Z",
+        series_0: 2,
+        series_1: 5,
+      },
+      {
+        bucketLabel: rows[1]?.bucketLabel,
+        bucketStart: "2026-04-02T00:01:00.000Z",
+        series_0: 3,
+        series_1: null,
+      },
+    ]);
+  });
+});

--- a/apps/web/test/metric-chart-data.test.ts
+++ b/apps/web/test/metric-chart-data.test.ts
@@ -29,12 +29,28 @@ const series: RenderSeries[] = [
 ];
 
 describe("buildPieData", () => {
-  it("collapses each series to the sum of its points (null counted as 0)", () => {
+  it("collapses each series to the sum of its points (null counted as 0) with a stable dataKey", () => {
     const slices = buildPieData(series);
-    expect(slices.map(slice => ({ name: slice.name, value: slice.value }))).toEqual([
-      { name: "Read", value: 5 },
-      { name: "Wait", value: 5 },
+    expect(slices).toEqual([
+      { dataKey: "series_0", name: "Read", value: 5, fill: "hsl(var(--llm))" },
+      { dataKey: "series_1", name: "Wait", value: 5, fill: "hsl(var(--signal))" },
     ]);
+  });
+
+  it("takes the absolute magnitude so negative series still render a slice", () => {
+    const negative: RenderSeries[] = [
+      {
+        key: "delta",
+        label: "delta",
+        dataKey: "series_0",
+        points: [
+          { bucketStart: "2026-04-02T00:00:00.000Z", value: -7 },
+          { bucketStart: "2026-04-02T00:01:00.000Z", value: 2 },
+        ],
+      },
+    ];
+    // sum = -5 → 绝对量 5（饼图切片不能是负角度）。
+    expect(buildPieData(negative)[0]?.value).toBe(5);
   });
 
   it("assigns a distinct fill per slice from the series palette", () => {


### PR DESCRIPTION
## 背景

Epic [#475](https://github.com/KisinTheFlame/kagami/issues/475) P4（末阶段）。P1-P3 把查询/派生层建齐，本 PR 补展示侧：同一份「整洁序列」按图表类型换画法。纯前端、无查询侧改动。

## 改动

`<MetricChartView>` 加 `chartType?: "line" | "bar" | "stacked" | "pie"`（默认 line）：
- **line / bar / stacked** 共用「桶 × 序列」矩阵（x=时间）。bar = 分组条；stacked = 所有序列共用一个 stackId 叠成构成条。
- **pie** = 单值构成：每序列 reduce 成一个切片（null 记 0），x=类别。饼图走「单桶查询」（bucket 覆盖整段范围）时每序列恰一点，求和即那个值。
- 抽出 `buildPieData` 纯变换；导出 buildChartRows/buildPieData/RenderSeries 供测试。

## 测试
- buildPieData：求和塌缩（null→0）+ 每片按调色板取色。
- buildChartRows：桶 × 序列透视、按 bucketStart 排序。
- 五件套 + 全量 202 文件全绿。

## 边界
- 组件仍不自动挂页（沿用 #444「按需嵌入」），只交付能力，使用处 recipe 后续按需插入。
- 不动查询侧 / agent 上下文。**至此 epic #475 四阶段全部落地。**

Refs #475