### PR TITLE
feat(web): 大盘一组调整（token 图折线 + 耗时改秒展示 + 命中率轴自适应）

### DIFF
--- a/apps/llm/src/app/llm-metrics.ts
+++ b/apps/llm/src/app/llm-metrics.ts
@@ -18,7 +18,6 @@ const METRIC_LATENCY = "llm.call.latency";
 const METRIC_TOKENS = "llm.call.tokens";
 
 /** 毫秒 → 秒。latency 以秒为单位打点（前端直接显示秒，单位口径在后端定死）。 */
-const MS_PER_SECOND = 1000;
 
 /** response.usage 的 token 字段 → 打点 kind。input_total = 命中 + 未命中（见 claude-code-response）。 */
 const TOKEN_KINDS: ReadonlyArray<readonly [kind: string, field: string]> = [
@@ -51,8 +50,8 @@ export function recordLlmCallMetrics(
 
   void metricService.record({
     metricName: METRIC_LATENCY,
-    // 以秒打点：LLM 调用动辄数秒，秒比毫秒更好读；p50/p95/p99 也直接是秒。
-    value: observation.latencyMs / MS_PER_SECOND,
+    // 打点存原始毫秒（无损整数）；秒是展示层的事，由前端 ÷1000 换算。
+    value: observation.latencyMs,
     tags: { ...base, status: observation.status },
   });
 

--- a/apps/llm/test/llm-metrics.test.ts
+++ b/apps/llm/test/llm-metrics.test.ts
@@ -79,8 +79,8 @@ describe("recordLlmCallMetrics", () => {
     expect(byMetric("llm.call.latency")).toEqual([
       {
         metricName: "llm.call.latency",
-        // latencyMs 1234 → 以秒打点 = 1.234。
-        value: 1.234,
+        // 打点存原始毫秒；秒换算在前端。
+        value: 1234,
         tags: { provider: "claude-code", model: "claude-x", usage: "agent", status: "success" },
       },
     ]);

--- a/apps/web/src/pages/dashboard/DashboardCacheChart.tsx
+++ b/apps/web/src/pages/dashboard/DashboardCacheChart.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { Area, CartesianGrid, ComposedChart, Line, XAxis, YAxis } from "recharts";
+import { CartesianGrid, ComposedChart, Line, XAxis, YAxis } from "recharts";
 import {
   formatCompactNumber,
   formatFullDateTime,
@@ -150,15 +150,14 @@ export function DashboardCacheChart({ range }: { range: DashboardRange }) {
                 }
               />
               <ChartLegend content={<ChartLegendContent />} />
-              <Area
+              <Line
                 yAxisId="tokens"
-                type="linear"
+                type="monotone"
                 dataKey="tokens"
                 name="总输入 token"
                 stroke="var(--color-tokens)"
-                fill="var(--color-tokens)"
-                fillOpacity={0.2}
                 strokeWidth={2}
+                dot={false}
                 connectNulls={false}
                 isAnimationActive={false}
               />

--- a/apps/web/src/pages/dashboard/DashboardCacheChart.tsx
+++ b/apps/web/src/pages/dashboard/DashboardCacheChart.tsx
@@ -63,6 +63,11 @@ export function DashboardCacheChart({ range }: { range: DashboardRange }) {
     () => buildCacheRows(totalQuery.data, rateQuery.data),
     [totalQuery.data, rateQuery.data],
   );
+  // 命中率 Y 轴自适应：数据全在 90-100 就放大到 [90,100] 看高区间波动；一旦有 <90 的点就回退 [0,100]。
+  const rateDomain = useMemo<[number, number]>(() => {
+    const hasBelow90 = rows.some(row => row.ratePct !== null && row.ratePct < 90);
+    return hasBelow90 ? [0, 100] : [90, 100];
+  }, [rows]);
 
   const isLoading = totalQuery.isLoading || rateQuery.isLoading;
   const isError = totalQuery.isError || rateQuery.isError;
@@ -115,7 +120,7 @@ export function DashboardCacheChart({ range }: { range: DashboardRange }) {
                 yAxisId="rate"
                 orientation="right"
                 width={44}
-                domain={[0, 100]}
+                domain={rateDomain}
                 tickLine={false}
                 axisLine={false}
                 tickFormatter={(value: number | string) =>

--- a/apps/web/src/pages/dashboard/DashboardPage.tsx
+++ b/apps/web/src/pages/dashboard/DashboardPage.tsx
@@ -127,6 +127,7 @@ export function DashboardPage() {
             groupByTag={MODEL_TAG}
             tagFilters={SUCCESS_ONLY}
             chartType="line"
+            valueScale={0.001}
             range={range}
           />
 
@@ -138,6 +139,7 @@ export function DashboardPage() {
             groupByTag={MODEL_TAG}
             tagFilters={SUCCESS_ONLY}
             chartType="line"
+            valueScale={0.001}
             range={range}
           />
 

--- a/apps/web/src/pages/dashboard/DashboardPage.tsx
+++ b/apps/web/src/pages/dashboard/DashboardPage.tsx
@@ -150,7 +150,7 @@ export function DashboardPage() {
             aggregator="sum"
             tagFilters={{ kind: { op: "eq", value: "output" } }}
             groupByTag={MODEL_TAG}
-            chartType="area"
+            chartType="line"
             range={range}
           />
         </div>

--- a/apps/web/src/pages/dashboard/dashboard-charts.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-charts.tsx
@@ -1,9 +1,11 @@
 import type {
   MetricChartAggregator,
   MetricChartBucket,
+  MetricChartQueryResponse,
   MetricChartQueryRequest,
   MetricChartTagFilters,
 } from "@kagami/metric-api/chart";
+import { useMemo } from "react";
 import { MetricChartView, type MetricChartType } from "@/components/metric/MetricChartView";
 import { useMetricChartData } from "@/components/metric/useMetricChartData";
 import { getApiErrorMessage } from "@/lib/api";
@@ -39,6 +41,26 @@ function toRequest(
 
 const CHART_HEIGHT = 300;
 
+/** 显示前把每个点乘以 scale（如延迟 ms→秒 传 0.001）；null 保持 null。 */
+function scaleResponse(
+  data: MetricChartQueryResponse | undefined,
+  scale: number,
+): MetricChartQueryResponse | undefined {
+  if (!data) {
+    return data;
+  }
+  return {
+    ...data,
+    series: data.series.map(series => ({
+      ...series,
+      points: series.points.map(point => ({
+        ...point,
+        value: point.value === null ? null : point.value * scale,
+      })),
+    })),
+  };
+}
+
 type DashboardChartProps = {
   title: string;
   subtitle?: string;
@@ -47,6 +69,8 @@ type DashboardChartProps = {
   chartType: MetricChartType;
   groupByTag?: string;
   tagFilters?: MetricChartTagFilters;
+  /** 显示前的值缩放系数（如延迟 ms→秒 传 0.001）；缺省不缩放。存储值不变，只改展示。 */
+  valueScale?: number;
   range: DashboardRange;
 };
 
@@ -59,10 +83,15 @@ export function DashboardChart({
   chartType,
   groupByTag,
   tagFilters,
+  valueScale,
   range,
 }: DashboardChartProps) {
   const query = useMetricChartData(
     toRequest({ metricName, aggregator, groupByTag, tagFilters }, range),
+  );
+  const data = useMemo(
+    () => (valueScale === undefined ? query.data : scaleResponse(query.data, valueScale)),
+    [query.data, valueScale],
   );
 
   return (
@@ -73,7 +102,7 @@ export function DashboardChart({
       isLoading={query.isLoading}
       isError={query.isError}
       errorMessage={query.isError ? getApiErrorMessage(query.error) : undefined}
-      data={query.data}
+      data={data}
       height={CHART_HEIGHT}
     />
   );


### PR DESCRIPTION
本次大盘一组迭代（前端为主 + 后端一处）：

1. **两张 token 图改折线**：LLM 输出 token、主 Agent 输入 token（双轴左轴）从面积 → 折线。
2. **耗时改回毫秒打点、前端换算秒**：`llm.call.latency` 打点存回原始毫秒（无损整数）；前端 `DashboardChart` 加 `valueScale`，两张延迟图传 `0.001` 显示秒。单位是展示层的事，存储值不变。
3. **缓存命中率 Y 轴自适应**：数据全在 90-100 → 轴 `[90,100]`（放大看高区间波动）；一旦有 <90 的点 → `[0,100]`（全貌）。

## 边界
- 含后端一处（llm-metrics 改回 ms）→ 部署要 `app:deploy llm` + 全量 build + `app:deploy gateway`。
- 五件套 + 全量测试全绿。