### PR TITLE
perf(llm): 成功轮不落 native_request_payload，控 llm_chat_call 库体积

### DIFF
--- a/apps/llm/src/app/llm-service-runtime.ts
+++ b/apps/llm/src/app/llm-service-runtime.ts
@@ -31,6 +31,7 @@ import { InternalLlmHandler } from "../http/internal-llm.handler.js";
 import { loadLlmServiceConfig } from "./config.js";
 import { startAuthRefreshTimers, type AuthRefreshTimers } from "./auth-refresh-timers.js";
 import { buildClaudeFileGcTask } from "./claude-file-gc-task.js";
+import { persistLlmChatCall } from "./persist-llm-chat-call.js";
 
 const logger = new AppLogger({ source: "llm-service-bootstrap" });
 
@@ -97,40 +98,13 @@ export async function buildLlmServiceRuntime(): Promise<LlmServiceRuntime> {
     baseUrl: `http://${config.services.metric.host}:${config.services.metric.port}`,
   });
 
-  // 落库在服务内：llm-client 只发 observation，这里订阅后写 llm_chat_call。返回 DAO 的
-  // Promise，让 client 内部 emitObservation 统一 catch（写库失败不影响 LLM 结果）。
+  // 落库在服务内：llm-client 只发 observation，这里订阅后写 llm_chat_call（策略见 persistLlmChatCall，
+  // 成功轮不落 native_request_payload 以控库体积）。返回 DAO 的 Promise，让 client 内部
+  // emitObservation 统一 catch（写库失败不影响 LLM 结果）。
   const recordLlmChatObservation = (observation: LlmChatCallObservation): Promise<void> => {
     // 每次 attempt 顺手打点（provider/model/status/latency/usage来处/token/失败原因），与落库解耦。
     recordLlmCallMetrics(metricService, observation);
-    if (observation.status === "success") {
-      return llmChatCallDao.recordSuccess({
-        provider: observation.provider,
-        model: observation.model,
-        extension: observation.extension,
-        requestId: observation.requestId,
-        seq: observation.seq,
-        latencyMs: observation.latencyMs,
-        request: observation.request,
-        response: observation.response,
-        nativeRequestPayload: observation.nativeRequestPayload,
-        nativeResponsePayload: observation.nativeResponsePayload,
-      });
-    }
-
-    return llmChatCallDao.recordError({
-      provider: observation.provider,
-      model: observation.model,
-      extension: observation.extension,
-      requestId: observation.requestId,
-      seq: observation.seq,
-      latencyMs: observation.latencyMs,
-      request: observation.request,
-      ...(observation.response ? { response: observation.response } : {}),
-      nativeRequestPayload: observation.nativeRequestPayload,
-      nativeResponsePayload: observation.nativeResponsePayload,
-      nativeError: observation.nativeError,
-      error: observation.error,
-    });
+    return persistLlmChatCall(llmChatCallDao, observation);
   };
 
   const llmClient: LlmClient = createLlmClient({

--- a/apps/llm/src/app/persist-llm-chat-call.ts
+++ b/apps/llm/src/app/persist-llm-chat-call.ts
@@ -1,0 +1,49 @@
+import type { LlmChatCallObservation } from "@kagami/llm-client";
+import type { LlmChatCallDao } from "@kagami/persistence/dao/llm-chat-call.dao";
+
+/**
+ * 把一条 LLM observation 落成 llm_chat_call 行（打点等其它订阅动作在调用方，与落库解耦）。
+ * 返回 DAO 的 Promise，让 client 内部 emitObservation 统一 catch（写库失败不影响 LLM 结果）。
+ *
+ * **成功轮刻意不落 native_request_payload**：它是 request_payload 的另一份序列化（同一批
+ * messages，只是 provider wire 形状）。ReAct 每轮把当前全部历史重发给 LLM，故这两列都随会话
+ * 长度线性增大，一个长会话累计写入 = O(轮数²)，两列并存又把常数翻倍，是 llm_chat_call 磁盘
+ * 占用的主要来源。native 请求体几乎只在诊断 provider 侧 native error 时有价值，成功轮无此需求，
+ * 丢弃可省掉约一半每行写入。**失败轮完整保留 native_request_payload**（历史上 lone-surrogate
+ * 400 之类正是靠它定位）。response 两列体量是 O(1)/行（单条回复、不含历史），不参与平方增长，
+ * 保留不动。
+ */
+export function persistLlmChatCall(
+  dao: LlmChatCallDao,
+  observation: LlmChatCallObservation,
+): Promise<void> {
+  if (observation.status === "success") {
+    return dao.recordSuccess({
+      provider: observation.provider,
+      model: observation.model,
+      extension: observation.extension,
+      requestId: observation.requestId,
+      seq: observation.seq,
+      latencyMs: observation.latencyMs,
+      request: observation.request,
+      response: observation.response,
+      nativeRequestPayload: null,
+      nativeResponsePayload: observation.nativeResponsePayload,
+    });
+  }
+
+  return dao.recordError({
+    provider: observation.provider,
+    model: observation.model,
+    extension: observation.extension,
+    requestId: observation.requestId,
+    seq: observation.seq,
+    latencyMs: observation.latencyMs,
+    request: observation.request,
+    ...(observation.response ? { response: observation.response } : {}),
+    nativeRequestPayload: observation.nativeRequestPayload,
+    nativeResponsePayload: observation.nativeResponsePayload,
+    nativeError: observation.nativeError,
+    error: observation.error,
+  });
+}

--- a/apps/llm/test/persist-llm-chat-call.test.ts
+++ b/apps/llm/test/persist-llm-chat-call.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import type { LlmChatCallObservation } from "@kagami/llm-client";
+import type { LlmChatCallDao } from "@kagami/persistence/dao/llm-chat-call.dao";
+import { persistLlmChatCall } from "../src/app/persist-llm-chat-call.js";
+
+function createDao(): LlmChatCallDao & {
+  recordSuccess: ReturnType<typeof vi.fn>;
+  recordError: ReturnType<typeof vi.fn>;
+} {
+  return {
+    countByQuery: vi.fn(),
+    listPage: vi.fn(),
+    findById: vi.fn(),
+    recordSuccess: vi.fn().mockResolvedValue(undefined),
+    recordError: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+const successObservation: LlmChatCallObservation = {
+  status: "success",
+  provider: "claude-code",
+  model: "claude",
+  usage: null,
+  extension: { actualModel: "claude-actual" },
+  requestId: "req-1",
+  seq: 1,
+  latencyMs: 42,
+  request: { messages: ["history"] },
+  response: { message: "ok" },
+  nativeRequestPayload: { anthropic: "wire body" },
+  nativeResponsePayload: { anthropic: "wire resp" },
+};
+
+const errorObservation: LlmChatCallObservation = {
+  status: "failed",
+  provider: "claude-code",
+  model: "claude",
+  usage: null,
+  extension: null,
+  requestId: "req-2",
+  seq: 1,
+  latencyMs: 7,
+  request: { messages: ["history"] },
+  nativeRequestPayload: { anthropic: "wire body" },
+  nativeResponsePayload: null,
+  nativeError: { message: "boom" },
+  error: new Error("boom"),
+};
+
+describe("persistLlmChatCall — 成功轮不落 native_request_payload", () => {
+  it("成功轮：recordSuccess 的 nativeRequestPayload 置 null，其余字段透传", async () => {
+    const dao = createDao();
+
+    await persistLlmChatCall(dao, successObservation);
+
+    expect(dao.recordError).not.toHaveBeenCalled();
+    expect(dao.recordSuccess).toHaveBeenCalledTimes(1);
+    const input = dao.recordSuccess.mock.calls[0]![0];
+    // 核心：native 请求体不落库。
+    expect(input.nativeRequestPayload).toBeNull();
+    // 其余照常透传（含 request 全量、native 响应体、response）。
+    expect(input.request).toEqual({ messages: ["history"] });
+    expect(input.response).toEqual({ message: "ok" });
+    expect(input.nativeResponsePayload).toEqual({ anthropic: "wire resp" });
+    expect(input.requestId).toBe("req-1");
+  });
+
+  it("失败轮：recordError 完整保留 native_request_payload（诊断需要）", async () => {
+    const dao = createDao();
+
+    await persistLlmChatCall(dao, errorObservation);
+
+    expect(dao.recordSuccess).not.toHaveBeenCalled();
+    expect(dao.recordError).toHaveBeenCalledTimes(1);
+    const input = dao.recordError.mock.calls[0]![0];
+    // 失败轮 native 请求体必须留存。
+    expect(input.nativeRequestPayload).toEqual({ anthropic: "wire body" });
+    expect(input.nativeError).toEqual({ message: "boom" });
+    expect(input.error).toBeInstanceOf(Error);
+  });
+});


### PR DESCRIPTION
## 背景
全仓审查里「每轮全量落库 O(context²) 库膨胀」这条的高 ROI 一半（A 方案）。

`native_request_payload` 是 `request_payload` 的**另一份序列化**（同一批 messages，只是 provider wire 形状）。ReAct 每轮把当前全部历史重发给 LLM，故这两列都随会话长度线性增大——一个长会话累计写入 = **O(轮数²)**，两列并存又把常数翻倍，是 `llm_chat_call` 磁盘占用的主要来源。配合 SQLite「删行不回缩文件」，历史高水位会长期驻留（21GB 库的机制之一）。

> 注：`llm_chat_call` 已有 1 天 retention TTL，常驻行数本就受限；本 PR 进一步砍每行体积 + 降写放大。

## 改动
把内联的落库闭包抽成独立可测函数 `persistLlmChatCall(dao, observation)`（[persist-llm-chat-call.ts](apps/llm/src/app/persist-llm-chat-call.ts)），并令 **成功轮不落 `native_request_payload`**（传 `null` → 存 DB NULL）:

- native 请求体只在诊断 provider 侧 native error 时有价值，成功轮无此需求，丢弃省掉**约一半每行写入**。
- **失败轮完整保留**（历史上 lone-surrogate 400 之类正是靠它定位）。
- `response` 两列体量 O(1)/行、不参与平方增长,保留不动;metric 打点与落库解耦、照常调用;`usage` 一如既往只喂 metric、不落库(**非回归**)。

## 安全
- **抽取忠实**:recordSuccess/recordError 字段与原闭包逐一对齐,仅 `nativeRequestPayload` 成功轮改 null。
- **无消费方假设成功轮非空**:console mapper 纯透传、wire schema `.nullable()`;前端 DetailPanel/Playground 走与 `nativeError=null` 同一 null-safe 渲染。
- **DAO/schema**:入参 `Record | null`、`native_request_payload Json?`,写 null 即 DB NULL,与失败轮同路径(已有测试覆盖)。
- **KV**:纯落库策略,不碰 provider 请求装配,对缓存前缀零影响。

## 测试
`apps/llm/test/persist-llm-chat-call.test.ts`:成功轮 `nativeRequestPayload` 置 null 且其余字段透传(fixture 给了非空值,证明是「置空」而非「本来就空」)、失败轮完整保留。五件套 + 全量测试通过。

## 审查
opus finder 五点全 CONFIRMED,无真问题。

无 DB 迁移(列本就 nullable)。属这条优化的第一半;另一半(部署时 VACUUM 缩文件)按需再议。