### PR TITLE
style(web): 大盘图表曲线由贝塞尔改为直线折线

### DIFF
--- a/apps/web/src/components/metric/MetricChartView.tsx
+++ b/apps/web/src/components/metric/MetricChartView.tsx
@@ -275,7 +275,7 @@ export function MetricChartView({
                   {renderSeries.map(series => (
                     <Line
                       key={series.key}
-                      type="monotone"
+                      type="linear"
                       dataKey={series.dataKey}
                       name={series.label}
                       stroke={`var(--color-${series.dataKey})`}

--- a/apps/web/src/pages/auth/AuthPage.tsx
+++ b/apps/web/src/pages/auth/AuthPage.tsx
@@ -560,7 +560,7 @@ function UsageTrendPanel({
           />
           <ChartLegend content={<ChartLegendContent />} />
           <Area
-            type="monotone"
+            type="linear"
             dataKey="five_hour"
             stroke="var(--color-five_hour)"
             fill={`url(#${gradientPrefix}-five-hour)`}
@@ -568,7 +568,7 @@ function UsageTrendPanel({
             connectNulls
           />
           <Area
-            type="monotone"
+            type="linear"
             dataKey="seven_day"
             stroke="var(--color-seven_day)"
             fill={`url(#${gradientPrefix}-seven-day)`}

--- a/apps/web/src/pages/dashboard/DashboardCacheChart.tsx
+++ b/apps/web/src/pages/dashboard/DashboardCacheChart.tsx
@@ -157,7 +157,7 @@ export function DashboardCacheChart({ range }: { range: DashboardRange }) {
               <ChartLegend content={<ChartLegendContent />} />
               <Line
                 yAxisId="tokens"
-                type="monotone"
+                type="linear"
                 dataKey="tokens"
                 name="总输入 token"
                 stroke="var(--color-tokens)"
@@ -168,7 +168,7 @@ export function DashboardCacheChart({ range }: { range: DashboardRange }) {
               />
               <Line
                 yAxisId="rate"
-                type="monotone"
+                type="linear"
                 dataKey="ratePct"
                 name="缓存命中率"
                 stroke="var(--color-ratePct)"


### PR DESCRIPTION
## 改动

把前端所有 recharts 图表的贝塞尔平滑曲线（`type="monotone"`）统一改为直线折线（`type="linear"`），点与点之间用直线段连接，不再平滑。

涉及 3 处组件、共 5 个曲线：

- `MetricChartView.tsx` — 大盘图表走的共享折线组件（`DashboardChart` / `DashboardOverlayChart` 复用）。面积图那条本就是 `linear`，未动。
- `DashboardCacheChart.tsx` — 缓存图的 token 折线 + 命中率折线。
- `AuthPage.tsx` — 用量趋势的两条面积线，一并改保持一致。

## 影响

纯视觉表现调整，不涉及数据 / 逻辑 / 后端。

## 验证

- `pnpm build` ✅
- `pnpm --filter @kagami/web typecheck` ✅
- `pnpm lint` ✅（仅既有 react-refresh 警告）
- `pnpm format` ✅
- `pnpm knip` ✅（仅既有 unused-export 警告）