### PR TITLE
fix(web): 面积图 linear 插值，修子集曲线假性反超全集

### DIFF
--- a/apps/web/src/components/metric/MetricChartView.tsx
+++ b/apps/web/src/components/metric/MetricChartView.tsx
@@ -227,12 +227,16 @@ export function MetricChartView({
                   {renderSeries.map(series => (
                     <Area
                       key={series.key}
-                      type="monotone"
+                      // linear 而非 monotone：面积图常用来叠「子集 vs 全集」（如 wait ⊆ 所有工具）。
+                      // monotone 平滑曲线各序列独立算、只在数据点上过点，点与点之间平滑段会互相超越——
+                      // 即便每个桶都满足 wait ≤ all，子集曲线也会在段间鼓包到全集之上，看着像 wait 更高。
+                      // linear 直线段逐点保序：每点 wait ≤ all → 整条线处处 ≤，绝不假性反超。
+                      type="linear"
                       dataKey={series.dataKey}
                       name={series.label}
                       stroke={`var(--color-${series.dataKey})`}
                       fill={`var(--color-${series.dataKey})`}
-                      // 面积图默认不堆叠、半透明叠放：wait ⊆ all 这类「子集 vs 全集」直接看出占比。
+                      // 默认不堆叠、半透明叠放：子集在上层，全集的多出部分从上缘露出，直接看出占比。
                       fillOpacity={0.25}
                       strokeWidth={2}
                       connectNulls={false}


### PR DESCRIPTION
## 问题
大盘的面积图里，Wait 工具（子集）的曲线在很多区段显示得比「所有工具」（全集）还高——但 Wait ⊆ 所有工具，数据上每个桶都满足 Wait ≤ All，不可能更高。

## 根因
面积图用 `type="monotone"`（平滑三次插值）。monotone 曲线**各序列独立计算、只在数据点上过点**，点与点之间的平滑段会互相超越。于是即便每个桶都 Wait ≤ All，Wait 的平滑曲线也会在段间**鼓包到 All 之上**，视觉上像 Wait 更高。

## 修复
面积图改 `type="linear"`：直线段在两端点间**逐点保序**——两端都 Wait ≤ All ⟹ 整段处处 Wait ≤ All。子集曲线绝不假性反超全集。（line/bar/stacked/pie 不改，line 多为单序列、无此叠加语义。）

## 验证
web typecheck / build / 五件套 / 全量测试全绿。纯渲染 prop 改动、无逻辑/数据变化。