### PR TITLE
feat(llm): LLM 调用打点（provider/model/status/latency/tokens/来处/失败原因）

### DIFF
--- a/apps/llm/package.json
+++ b/apps/llm/package.json
@@ -18,6 +18,7 @@
     "@kagami/llm": "workspace:*",
     "@kagami/llm-api": "workspace:*",
     "@kagami/llm-client": "workspace:*",
+    "@kagami/metric-client": "workspace:*",
     "@kagami/persistence": "workspace:*",
     "@kagami/scheduler-client": "workspace:*",
     "fastify": "^5.6.2",

--- a/apps/llm/src/app/llm-metrics.ts
+++ b/apps/llm/src/app/llm-metrics.ts
@@ -1,4 +1,8 @@
-import type { LlmChatCallErrorObservation, LlmChatCallObservation } from "@kagami/llm-client";
+import {
+  LLM_PROVIDER_UNAVAILABLE_MESSAGE,
+  type LlmChatCallErrorObservation,
+  type LlmChatCallObservation,
+} from "@kagami/llm-client";
 import type { MetricClient } from "@kagami/metric-client/client";
 
 // LLM 调用打点（fire-and-forget）：在 kagami-llm 的观测点把每次 attempt 记成 metric，喂给独占 DuckDB
@@ -93,8 +97,12 @@ function classifyLlmError(observation: LlmChatCallErrorObservation): string {
   }
 
   const message = extractErrorMessage(observation).toLowerCase();
-  // provider 不可用错误消息是中文（LLM_PROVIDER_UNAVAILABLE_MESSAGE = "所选 LLM provider 当前不可用"）。
-  if (message.includes("unavailable") || message.includes("不可用")) {
+  // provider 不可用错误消息是中文哨兵串（LLM_PROVIDER_UNAVAILABLE_MESSAGE）。匹配完整哨兵而非「不可用」
+  // 子串，避免把「服务暂时不可用」等普通消息误标成 provider_unavailable。
+  if (
+    message.includes("unavailable") ||
+    message.includes(LLM_PROVIDER_UNAVAILABLE_MESSAGE.toLowerCase())
+  ) {
     return "provider_unavailable";
   }
   if (message.includes("fetch failed")) {

--- a/apps/llm/src/app/llm-metrics.ts
+++ b/apps/llm/src/app/llm-metrics.ts
@@ -1,0 +1,148 @@
+import type { LlmChatCallErrorObservation, LlmChatCallObservation } from "@kagami/llm-client";
+import type { MetricClient } from "@kagami/metric-client/client";
+
+// LLM 调用打点（fire-and-forget）：在 kagami-llm 的观测点把每次 attempt 记成 metric，喂给独占 DuckDB
+// 的查询/派生层（P1-P4）。三个 metric：
+// - llm.call        计数（provider/model/status/usage[来处]，失败带 error 粗分类）→ 调用量 / 成功率
+// - llm.call.latency 延迟 ms（同上 tags）→ p50/p95/p99
+// - llm.call.tokens  token 用量，按 kind 拆（input_total/input_cache_hit/input_cache_miss/output）
+//                    → 用量 + KV 缓存命中率（cache_hit ÷ input_total，派生一条比率线）
+// record 永不 reject（HttpMetricClient 咽下失败），故一律 `void`，绝不影响 LLM 结果。
+
+const METRIC_CALL = "llm.call";
+const METRIC_LATENCY = "llm.call.latency";
+const METRIC_TOKENS = "llm.call.tokens";
+
+/** response.usage 的 token 字段 → 打点 kind。input_total = 命中 + 未命中（见 claude-code-response）。 */
+const TOKEN_KINDS: ReadonlyArray<readonly [kind: string, field: string]> = [
+  ["input_total", "promptTokens"],
+  ["input_cache_hit", "cacheHitTokens"],
+  ["input_cache_miss", "cacheMissTokens"],
+  ["output", "completionTokens"],
+];
+
+export function recordLlmCallMetrics(
+  metricService: MetricClient,
+  observation: LlmChatCallObservation,
+): void {
+  const base = {
+    provider: observation.provider,
+    model: observation.model,
+    // chatDirect 无调用来处 → "direct"。
+    usage: observation.usage ?? "direct",
+  };
+
+  void metricService.record({
+    metricName: METRIC_CALL,
+    value: 1,
+    tags: {
+      ...base,
+      status: observation.status,
+      ...(observation.status === "failed" ? { error: classifyLlmError(observation) } : {}),
+    },
+  });
+
+  void metricService.record({
+    metricName: METRIC_LATENCY,
+    value: observation.latencyMs,
+    tags: { ...base, status: observation.status },
+  });
+
+  if (observation.status === "success") {
+    for (const [kind, value] of extractUsageTokens(observation.response)) {
+      void metricService.record({
+        metricName: METRIC_TOKENS,
+        value,
+        tags: { ...base, kind },
+      });
+    }
+  }
+}
+
+/** 从 recordable response 里安全取 4 类 token（缺失 / 非有限 / ≤0 一律跳过，不打 0 点省行数）。 */
+function extractUsageTokens(response: Record<string, unknown>): Array<[string, number]> {
+  const usage = response.usage;
+  if (typeof usage !== "object" || usage === null) {
+    return [];
+  }
+  const fields = usage as Record<string, unknown>;
+  const result: Array<[string, number]> = [];
+  for (const [kind, field] of TOKEN_KINDS) {
+    const value = fields[field];
+    if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+      result.push([kind, value]);
+    }
+  }
+  return result;
+}
+
+/** 失败原因粗分类（一个 tag 维度，别做成大而全的错误树）：先看 HTTP status，再看消息关键字。 */
+function classifyLlmError(observation: LlmChatCallErrorObservation): string {
+  const status = readNumber(observation.nativeError, "status");
+  if (status === 429) {
+    return "rate_limit";
+  }
+  if (status === 401 || status === 403) {
+    return "auth";
+  }
+  if (status === 408) {
+    return "timeout";
+  }
+  if (typeof status === "number" && status >= 500) {
+    return "server";
+  }
+
+  const message = extractErrorMessage(observation).toLowerCase();
+  // provider 不可用错误消息是中文（LLM_PROVIDER_UNAVAILABLE_MESSAGE = "所选 LLM provider 当前不可用"）。
+  if (message.includes("unavailable") || message.includes("不可用")) {
+    return "provider_unavailable";
+  }
+  if (message.includes("fetch failed")) {
+    return "fetch_failed";
+  }
+  if (
+    message.includes("timeout") ||
+    message.includes("timed out") ||
+    message.includes("etimedout") ||
+    message.includes("aborted")
+  ) {
+    return "timeout";
+  }
+  return "other";
+}
+
+function extractErrorMessage(observation: LlmChatCallErrorObservation): string {
+  const parts: string[] = [];
+  const error = observation.error;
+  if (typeof error === "string") {
+    parts.push(error);
+  } else if (error instanceof Error) {
+    parts.push(error.message);
+  } else {
+    const message = readString(error, "message");
+    if (message !== undefined) {
+      parts.push(message);
+    }
+  }
+  const nativeMessage = readString(observation.nativeError, "message");
+  if (nativeMessage !== undefined) {
+    parts.push(nativeMessage);
+  }
+  return parts.join(" ");
+}
+
+function readNumber(source: unknown, key: string): number | undefined {
+  if (typeof source !== "object" || source === null) {
+    return undefined;
+  }
+  const value = (source as Record<string, unknown>)[key];
+  return typeof value === "number" ? value : undefined;
+}
+
+function readString(source: unknown, key: string): string | undefined {
+  if (typeof source !== "object" || source === null) {
+    return undefined;
+  }
+  const value = (source as Record<string, unknown>)[key];
+  return typeof value === "string" ? value : undefined;
+}

--- a/apps/llm/src/app/llm-service-runtime.ts
+++ b/apps/llm/src/app/llm-service-runtime.ts
@@ -22,7 +22,9 @@ import {
   type LlmClient,
 } from "@kagami/llm-client";
 import { createEmbeddingClient, type EmbeddingClient } from "@kagami/llm-client/embedding";
+import { HttpMetricClient } from "@kagami/metric-client/client";
 import { SchedulerClient } from "@kagami/scheduler-client/scheduler-client";
+import { recordLlmCallMetrics } from "./llm-metrics.js";
 import { PrismaEmbeddingCacheDao } from "../infra/prisma-embedding-cache.dao.js";
 import { PrismaClaudeFileCacheDao } from "../infra/prisma-claude-file-cache.dao.js";
 import { InternalLlmHandler } from "../http/internal-llm.handler.js";
@@ -89,9 +91,17 @@ export async function buildLlmServiceRuntime(): Promise<LlmServiceRuntime> {
     }),
   };
 
+  // metric 打点走独立 metric 服务（@kagami/metric）的 HTTP 摄取端点；地址取自 services.metric。
+  // record 是 fire-and-forget（永不 reject），打点失败绝不影响 LLM 结果。
+  const metricService = new HttpMetricClient({
+    baseUrl: `http://${config.services.metric.host}:${config.services.metric.port}`,
+  });
+
   // 落库在服务内：llm-client 只发 observation，这里订阅后写 llm_chat_call。返回 DAO 的
   // Promise，让 client 内部 emitObservation 统一 catch（写库失败不影响 LLM 结果）。
   const recordLlmChatObservation = (observation: LlmChatCallObservation): Promise<void> => {
+    // 每次 attempt 顺手打点（provider/model/status/latency/usage来处/token/失败原因），与落库解耦。
+    recordLlmCallMetrics(metricService, observation);
     if (observation.status === "success") {
       return llmChatCallDao.recordSuccess({
         provider: observation.provider,

--- a/apps/llm/test/llm-metrics.test.ts
+++ b/apps/llm/test/llm-metrics.test.ts
@@ -139,6 +139,8 @@ describe("recordLlmCallMetrics", () => {
     );
     expect(kindOf({ error: new Error("request timed out") })).toBe("timeout");
     expect(kindOf({ error: new Error("something odd") })).toBe("other");
+    // 「不可用」子串但非 provider 哨兵串 → 不误标 provider_unavailable。
+    expect(kindOf({ error: new Error("服务暂时不可用") })).toBe("other");
   });
 
   it("labels chatDirect (usage=null) as 'direct'", () => {

--- a/apps/llm/test/llm-metrics.test.ts
+++ b/apps/llm/test/llm-metrics.test.ts
@@ -1,0 +1,149 @@
+import type { LlmChatCallObservation } from "@kagami/llm-client";
+import type { MetricClient, RecordMetricInput } from "@kagami/metric-client/client";
+import { describe, expect, it } from "vitest";
+import { recordLlmCallMetrics } from "../src/app/llm-metrics.js";
+
+function capturing(): { client: MetricClient; calls: RecordMetricInput[] } {
+  const calls: RecordMetricInput[] = [];
+  const client: MetricClient = {
+    record: input => {
+      calls.push(input);
+      return Promise.resolve();
+    },
+  };
+  return { client, calls };
+}
+
+function successObservation(
+  over: Partial<Extract<LlmChatCallObservation, { status: "success" }>> = {},
+): LlmChatCallObservation {
+  return {
+    status: "success",
+    provider: "claude-code",
+    model: "claude-x",
+    usage: "agent",
+    extension: {},
+    requestId: "r1",
+    seq: 1,
+    latencyMs: 1234,
+    request: {},
+    response: {
+      usage: {
+        promptTokens: 100,
+        cacheHitTokens: 80,
+        cacheMissTokens: 20,
+        completionTokens: 50,
+      },
+    },
+    nativeRequestPayload: null,
+    nativeResponsePayload: null,
+    ...over,
+  };
+}
+
+function failedObservation(
+  over: Partial<Extract<LlmChatCallObservation, { status: "failed" }>> = {},
+): LlmChatCallObservation {
+  return {
+    status: "failed",
+    provider: "openai",
+    model: "gpt-x",
+    usage: "contextSummarizer",
+    extension: null,
+    requestId: "r2",
+    seq: 1,
+    latencyMs: 500,
+    request: {},
+    nativeRequestPayload: null,
+    nativeResponsePayload: null,
+    nativeError: null,
+    error: new Error("boom"),
+    ...over,
+  };
+}
+
+describe("recordLlmCallMetrics", () => {
+  it("emits call count, latency, and per-kind tokens on success", () => {
+    const { client, calls } = capturing();
+    recordLlmCallMetrics(client, successObservation());
+
+    const byMetric = (name: string) => calls.filter(call => call.metricName === name);
+
+    expect(byMetric("llm.call")).toEqual([
+      {
+        metricName: "llm.call",
+        value: 1,
+        tags: { provider: "claude-code", model: "claude-x", usage: "agent", status: "success" },
+      },
+    ]);
+    expect(byMetric("llm.call.latency")).toEqual([
+      {
+        metricName: "llm.call.latency",
+        value: 1234,
+        tags: { provider: "claude-code", model: "claude-x", usage: "agent", status: "success" },
+      },
+    ]);
+
+    const tokens = byMetric("llm.call.tokens");
+    expect(tokens.map(call => ({ kind: call.tags?.kind, value: call.value }))).toEqual([
+      { kind: "input_total", value: 100 },
+      { kind: "input_cache_hit", value: 80 },
+      { kind: "input_cache_miss", value: 20 },
+      { kind: "output", value: 50 },
+    ]);
+    expect(tokens[0]?.tags).toMatchObject({ provider: "claude-code", usage: "agent" });
+  });
+
+  it("skips token kinds that are missing or zero", () => {
+    const { client, calls } = capturing();
+    recordLlmCallMetrics(
+      client,
+      successObservation({
+        response: { usage: { promptTokens: 40, cacheHitTokens: 0, completionTokens: 40 } },
+      }),
+    );
+
+    const kinds = calls.filter(c => c.metricName === "llm.call.tokens").map(c => c.tags?.kind);
+    // cacheHitTokens=0 跳过、cacheMissTokens 缺失跳过；只留 input_total 与 output。
+    expect(kinds).toEqual(["input_total", "output"]);
+  });
+
+  it("tags status=failed with an error class and emits no tokens", () => {
+    const { client, calls } = capturing();
+    recordLlmCallMetrics(client, failedObservation({ nativeError: { status: 429 } }));
+
+    const call = calls.find(c => c.metricName === "llm.call");
+    expect(call?.tags).toEqual({
+      provider: "openai",
+      model: "gpt-x",
+      usage: "contextSummarizer",
+      status: "failed",
+      error: "rate_limit",
+    });
+    expect(calls.some(c => c.metricName === "llm.call.latency")).toBe(true);
+    expect(calls.some(c => c.metricName === "llm.call.tokens")).toBe(false);
+  });
+
+  it("classifies common failure kinds", () => {
+    const kindOf = (over: Partial<Extract<LlmChatCallObservation, { status: "failed" }>>) => {
+      const { client, calls } = capturing();
+      recordLlmCallMetrics(client, failedObservation(over));
+      return calls.find(c => c.metricName === "llm.call")?.tags?.error;
+    };
+
+    expect(kindOf({ nativeError: { status: 401 } })).toBe("auth");
+    expect(kindOf({ nativeError: { status: 503 } })).toBe("server");
+    expect(kindOf({ error: new Error("fetch failed") })).toBe("fetch_failed");
+    expect(kindOf({ error: new Error("所选 LLM provider 当前不可用") })).toBe(
+      "provider_unavailable",
+    );
+    expect(kindOf({ error: new Error("request timed out") })).toBe("timeout");
+    expect(kindOf({ error: new Error("something odd") })).toBe("other");
+  });
+
+  it("labels chatDirect (usage=null) as 'direct'", () => {
+    const { client, calls } = capturing();
+    recordLlmCallMetrics(client, successObservation({ usage: null }));
+    expect(calls.every(c => c.tags?.usage === "direct")).toBe(true);
+  });
+});

--- a/packages/llm-client/src/client.ts
+++ b/packages/llm-client/src/client.ts
@@ -82,6 +82,8 @@ export type LlmChatCallSuccessObservation = {
   status: "success";
   provider: LlmProviderId;
   model: string;
+  /** 调用来处（主循环 / 摘要 / todo / inner-voice…）；chatDirect 无来处时为 null。 */
+  usage: LlmUsageId | null;
   extension: Record<string, unknown>;
   requestId: string;
   seq: number;
@@ -96,6 +98,8 @@ export type LlmChatCallErrorObservation = {
   status: "failed";
   provider: LlmProviderId;
   model: string;
+  /** 调用来处；chatDirect 无来处时为 null。 */
+  usage: LlmUsageId | null;
   extension: Record<string, unknown> | null;
   requestId: string;
   seq: number;
@@ -147,6 +151,7 @@ export function createLlmClient(options: CreateLlmClientOptions): LlmClient {
               providerConfigs: options.providerConfigs,
               request,
               attempt,
+              usage,
               requestId,
               seq: (seq += 1),
               recordCall,
@@ -177,6 +182,7 @@ export function createLlmClient(options: CreateLlmClientOptions): LlmClient {
           model,
           times: 1,
         },
+        usage: null,
         requestId: randomUUID(),
         seq: 1,
         recordCall: chatOptions?.recordCall ?? true,
@@ -191,6 +197,7 @@ async function executeChatAttempt({
   providerConfigs,
   request,
   attempt,
+  usage,
   requestId,
   seq,
   recordCall,
@@ -200,6 +207,7 @@ async function executeChatAttempt({
   providerConfigs: ProviderConfigs;
   request: LlmChatRequest;
   attempt: LlmUsageAttemptConfig;
+  usage: LlmUsageId | null;
   requestId: string;
   seq: number;
   recordCall: boolean;
@@ -230,6 +238,7 @@ async function executeChatAttempt({
         status: "success",
         provider: provider.id,
         model: attempt.model,
+        usage,
         extension: buildExtension({
           actualModel: response.model,
         }),
@@ -261,6 +270,7 @@ async function executeChatAttempt({
         status: "failed",
         provider: attempt.provider,
         model: attempt.model,
+        usage,
         extension:
           actualModel === undefined
             ? null

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,6 +234,9 @@ importers:
       '@kagami/llm-client':
         specifier: workspace:*
         version: link:../../packages/llm-client
+      '@kagami/metric-client':
+        specifier: workspace:*
+        version: link:../../packages/metric-client
       '@kagami/persistence':
         specifier: workspace:*
         version: link:../../packages/persistence


### PR DESCRIPTION
## 需求
给 LLM 服务的每次调用打点，喂给刚上线的 DuckDB metric 查询/派生层（#475 P1-P4）。字段：provider、model、status、latency、usage(token)，外加对齐讨论后确认的：调用来处、cache token 拆分、失败原因分类。

## 三个 metric（kagami-llm 观测点 fire-and-forget）
- **llm.call** — 计数，tags: provider / model / status / usage(来处)；失败带 error 粗分类 → 调用量、成功率、按来处/provider 拆。
- **llm.call.latency** — 延迟 ms，同 tags → 用 P2 的 p50/p95/p99。
- **llm.call.tokens** — token 用量按 `kind` 拆：`input_total` / `input_cache_hit` / `input_cache_miss` / `output`（`input_total = 命中 + 未命中`，与 claude-code-response 语义一致）→ 用量 + **KV 缓存命中率**（cache_hit ÷ input_total 用 P3 派生一条比率线）。

## 失败原因分类（llm.call 的 error tag）
先看 HTTP status（429→rate_limit / 401·403→auth / 408→timeout / 5xx→server），再看消息关键字（provider_unavailable 含中文「不可用」/ fetch_failed / timeout / other）。

## 实现
- 观测事件 `LlmChatCallObservation` 加 `usage: LlmUsageId | null`（调用来处）：`chat` 传来处、`chatDirect` 传 null（打点记 `direct`）。llm-client 只加一个字段，唯一消费者是 kagami-llm 的 `recordLlmChatObservation`。
- apps/llm 加 `@kagami/metric-client` 依赖，构造 `HttpMetricClient(services.metric)`。
- `record` 永不 reject（HttpMetricClient 咽下失败），全部 `void` → 打点失败绝不影响 LLM 结果。

## 测试
- `llm-metrics`：三 metric 形状 / token kind 拆分与跳 0 / 失败 error 分类各档 / usage=null→direct。
- 五件套 + 全量 204 文件全绿。

## 边界
- 无 DB 迁移、无 agent 上下文改动。部署走 `app:deploy llm`（先 pnpm install，apps/llm 新增 metric-client 依赖）。