### PR TITLE
chore(config): 图片转文字改用 claude-sonnet-5 并移除 codex 兜底

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -91,6 +91,7 @@ server:
         models:
           - claude-opus-4-8
           - claude-opus-4-6
+          - claude-sonnet-5
           - claude-sonnet-4-6
           - claude-haiku-4-5
         keepAliveReplayIntervalMinutes: 30
@@ -116,11 +117,8 @@ server:
       vision:
         attempts:
           - provider: claude-code
-            model: claude-haiku-4-5
+            model: claude-sonnet-5
             times: 2
-          - provider: openai-codex
-            model: gpt-5.4-mini
-            times: 1
       todoSuggestionAgent:
         attempts:
           - provider: claude-code


### PR DESCRIPTION
## 改动

图片转文字（`vision` usage）配置调整，均在 `config.yaml`：

1. **主模型换 Sonnet 5**：`claude-haiku-4-5` → `claude-sonnet-5`，并把 `claude-sonnet-5` 加入 `claudeCode` provider 的 `models` 白名单（否则 `llm-client` 运行时校验会拒）。
2. **移除 codex 兜底**：删掉 `openai-codex` / `gpt-5.4-mini` 那条 fallback attempt。

## 为什么去兜底安全

vision 失败时 `image-message-analyzer.ts` 的 `describe()` 已 catch 异常并返回空描述，`resid` 由 `archive()` 独立产出——所以 Sonnet 5 失败 = 描述为空 + resid 照常。小镜需要时可凭 resid 自行看原图，无需再花一次 codex 调用兜底文字描述。

## 影响面

纯配置值改动，不动任何 TS 代码，不涉及 DB 迁移，不触碰 KV 缓存前缀。生效需重载 `kagami-llm`（`pnpm app:deploy llm`）。

## 检查

- ✅ pnpm build / typecheck / lint / format / knip 全过（lint/knip 仅既存无关 warning）