### PR TITLE
feat(web): 新增「大盘」页 + 面积图（Wait 工具 vs 所有工具调用次数）

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -10,6 +10,11 @@ const MainAgentContextPage = lazy(() =>
     default: module.MainAgentContextPage,
   })),
 );
+const DashboardPage = lazy(() =>
+  import("@/pages/dashboard/DashboardPage").then(module => ({
+    default: module.DashboardPage,
+  })),
+);
 const ControlPanelPage = lazy(() =>
   import("@/pages/control-panel/ControlPanelPage").then(module => ({
     default: module.ControlPanelPage,
@@ -68,6 +73,7 @@ function App() {
           <Route path="/auth" element={<Navigate to="/auth/claude-code" replace />} />
           <Route path="/auth/:provider" element={<AuthPage />} />
           <Route path="/main-agent-context" element={<MainAgentContextPage />} />
+          <Route path="/dashboard" element={<DashboardPage />} />
           <Route path="/control-panel" element={<ControlPanelPage />} />
           <Route path="/scheduler-tasks" element={<SchedulerTasksPage />} />
           <Route path="/llm-playground" element={<LlmPlaygroundPage />} />

--- a/apps/web/src/components/layout/navigation.ts
+++ b/apps/web/src/components/layout/navigation.ts
@@ -4,6 +4,7 @@ import {
   CalendarClock,
   FileText,
   FlaskConical,
+  Gauge,
   HardDrive,
   History,
   type LucideIcon,
@@ -22,6 +23,7 @@ type NavItem = {
 };
 
 export const navItems: readonly NavItem[] = [
+  { to: "/dashboard", label: "大盘", icon: Gauge },
   { to: "/main-agent-context", label: "主 Agent 上下文", icon: Bot },
   { to: "/control-panel", label: "控制面板", icon: SlidersHorizontal },
   { to: "/scheduler-tasks", label: "调度任务", icon: CalendarClock },

--- a/apps/web/src/components/metric/MetricChartView.tsx
+++ b/apps/web/src/components/metric/MetricChartView.tsx
@@ -1,6 +1,8 @@
 import { type MetricChartQueryResponse, type MetricChartSeries } from "@kagami/metric-api/chart";
 import { useMemo } from "react";
 import {
+  Area,
+  AreaChart,
   Bar,
   BarChart,
   CartesianGrid,
@@ -28,8 +30,8 @@ import {
 // 矩阵（x=时间），pie 走单值构成（每序列塌成一个切片，x=类别）。查询侧不变；pie/stacked 的构成语义
 // 由使用处用「单桶查询」（bucket 覆盖整段范围）喂进来，这里只负责渲染。
 
-/** 图表画法。line/bar/stacked = 时序（x=桶）；pie = 构成（每序列一片）。 */
-export type MetricChartType = "line" | "bar" | "stacked" | "pie";
+/** 图表画法。line/area/bar/stacked = 时序（x=桶）；pie = 构成（每序列一片）。 */
+export type MetricChartType = "line" | "area" | "bar" | "stacked" | "pie";
 
 type MetricChartViewProps = {
   title: string;
@@ -196,6 +198,48 @@ export function MetricChartView({
                     />
                   ))}
                 </BarChart>
+              ) : chartType === "area" ? (
+                <AreaChart data={rows} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+                  <CartesianGrid vertical={false} />
+                  <XAxis dataKey="bucketLabel" tickLine={false} axisLine={false} minTickGap={24} />
+                  <YAxis
+                    width={56}
+                    tickLine={false}
+                    axisLine={false}
+                    tickFormatter={(value: number | string) => formatMetricValue(value)}
+                  />
+                  <ChartTooltip
+                    content={
+                      <ChartTooltipContent
+                        labelFormatter={(_label, payload) => {
+                          const entry = payload?.[0]?.payload as
+                            | { bucketStart?: unknown }
+                            | undefined;
+                          const bucketStart = entry?.bucketStart;
+                          return typeof bucketStart === "string"
+                            ? formatFullDateTime(bucketStart)
+                            : "未知时间";
+                        }}
+                      />
+                    }
+                  />
+                  <ChartLegend content={<ChartLegendContent />} />
+                  {renderSeries.map(series => (
+                    <Area
+                      key={series.key}
+                      type="monotone"
+                      dataKey={series.dataKey}
+                      name={series.label}
+                      stroke={`var(--color-${series.dataKey})`}
+                      fill={`var(--color-${series.dataKey})`}
+                      // 面积图默认不堆叠、半透明叠放：wait ⊆ all 这类「子集 vs 全集」直接看出占比。
+                      fillOpacity={0.25}
+                      strokeWidth={2}
+                      connectNulls={false}
+                      isAnimationActive={false}
+                    />
+                  ))}
+                </AreaChart>
               ) : (
                 <LineChart data={rows} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
                   <CartesianGrid vertical={false} />

--- a/apps/web/src/pages/dashboard/DashboardPage.tsx
+++ b/apps/web/src/pages/dashboard/DashboardPage.tsx
@@ -1,0 +1,134 @@
+import type { MetricChartBucket, MetricChartQueryRequest } from "@kagami/metric-api/chart";
+import { RefreshCw } from "lucide-react";
+import { useState } from "react";
+import { MetricChartView } from "@/components/metric/MetricChartView";
+import { useMetricChartData } from "@/components/metric/useMetricChartData";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { getApiErrorMessage } from "@/lib/api";
+import { mergeToolSeries } from "./dashboard-series";
+
+// === 大盘（#475 后续）===
+//
+// 首张图：Wait 工具 vs 所有工具的调用次数（面积图）。两条各自过滤的单序列查询共享同一显式 range +
+// bucket（一次算好，避免两次 new Date() 桶轴错位），再叠成两序列。日后往这页加图即可。
+
+const TOOL_CALL_METRIC = "agent.tool.call";
+const WAIT_TOOL = "wait"; // WaitTool 的注册名（tool-call-metric 打点里 tags.tool 的取值）
+
+type RangePreset = {
+  key: string;
+  label: string;
+  rangeMs: number;
+  bucket: MetricChartBucket;
+};
+
+const RANGE_PRESETS: readonly RangePreset[] = [
+  { key: "1h", label: "近 1 小时", rangeMs: 60 * 60 * 1000, bucket: "5m" },
+  { key: "6h", label: "近 6 小时", rangeMs: 6 * 60 * 60 * 1000, bucket: "30m" },
+  { key: "1d", label: "近 1 天", rangeMs: 24 * 60 * 60 * 1000, bucket: "1h" },
+];
+
+const DEFAULT_PRESET = RANGE_PRESETS[1];
+
+function computeRange(rangeMs: number): { startAt: string; endAt: string } {
+  const endAt = new Date();
+  const startAt = new Date(endAt.getTime() - rangeMs);
+  return { startAt: startAt.toISOString(), endAt: endAt.toISOString() };
+}
+
+export function DashboardPage() {
+  const [presetKey, setPresetKey] = useState(DEFAULT_PRESET.key);
+  const preset = RANGE_PRESETS.find(item => item.key === presetKey) ?? DEFAULT_PRESET;
+  // range 只在初次 / 换 preset / 手动刷新时重算一次，两条查询共享，保证桶轴对齐、也避免每次渲染 refetch。
+  const [range, setRange] = useState(() => computeRange(DEFAULT_PRESET.rangeMs));
+
+  const allRequest: MetricChartQueryRequest = {
+    metricName: TOOL_CALL_METRIC,
+    aggregator: "count",
+    bucket: preset.bucket,
+    startAt: range.startAt,
+    endAt: range.endAt,
+  };
+  const waitRequest: MetricChartQueryRequest = {
+    ...allRequest,
+    tagFilters: { tool: { op: "eq", value: WAIT_TOOL } },
+  };
+
+  const allQuery = useMetricChartData(allRequest);
+  const waitQuery = useMetricChartData(waitRequest);
+
+  const data = mergeToolSeries([
+    { label: "所有工具", data: allQuery.data },
+    { label: "Wait 工具", data: waitQuery.data },
+  ]);
+
+  const isLoading = allQuery.isLoading || waitQuery.isLoading;
+  const isError = allQuery.isError || waitQuery.isError;
+  const isFetching = allQuery.isFetching || waitQuery.isFetching;
+  const errorMessage = allQuery.isError
+    ? getApiErrorMessage(allQuery.error)
+    : waitQuery.isError
+      ? getApiErrorMessage(waitQuery.error)
+      : undefined;
+
+  function handleSelectPreset(nextKey: string) {
+    const next = RANGE_PRESETS.find(item => item.key === nextKey) ?? DEFAULT_PRESET;
+    setPresetKey(next.key);
+    setRange(computeRange(next.rangeMs));
+  }
+
+  function handleRefresh() {
+    setRange(computeRange(preset.rangeMs));
+  }
+
+  return (
+    <div className="flex h-full min-h-0 w-full flex-col overflow-hidden p-3 md:p-6">
+      <h1 className="text-2xl font-semibold tracking-tight">大盘</h1>
+      <div className="mt-4 min-h-0 flex-1 overflow-y-auto pr-1">
+        <MetricChartView
+          title="工具使用次数"
+          subtitle="Wait 工具 vs 所有工具的调用次数"
+          chartType="area"
+          isLoading={isLoading}
+          isError={isError}
+          errorMessage={errorMessage}
+          data={data}
+          height={360}
+          headerRight={
+            <div className="flex flex-wrap items-center gap-2">
+              <Select value={preset.key} onValueChange={handleSelectPreset}>
+                <SelectTrigger className="h-8 w-28 rounded-none text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {RANGE_PRESETS.map(item => (
+                    <SelectItem key={item.key} value={item.key}>
+                      {item.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="h-8 rounded-none"
+                onClick={handleRefresh}
+                disabled={isFetching}
+              >
+                <RefreshCw className={`h-4 w-4 ${isFetching ? "animate-spin" : ""}`} />
+              </Button>
+            </div>
+          }
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/dashboard/dashboard-series.ts
+++ b/apps/web/src/pages/dashboard/dashboard-series.ts
@@ -1,0 +1,30 @@
+import type { MetricChartQueryResponse } from "@kagami/metric-api/chart";
+
+// 大盘把「两条各自过滤的单序列查询」（Wait 工具计数 / 所有工具计数）叠成一张两序列图。两条查询共享
+// 同一显式 range + bucket，故桶轴一致；某条无数据时沿另一条的桶轴补 0（大盘只用 count，缺桶即 0）。
+
+export type ToolSeriesInput = {
+  label: string;
+  data: MetricChartQueryResponse | undefined;
+};
+
+export function mergeToolSeries(inputs: ToolSeriesInput[]): MetricChartQueryResponse | undefined {
+  const withData = inputs.find(input => (input.data?.series.length ?? 0) > 0)?.data;
+  if (!withData) {
+    // 两条都无数据 → 交给 MetricChartView 出「没有数据」占位。
+    return undefined;
+  }
+
+  const axis = withData.series[0]?.points.map(point => point.bucketStart) ?? [];
+
+  return {
+    bucket: withData.bucket,
+    startAt: withData.startAt,
+    endAt: withData.endAt,
+    series: inputs.map((input, index) => ({
+      key: `s${index}`,
+      label: input.label,
+      points: input.data?.series[0]?.points ?? axis.map(bucketStart => ({ bucketStart, value: 0 })),
+    })),
+  };
+}

--- a/apps/web/test/dashboard-series.test.ts
+++ b/apps/web/test/dashboard-series.test.ts
@@ -1,0 +1,87 @@
+import type { MetricChartQueryResponse } from "@kagami/metric-api/chart";
+import { describe, expect, it } from "vitest";
+import { mergeToolSeries } from "@/pages/dashboard/dashboard-series";
+
+function response(
+  points: Array<{ bucketStart: string; value: number | null }>,
+): MetricChartQueryResponse {
+  return {
+    bucket: "1m",
+    startAt: "2026-04-02T00:00:00.000Z",
+    endAt: "2026-04-02T00:02:00.000Z",
+    series: points.length ? [{ key: "__default__", label: "agent.tool.call", points }] : [],
+  };
+}
+
+const b0 = "2026-04-02T00:00:00.000Z";
+const b1 = "2026-04-02T00:01:00.000Z";
+
+describe("mergeToolSeries", () => {
+  it("overlays two single-series responses into one two-series response", () => {
+    const merged = mergeToolSeries([
+      {
+        label: "所有工具",
+        data: response([
+          { bucketStart: b0, value: 5 },
+          { bucketStart: b1, value: 3 },
+        ]),
+      },
+      {
+        label: "Wait 工具",
+        data: response([
+          { bucketStart: b0, value: 2 },
+          { bucketStart: b1, value: 1 },
+        ]),
+      },
+    ]);
+
+    expect(merged?.series).toEqual([
+      {
+        key: "s0",
+        label: "所有工具",
+        points: [
+          { bucketStart: b0, value: 5 },
+          { bucketStart: b1, value: 3 },
+        ],
+      },
+      {
+        key: "s1",
+        label: "Wait 工具",
+        points: [
+          { bucketStart: b0, value: 2 },
+          { bucketStart: b1, value: 1 },
+        ],
+      },
+    ]);
+  });
+
+  it("fills a series with zeros along the other series' axis when it has no data", () => {
+    const merged = mergeToolSeries([
+      {
+        label: "所有工具",
+        data: response([
+          { bucketStart: b0, value: 4 },
+          { bucketStart: b1, value: 2 },
+        ]),
+      },
+      { label: "Wait 工具", data: response([]) }, // Wait 工具本区间零次调用
+    ]);
+
+    expect(merged?.series[1]).toEqual({
+      key: "s1",
+      label: "Wait 工具",
+      points: [
+        { bucketStart: b0, value: 0 },
+        { bucketStart: b1, value: 0 },
+      ],
+    });
+  });
+
+  it("returns undefined when neither series has data", () => {
+    const merged = mergeToolSeries([
+      { label: "所有工具", data: response([]) },
+      { label: "Wait 工具", data: response([]) },
+    ]);
+    expect(merged).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## 需求
前端加一个「大盘」页，先只放一张面积图，两条 series：Wait 工具使用次数 + 所有工具使用次数。

## 改动
- **MetricChartView 加 `area` chartType**（recharts AreaChart，半透明叠放；子集 vs 全集直接看占比）。补齐 P4 适配器（line/area/bar/stacked/pie）。
- **DashboardPage**（`/dashboard`）：两条各自过滤的单序列 `count` 查询（全部 / `tool=wait`）**共享同一显式 range + bucket**（一次算好，避免两次 `new Date()` 桶轴错位），`mergeToolSeries` 叠成两序列；某条整段无数据时沿另一条桶轴补 0。preset(1h/6h/1d)+刷新控件。
- 路由 `/dashboard` + nav「大盘」(Gauge 图标)。
- metric = `agent.tool.call`；Wait 工具 tag = `tool:"wait"`（`WAIT_TOOL_NAME`，wait 是顶层工具非 invoke 子工具，从打点 emitter 核实）。

## 数据正确性（生产实证）
- `wait` 工具确实上报 `agent.tool.call`：近 1 天 **342** 次 wait 调用可查。
- 「所有工具」= 不过滤 count（含 wait 及所有 invoke:\*）。

## 测试
- `mergeToolSeries`：叠加两序列 / 某条补零 / 双空返回 undefined。
- 五件套 + 全量测试全绿。

## Review（cross-model 一致 approve）
Codex + opus 子 Agent 均无阻塞发现，确认：TanStack 结构化 query key 无 refetch 循环、React 18 批处理无 bucket/range desync、服务端稠密零填保证两轴逐字节对齐、wait tag 取值正确。

## 边界
- 不动查询侧 / agent 上下文。纯前端增量、无迁移无新依赖。
- 只放首图；后续可继续往这页加图。