### PR TITLE
feat(web): 大盘缓存图合并成双 Y 轴（总输入 token + 命中率）

### DIFF
--- a/apps/llm/src/app/llm-metrics.ts
+++ b/apps/llm/src/app/llm-metrics.ts
@@ -8,7 +8,7 @@ import type { MetricClient } from "@kagami/metric-client/client";
 // LLM 调用打点（fire-and-forget）：在 kagami-llm 的观测点把每次 attempt 记成 metric，喂给独占 DuckDB
 // 的查询/派生层（P1-P4）。三个 metric：
 // - llm.call        计数（provider/model/status/usage[来处]，失败带 error 粗分类）→ 调用量 / 成功率
-// - llm.call.latency 延迟 ms（同上 tags）→ p50/p95/p99
+// - llm.call.latency 延迟秒（同上 tags）→ p50/p95/p99
 // - llm.call.tokens  token 用量，按 kind 拆（input_total/input_cache_hit/input_cache_miss/output）
 //                    → 用量 + KV 缓存命中率（cache_hit ÷ input_total，派生一条比率线）
 // record 永不 reject（HttpMetricClient 咽下失败），故一律 `void`，绝不影响 LLM 结果。
@@ -16,6 +16,9 @@ import type { MetricClient } from "@kagami/metric-client/client";
 const METRIC_CALL = "llm.call";
 const METRIC_LATENCY = "llm.call.latency";
 const METRIC_TOKENS = "llm.call.tokens";
+
+/** 毫秒 → 秒。latency 以秒为单位打点（前端直接显示秒，单位口径在后端定死）。 */
+const MS_PER_SECOND = 1000;
 
 /** response.usage 的 token 字段 → 打点 kind。input_total = 命中 + 未命中（见 claude-code-response）。 */
 const TOKEN_KINDS: ReadonlyArray<readonly [kind: string, field: string]> = [
@@ -48,7 +51,8 @@ export function recordLlmCallMetrics(
 
   void metricService.record({
     metricName: METRIC_LATENCY,
-    value: observation.latencyMs,
+    // 以秒打点：LLM 调用动辄数秒，秒比毫秒更好读；p50/p95/p99 也直接是秒。
+    value: observation.latencyMs / MS_PER_SECOND,
     tags: { ...base, status: observation.status },
   });
 

--- a/apps/llm/test/llm-metrics.test.ts
+++ b/apps/llm/test/llm-metrics.test.ts
@@ -79,7 +79,8 @@ describe("recordLlmCallMetrics", () => {
     expect(byMetric("llm.call.latency")).toEqual([
       {
         metricName: "llm.call.latency",
-        value: 1234,
+        // latencyMs 1234 → 以秒打点 = 1.234。
+        value: 1.234,
         tags: { provider: "claude-code", model: "claude-x", usage: "agent", status: "success" },
       },
     ]);

--- a/apps/web/src/components/metric/MetricChartView.tsx
+++ b/apps/web/src/components/metric/MetricChartView.tsx
@@ -23,7 +23,7 @@ import {
   ChartTooltipContent,
   type ChartConfig,
 } from "@/components/ui/chart";
-import { formatBucketLabel, formatFullDateTime, formatMetricValue } from "./metric-format";
+import { formatBucketLabel, formatCompactNumber, formatFullDateTime } from "./metric-format";
 
 // === 纯展示层：只吃 data / 查询状态 + 展示 props，不发请求、不持控件状态（#444）===
 //
@@ -169,7 +169,7 @@ export function MetricChartView({
                     width={56}
                     tickLine={false}
                     axisLine={false}
-                    tickFormatter={(value: number | string) => formatMetricValue(value)}
+                    tickFormatter={(value: number | string) => formatCompactNumber(value)}
                   />
                   <ChartTooltip
                     content={
@@ -207,7 +207,7 @@ export function MetricChartView({
                     width={56}
                     tickLine={false}
                     axisLine={false}
-                    tickFormatter={(value: number | string) => formatMetricValue(value)}
+                    tickFormatter={(value: number | string) => formatCompactNumber(value)}
                   />
                   <ChartTooltip
                     content={
@@ -253,7 +253,7 @@ export function MetricChartView({
                     width={56}
                     tickLine={false}
                     axisLine={false}
-                    tickFormatter={(value: number | string) => formatMetricValue(value)}
+                    tickFormatter={(value: number | string) => formatCompactNumber(value)}
                   />
                   <ChartTooltip
                     content={

--- a/apps/web/src/components/metric/MetricChartView.tsx
+++ b/apps/web/src/components/metric/MetricChartView.tsx
@@ -23,6 +23,7 @@ import {
   ChartTooltipContent,
   type ChartConfig,
 } from "@/components/ui/chart";
+import { formatBucketLabel, formatFullDateTime, formatMetricValue } from "./metric-format";
 
 // === 纯展示层：只吃 data / 查询状态 + 展示 props，不发请求、不持控件状态（#444）===
 //
@@ -352,50 +353,4 @@ export function buildChartRows(series: RenderSeries[]): ChartRow[] {
   return [...rowsByBucketStart.values()].sort((left, right) =>
     left.bucketStart.localeCompare(right.bucketStart),
   );
-}
-
-function formatBucketLabel(value: string): string {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return value;
-  }
-
-  return new Intl.DateTimeFormat("zh-CN", {
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-  }).format(date);
-}
-
-function formatFullDateTime(value: string): string {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return value;
-  }
-
-  return new Intl.DateTimeFormat("zh-CN", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-  }).format(date);
-}
-
-function formatMetricValue(value: number | string): string {
-  if (typeof value !== "number") {
-    return String(value);
-  }
-
-  if (Math.abs(value) >= 1000) {
-    return value.toLocaleString("zh-CN", {
-      maximumFractionDigits: 1,
-    });
-  }
-
-  return value.toLocaleString("zh-CN", {
-    maximumFractionDigits: 2,
-  });
 }

--- a/apps/web/src/components/metric/metric-format.ts
+++ b/apps/web/src/components/metric/metric-format.ts
@@ -1,0 +1,50 @@
+// metric 图表共享的格式化助手（从 MetricChartView 抽出，供大盘 composed 图等复用）。
+
+/** 桶起点 → 轴标签（月-日 时:分）。 */
+export function formatBucketLabel(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat("zh-CN", {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+}
+
+/** 桶起点 → tooltip 完整时间（年-月-日 时:分:秒）。 */
+export function formatFullDateTime(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat("zh-CN", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).format(date);
+}
+
+/** 数值 → 轴/tooltip 显示（≥1000 千分位、否则最多两位小数）。 */
+export function formatMetricValue(value: number | string): string {
+  if (typeof value !== "number") {
+    return String(value);
+  }
+
+  if (Math.abs(value) >= 1000) {
+    return value.toLocaleString("zh-CN", {
+      maximumFractionDigits: 1,
+    });
+  }
+
+  return value.toLocaleString("zh-CN", {
+    maximumFractionDigits: 2,
+  });
+}

--- a/apps/web/src/components/metric/metric-format.ts
+++ b/apps/web/src/components/metric/metric-format.ts
@@ -32,6 +32,31 @@ export function formatFullDateTime(value: string): string {
   }).format(date);
 }
 
+/**
+ * 数值 → 紧凑单位（K/M/B）。给轴刻度用：token 动辄百万，裸数字带千分位会撑爆窄轴。
+ * 1,435,008 → "1.44M"、435,008 → "435K"、8.1 → "8.1"。tooltip 仍用 formatMetricValue 显精确值。
+ */
+export function formatCompactNumber(value: number | string): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return String(value);
+  }
+  const abs = Math.abs(value);
+  if (abs >= 1e9) {
+    return trimTrailingZeros(value / 1e9) + "B";
+  }
+  if (abs >= 1e6) {
+    return trimTrailingZeros(value / 1e6) + "M";
+  }
+  if (abs >= 1e3) {
+    return trimTrailingZeros(value / 1e3) + "K";
+  }
+  return value.toLocaleString("zh-CN", { maximumFractionDigits: 2 });
+}
+
+function trimTrailingZeros(value: number): string {
+  return value.toFixed(2).replace(/\.?0+$/, "");
+}
+
 /** 数值 → 轴/tooltip 显示（≥1000 千分位、否则最多两位小数）。 */
 export function formatMetricValue(value: number | string): string {
   if (typeof value !== "number") {

--- a/apps/web/src/pages/dashboard/DashboardCacheChart.tsx
+++ b/apps/web/src/pages/dashboard/DashboardCacheChart.tsx
@@ -1,6 +1,10 @@
 import { useMemo } from "react";
 import { Area, CartesianGrid, ComposedChart, Line, XAxis, YAxis } from "recharts";
-import { formatFullDateTime, formatMetricValue } from "@/components/metric/metric-format";
+import {
+  formatCompactNumber,
+  formatFullDateTime,
+  formatMetricValue,
+} from "@/components/metric/metric-format";
 import { useMetricChartData } from "@/components/metric/useMetricChartData";
 import { useMetricDerivedData } from "@/components/metric/useMetricDerivedData";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -105,7 +109,7 @@ export function DashboardCacheChart({ range }: { range: DashboardRange }) {
                 width={56}
                 tickLine={false}
                 axisLine={false}
-                tickFormatter={(value: number | string) => formatMetricValue(value)}
+                tickFormatter={(value: number | string) => formatCompactNumber(value)}
               />
               <YAxis
                 yAxisId="rate"

--- a/apps/web/src/pages/dashboard/DashboardCacheChart.tsx
+++ b/apps/web/src/pages/dashboard/DashboardCacheChart.tsx
@@ -1,0 +1,164 @@
+import { useMemo } from "react";
+import { Area, CartesianGrid, ComposedChart, Line, XAxis, YAxis } from "recharts";
+import { formatFullDateTime, formatMetricValue } from "@/components/metric/metric-format";
+import { useMetricChartData } from "@/components/metric/useMetricChartData";
+import { useMetricDerivedData } from "@/components/metric/useMetricDerivedData";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import { getApiErrorMessage } from "@/lib/api";
+import { buildCacheRows } from "./dashboard-cache";
+import type { DashboardRange } from "./dashboard-charts";
+
+// 主 Agent 输入 token 缓存图：一张双 Y 轴 composed 图同时给出「用了多少 token」（左轴面积）与「命中率
+// 多少」（右轴线，%）——把绝对量与派生比率合进一张，不再分两张。命中率走 P3 /metric/derive
+// （cache_hit ÷ input_total），口径收在后端。两条查询共享同一 range，桶轴对齐。
+
+const LLM_TOKENS = "llm.call.tokens";
+const AGENT_USAGE = { usage: { op: "eq" as const, value: "agent" } };
+const CHART_HEIGHT = 300;
+
+const chartConfig = {
+  tokens: { label: "总输入 token", color: "hsl(var(--llm))" },
+  ratePct: { label: "缓存命中率", color: "hsl(var(--story))" },
+} satisfies ChartConfig;
+
+export function DashboardCacheChart({ range }: { range: DashboardRange }) {
+  const totalQuery = useMetricChartData({
+    metricName: LLM_TOKENS,
+    aggregator: "sum",
+    bucket: range.bucket,
+    startAt: range.startAt,
+    endAt: range.endAt,
+    tagFilters: { ...AGENT_USAGE, kind: { op: "eq", value: "input_total" } },
+  });
+  const rateQuery = useMetricDerivedData({
+    numerator: {
+      metricName: LLM_TOKENS,
+      aggregator: "sum",
+      tagFilters: { ...AGENT_USAGE, kind: { op: "eq", value: "input_cache_hit" } },
+    },
+    denominator: {
+      metricName: LLM_TOKENS,
+      aggregator: "sum",
+      tagFilters: { ...AGENT_USAGE, kind: { op: "eq", value: "input_total" } },
+    },
+    op: "ratio",
+    bucket: range.bucket,
+    startAt: range.startAt,
+    endAt: range.endAt,
+  });
+
+  const rows = useMemo(
+    () => buildCacheRows(totalQuery.data, rateQuery.data),
+    [totalQuery.data, rateQuery.data],
+  );
+
+  const isLoading = totalQuery.isLoading || rateQuery.isLoading;
+  const isError = totalQuery.isError || rateQuery.isError;
+  const errorMessage = totalQuery.isError
+    ? getApiErrorMessage(totalQuery.error)
+    : rateQuery.isError
+      ? getApiErrorMessage(rateQuery.error)
+      : undefined;
+  const placeholderClassName = "flex items-center justify-center rounded-none border border-dashed";
+  const placeholderStyle = { height: CHART_HEIGHT };
+
+  return (
+    <Card className="overflow-hidden">
+      <CardHeader className="gap-2 pb-4">
+        <CardTitle className="text-lg">主 Agent 输入 token</CardTitle>
+        <CardDescription>总输入量（左轴）与缓存命中率（右轴）</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {isLoading ? (
+          <div className={placeholderClassName} style={placeholderStyle}>
+            <p className="text-sm text-muted-foreground">正在加载图表数据…</p>
+          </div>
+        ) : null}
+
+        {!isLoading && isError ? (
+          <div className={placeholderClassName} style={placeholderStyle}>
+            <p className="text-sm text-destructive">数据加载失败：{errorMessage ?? "未知错误"}</p>
+          </div>
+        ) : null}
+
+        {!isLoading && !isError && rows.length === 0 ? (
+          <div className={placeholderClassName} style={placeholderStyle}>
+            <p className="text-sm text-muted-foreground">当前时间范围内没有数据。</p>
+          </div>
+        ) : null}
+
+        {!isLoading && !isError && rows.length > 0 ? (
+          <ChartContainer className="w-full" style={{ height: CHART_HEIGHT }} config={chartConfig}>
+            <ComposedChart data={rows} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+              <CartesianGrid vertical={false} />
+              <XAxis dataKey="label" tickLine={false} axisLine={false} minTickGap={24} />
+              <YAxis
+                yAxisId="tokens"
+                width={56}
+                tickLine={false}
+                axisLine={false}
+                tickFormatter={(value: number | string) => formatMetricValue(value)}
+              />
+              <YAxis
+                yAxisId="rate"
+                orientation="right"
+                width={44}
+                domain={[0, 100]}
+                tickLine={false}
+                axisLine={false}
+                tickFormatter={(value: number | string) =>
+                  typeof value === "number" ? `${value}%` : String(value)
+                }
+              />
+              <ChartTooltip
+                content={
+                  <ChartTooltipContent
+                    labelFormatter={(_label, payload) => {
+                      const entry = payload?.[0]?.payload as { bucketStart?: unknown } | undefined;
+                      const bucketStart = entry?.bucketStart;
+                      return typeof bucketStart === "string"
+                        ? formatFullDateTime(bucketStart)
+                        : "未知时间";
+                    }}
+                  />
+                }
+              />
+              <ChartLegend content={<ChartLegendContent />} />
+              <Area
+                yAxisId="tokens"
+                type="linear"
+                dataKey="tokens"
+                name="总输入 token"
+                stroke="var(--color-tokens)"
+                fill="var(--color-tokens)"
+                fillOpacity={0.2}
+                strokeWidth={2}
+                connectNulls={false}
+                isAnimationActive={false}
+              />
+              <Line
+                yAxisId="rate"
+                type="monotone"
+                dataKey="ratePct"
+                name="缓存命中率"
+                stroke="var(--color-ratePct)"
+                strokeWidth={2}
+                dot={false}
+                connectNulls
+                isAnimationActive={false}
+              />
+            </ComposedChart>
+          </ChartContainer>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/pages/dashboard/DashboardCacheChart.tsx
+++ b/apps/web/src/pages/dashboard/DashboardCacheChart.tsx
@@ -128,6 +128,20 @@ export function DashboardCacheChart({ range }: { range: DashboardRange }) {
                         ? formatFullDateTime(bucketStart)
                         : "未知时间";
                     }}
+                    // 自定义每行：命中率带 % 单位、token 千分位；且 0 值也显示（默认 falsy 守卫会吞 0）。
+                    formatter={(value, name, item) => {
+                      const numeric = typeof value === "number" ? value : Number(value);
+                      const suffix = item?.dataKey === "ratePct" ? "%" : "";
+                      return (
+                        <div className="flex flex-1 justify-between gap-3 leading-none">
+                          <span className="text-muted-foreground">{name}</span>
+                          <span className="font-mono font-medium tabular-nums text-foreground">
+                            {formatMetricValue(numeric)}
+                            {suffix}
+                          </span>
+                        </div>
+                      );
+                    }}
                   />
                 }
               />

--- a/apps/web/src/pages/dashboard/DashboardPage.tsx
+++ b/apps/web/src/pages/dashboard/DashboardPage.tsx
@@ -9,6 +9,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { DashboardCacheChart } from "./DashboardCacheChart";
 import { DashboardChart, DashboardOverlayChart, type DashboardRange } from "./dashboard-charts";
 
 // === 大盘 ===
@@ -22,8 +23,6 @@ const LLM_LATENCY = "llm.call.latency";
 const LLM_TOKENS = "llm.call.tokens";
 const MODEL_TAG = "model";
 
-// 主 Agent 主循环的调用来处（LlmUsageId），用于「主 Agent 输入 token」图过滤。
-const AGENT_USAGE = { usage: { op: "eq" as const, value: "agent" } };
 // 延迟图只算成功调用：失败（尤其超时，latency=整个超时时长）会污染 avg/P99 读数。
 const SUCCESS_ONLY = { status: { op: "eq" as const, value: "success" } };
 
@@ -142,23 +141,7 @@ export function DashboardPage() {
             range={range}
           />
 
-          <DashboardOverlayChart
-            title="主 Agent 输入 token"
-            subtitle="缓存命中输入 vs 总输入"
-            total={{
-              label: "总输入",
-              metricName: LLM_TOKENS,
-              aggregator: "sum",
-              tagFilters: { ...AGENT_USAGE, kind: { op: "eq", value: "input_total" } },
-            }}
-            subset={{
-              label: "缓存命中输入",
-              metricName: LLM_TOKENS,
-              aggregator: "sum",
-              tagFilters: { ...AGENT_USAGE, kind: { op: "eq", value: "input_cache_hit" } },
-            }}
-            range={range}
-          />
+          <DashboardCacheChart range={range} />
 
           <DashboardChart
             title="LLM 输出 token"

--- a/apps/web/src/pages/dashboard/DashboardPage.tsx
+++ b/apps/web/src/pages/dashboard/DashboardPage.tsx
@@ -121,7 +121,7 @@ export function DashboardPage() {
 
           <DashboardChart
             title="LLM 调用耗时均值"
-            subtitle="成功调用 · 按模型分组 · 毫秒"
+            subtitle="成功调用 · 按模型分组 · 秒"
             metricName={LLM_LATENCY}
             aggregator="avg"
             groupByTag={MODEL_TAG}
@@ -132,7 +132,7 @@ export function DashboardPage() {
 
           <DashboardChart
             title="LLM 调用耗时 P99"
-            subtitle="成功调用 · 按模型分组 · 毫秒"
+            subtitle="成功调用 · 按模型分组 · 秒"
             metricName={LLM_LATENCY}
             aggregator="p99"
             groupByTag={MODEL_TAG}

--- a/apps/web/src/pages/dashboard/dashboard-cache.ts
+++ b/apps/web/src/pages/dashboard/dashboard-cache.ts
@@ -1,0 +1,35 @@
+import type { MetricChartQueryResponse } from "@kagami/metric-api/chart";
+import { formatBucketLabel } from "@/components/metric/metric-format";
+
+// 缓存图把「总输入 token（绝对量）」与「缓存命中率（派生比率）」两条各自查询按桶对齐成一行行，供双 Y
+// 轴 composed 图用：左轴画 token 面积、右轴画命中率 %。两条查询共享同一 range/bucket，桶轴一致。
+
+export type CacheRow = {
+  bucketStart: string;
+  label: string;
+  /** 总输入 token（左轴，面积）。 */
+  tokens: number | null;
+  /** 缓存命中率 %（右轴，线）；派生比率 0-1 × 100，缺桶 / 除零为 null。 */
+  ratePct: number | null;
+};
+
+export function buildCacheRows(
+  total: MetricChartQueryResponse | undefined,
+  rate: MetricChartQueryResponse | undefined,
+): CacheRow[] {
+  const totalPoints = total?.series[0]?.points ?? [];
+  const rateByBucket = new Map<string, number | null>();
+  for (const point of rate?.series[0]?.points ?? []) {
+    rateByBucket.set(point.bucketStart, point.value);
+  }
+
+  return totalPoints.map(point => {
+    const ratio = rateByBucket.get(point.bucketStart);
+    return {
+      bucketStart: point.bucketStart,
+      label: formatBucketLabel(point.bucketStart),
+      tokens: point.value,
+      ratePct: ratio === undefined || ratio === null ? null : ratio * 100,
+    };
+  });
+}

--- a/apps/web/test/dashboard-cache.test.ts
+++ b/apps/web/test/dashboard-cache.test.ts
@@ -1,0 +1,57 @@
+import type { MetricChartQueryResponse } from "@kagami/metric-api/chart";
+import { describe, expect, it } from "vitest";
+import { buildCacheRows } from "@/pages/dashboard/dashboard-cache";
+
+function response(
+  points: Array<{ bucketStart: string; value: number | null }>,
+): MetricChartQueryResponse {
+  return {
+    bucket: "1m",
+    startAt: "2026-04-02T00:00:00.000Z",
+    endAt: "2026-04-02T00:02:00.000Z",
+    series: points.length ? [{ key: "s", label: "s", points }] : [],
+  };
+}
+
+const b0 = "2026-04-02T00:00:00.000Z";
+const b1 = "2026-04-02T00:01:00.000Z";
+
+describe("buildCacheRows", () => {
+  it("aligns total tokens with the derived rate (× 100) by bucket", () => {
+    const rows = buildCacheRows(
+      response([
+        { bucketStart: b0, value: 1000 },
+        { bucketStart: b1, value: 2000 },
+      ]),
+      response([
+        { bucketStart: b0, value: 0.999 },
+        { bucketStart: b1, value: 0.95 },
+      ]),
+    );
+
+    expect(rows.map(r => ({ tokens: r.tokens, ratePct: r.ratePct }))).toEqual([
+      { tokens: 1000, ratePct: 99.9 },
+      { tokens: 2000, ratePct: 95 },
+    ]);
+  });
+
+  it("keeps rate null when the derive series has no value for a bucket (missing or divzero)", () => {
+    const rows = buildCacheRows(
+      response([
+        { bucketStart: b0, value: 500 },
+        { bucketStart: b1, value: 0 },
+      ]),
+      // b0 divzero → null; b1 absent from derive series entirely.
+      response([{ bucketStart: b0, value: null }]),
+    );
+
+    expect(rows).toEqual([
+      { bucketStart: b0, label: rows[0]?.label, tokens: 500, ratePct: null },
+      { bucketStart: b1, label: rows[1]?.label, tokens: 0, ratePct: null },
+    ]);
+  });
+
+  it("returns no rows when there is no total token data", () => {
+    expect(buildCacheRows(response([]), response([{ bucketStart: b0, value: 0.9 }]))).toEqual([]);
+  });
+});

--- a/apps/web/test/metric-format.test.ts
+++ b/apps/web/test/metric-format.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { formatCompactNumber } from "@/components/metric/metric-format";
+
+describe("formatCompactNumber", () => {
+  it("compacts large numbers to K / M / B so narrow axes don't overflow", () => {
+    expect(formatCompactNumber(1_500_000)).toBe("1.5M");
+    expect(formatCompactNumber(1_435_008)).toBe("1.44M");
+    expect(formatCompactNumber(12_000)).toBe("12K");
+    expect(formatCompactNumber(2_500_000_000)).toBe("2.5B");
+  });
+
+  it("leaves sub-1000 values readable (latency seconds, counts, percentages)", () => {
+    expect(formatCompactNumber(8.1)).toBe("8.1");
+    expect(formatCompactNumber(79)).toBe("79");
+    expect(formatCompactNumber(999)).toBe("999");
+    expect(formatCompactNumber(0)).toBe("0");
+  });
+
+  it("passes non-finite / non-number through as string", () => {
+    expect(formatCompactNumber(Number.NaN)).toBe("NaN");
+    expect(formatCompactNumber("x")).toBe("x");
+  });
+});


### PR DESCRIPTION
## 背景
你指出「缓存命中 vs 总输入」面积图 + 单独的缓存命中率图有重复（两条绝对量面积的比值本就是命中率）。合并成**一张双 Y 轴图**。

## 改动
- 大盘第 4 张换成 `DashboardCacheChart`（recharts ComposedChart）：
  - **左轴**：总输入 token（面积，`llm.call.tokens` sum，usage=agent kind=input_total）
  - **右轴**：缓存命中率 %（线，走 P3 `/metric/derive` cache_hit÷input_total，口径收后端不散前端）
  - 一张图同时给出「用了多少 token」与「命中率多少」，不再分两张。
- 纯 `buildCacheRows` 按桶对齐两条查询（共享 range → 桶轴一致）。
- 抽 `metric-format.ts` 共享格式化 helper（MetricChartView + 缓存图复用）。

## 生产校验
derive 命中率查询实测返回 ~99.9%（[0.9993, 0.9989, 0.9988]）。

## 边界
纯前端、无迁移无新依赖。部署走全量 build + `app:deploy gateway`。