### PR TITLE
refactor(web): 前端接入 @kagami/rpc-client，消除 lib/api.ts 手写 fetch

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
     "@kagami/llm-api": "workspace:*",
     "@kagami/metric-api": "workspace:*",
     "@kagami/oss-api": "workspace:*",
+    "@kagami/rpc-client": "workspace:*",
     "@radix-ui/react-select": "^2.2.6",
     "@tanstack/react-query": "^5.90.21",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/src/components/metric/useMetricChartData.ts
+++ b/apps/web/src/components/metric/useMetricChartData.ts
@@ -1,14 +1,9 @@
-import {
-  MetricChartQueryResponseSchema,
-  type MetricChartQueryRequest,
-} from "@kagami/metric-api/chart";
-import { metricApiContract } from "@kagami/metric-api/contract";
-import { contractUrl } from "@kagami/http/url";
+import { type MetricChartQueryRequest } from "@kagami/metric-api/chart";
 import { useQuery } from "@tanstack/react-query";
-import { apiPostWithSchema } from "@/lib/api";
 import { queryKeys } from "@/lib/query";
+import { metricClient } from "@/lib/rpc";
 
-// === 取数层：只管 react-query + 契约 path + POST + zod parse（#444）===
+// === 取数层：只管 react-query + 契约 client + POST（#444）===
 //
 // 图表定义已迁回代码，此 hook 直接把内联聚合规格 POST 给 /metric/query。与展示层
 // (<MetricChartView />) 解耦，方便日后一页多图共享 range 或页面自控 range 时复用。
@@ -16,12 +11,7 @@ import { queryKeys } from "@/lib/query";
 export function useMetricChartData(request: MetricChartQueryRequest, enabled = true) {
   return useQuery({
     queryKey: queryKeys.metricChart.data(request),
-    queryFn: () =>
-      apiPostWithSchema(
-        contractUrl(metricApiContract.query),
-        request,
-        MetricChartQueryResponseSchema,
-      ),
+    queryFn: () => metricClient.query(request),
     enabled,
   });
 }

--- a/apps/web/src/components/metric/useMetricDerivedData.ts
+++ b/apps/web/src/components/metric/useMetricDerivedData.ts
@@ -1,10 +1,7 @@
-import { MetricChartQueryResponseSchema } from "@kagami/metric-api/chart";
-import { metricApiContract } from "@kagami/metric-api/contract";
 import { type MetricDeriveRequest } from "@kagami/metric-api/derive";
-import { contractUrl } from "@kagami/http/url";
 import { useQuery } from "@tanstack/react-query";
-import { apiPostWithSchema } from "@/lib/api";
 import { queryKeys } from "@/lib/query";
+import { metricClient } from "@/lib/rpc";
 
 // === 派生取数层（#475 P3）===
 //
@@ -15,12 +12,7 @@ import { queryKeys } from "@/lib/query";
 export function useMetricDerivedData(request: MetricDeriveRequest, enabled = true) {
   return useQuery({
     queryKey: queryKeys.metricChart.derived(request),
-    queryFn: () =>
-      apiPostWithSchema(
-        contractUrl(metricApiContract.derive),
-        request,
-        MetricChartQueryResponseSchema,
-      ),
+    queryFn: () => metricClient.derive(request),
     enabled,
   });
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,195 +1,23 @@
-export type ApiRequestResult = {
-  ok: boolean;
-  status: number;
-  statusText: string;
-  headers: Record<string, string>;
-  contentType: string | null;
-  body: unknown;
-  rawBody: string | null;
-};
-
-type ApiRequestWithSchemaParams<T> = {
-  path: string;
-  schema: { parse: (value: unknown) => T };
-  init?: RequestInit;
-};
-
 const DEFAULT_API_BASE_PATH = "/api";
 
-export class ApiError extends Error {
-  readonly status: number;
-  readonly statusText: string;
-  readonly body: unknown;
-  readonly result: ApiRequestResult;
-
-  constructor(result: ApiRequestResult) {
-    super(resolveApiErrorMessage(result));
-    this.name = "ApiError";
-    this.status = result.status;
-    this.statusText = result.statusText;
-    this.body = result.body;
-    this.result = result;
-  }
+/** 解析 API base（VITE_API_BASE_URL 覆盖，缺省 /api），去尾斜杠。RPC client 与 buildApiUrl 共用。 */
+export function resolveApiBaseUrl(): string {
+  const configured = import.meta.env.VITE_API_BASE_URL?.trim();
+  const base = configured && configured.length > 0 ? configured : DEFAULT_API_BASE_PATH;
+  return base.replace(/\/+$/, "");
 }
 
+/** 拼出一个后端资源的完整 URL（如 OSS 对象预览图的 src），走同一套 base 解析。 */
 export function buildApiUrl(path: string): string {
   const normalizedPath = path.startsWith("/") ? path : `/${path}`;
-  const configuredBaseUrl = import.meta.env.VITE_API_BASE_URL?.trim();
-  const baseUrl =
-    configuredBaseUrl && configuredBaseUrl.length > 0 ? configuredBaseUrl : DEFAULT_API_BASE_PATH;
-
-  return `${baseUrl.replace(/\/+$/, "")}${normalizedPath}`;
+  return `${resolveApiBaseUrl()}${normalizedPath}`;
 }
 
+/** 把任意抛出的错误映射成展示文案。RPC client 的错误已在 decodeError 里把 message 备好。 */
 export function getApiErrorMessage(error: unknown): string {
-  if (error instanceof ApiError) {
-    return error.message;
-  }
-
   if (error instanceof Error) {
     return error.message;
   }
 
   return "请求失败，请稍后再试";
 }
-
-async function apiRequest(path: string, init?: RequestInit): Promise<ApiRequestResult> {
-  const headers = new Headers(init?.headers);
-  if (init?.body !== undefined && !headers.has("Content-Type")) {
-    headers.set("Content-Type", "application/json");
-  }
-
-  const res = await fetch(buildApiUrl(path), {
-    ...init,
-    headers,
-  });
-
-  const contentType = res.headers.get("content-type");
-  const rawText = await res.text();
-  let body: unknown = null;
-  if (rawText.length > 0) {
-    if (contentType?.includes("application/json")) {
-      try {
-        body = JSON.parse(rawText);
-      } catch {
-        body = rawText;
-      }
-    } else {
-      body = rawText;
-    }
-  }
-
-  const result: ApiRequestResult = {
-    ok: res.ok,
-    status: res.status,
-    statusText: res.statusText,
-    headers: Object.fromEntries(res.headers.entries()),
-    contentType,
-    body,
-    rawBody: rawText.length > 0 ? rawText : null,
-  };
-
-  if (!result.ok) {
-    throw new ApiError(result);
-  }
-
-  return result;
-}
-
-async function apiRequestWithSchema<T>({
-  path,
-  schema,
-  init,
-}: ApiRequestWithSchemaParams<T>): Promise<T> {
-  const result = await apiRequest(path, init);
-  return schema.parse(result.body);
-}
-
-async function apiPost(path: string, body?: unknown, init?: Omit<RequestInit, "body" | "method">) {
-  return apiRequest(path, {
-    ...init,
-    method: "POST",
-    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
-  });
-}
-
-async function apiGetWithSchema<T>(
-  path: string,
-  schema: ApiRequestWithSchemaParams<T>["schema"],
-  init?: Omit<RequestInit, "method">,
-): Promise<T> {
-  return apiRequestWithSchema({
-    path,
-    schema,
-    init: {
-      ...init,
-      method: "GET",
-    },
-  });
-}
-
-async function apiPostWithSchema<T>(
-  path: string,
-  body: unknown,
-  schema: ApiRequestWithSchemaParams<T>["schema"],
-  init?: Omit<RequestInit, "body" | "method">,
-): Promise<T> {
-  return apiRequestWithSchema({
-    path,
-    schema,
-    init: {
-      ...init,
-      method: "POST",
-      body: JSON.stringify(body),
-    },
-  });
-}
-
-function resolveApiErrorMessage(result: ApiRequestResult): string {
-  const bodyMessage = readApiErrorBodyMessage(result.body);
-  if (bodyMessage) {
-    return bodyMessage;
-  }
-
-  if (result.statusText) {
-    return `请求失败 (${result.status} ${result.statusText})`;
-  }
-
-  return `请求失败 (${result.status})`;
-}
-
-function readApiErrorBodyMessage(body: unknown): string | null {
-  if (typeof body === "string") {
-    const trimmed = body.trim();
-    return trimmed.length > 0 ? trimmed : null;
-  }
-
-  if (typeof body !== "object" || body === null) {
-    return null;
-  }
-
-  const recordBody = body as Record<string, unknown>;
-
-  for (const key of ["message", "error", "detail"]) {
-    const value = recordBody[key];
-    if (typeof value === "string") {
-      const trimmed = value.trim();
-      if (trimmed.length > 0) {
-        return trimmed;
-      }
-    }
-  }
-
-  const nestedError =
-    typeof recordBody.error === "object" && recordBody.error !== null
-      ? (recordBody.error as Record<string, unknown>)
-      : null;
-  if (nestedError && typeof nestedError.message === "string") {
-    const trimmed = nestedError.message.trim();
-    return trimmed.length > 0 ? trimmed : null;
-  }
-
-  return null;
-}
-
-export { apiPost, apiGetWithSchema, apiPostWithSchema };

--- a/apps/web/src/lib/query.ts
+++ b/apps/web/src/lib/query.ts
@@ -1,19 +1,11 @@
 import { QueryClient, keepPreviousData, queryOptions, type QueryKey } from "@tanstack/react-query";
-import { apiGetWithSchema } from "@/lib/api";
-import { buildQueryString } from "@/lib/search-params";
 
 type QueryParamValue = string | number | undefined;
 type QueryParams = Record<string, QueryParamValue>;
 
-type SchemaLike<T> = {
-  parse: (value: unknown) => T;
-};
-
 type CreateSchemaQueryOptionsParams<T, TQueryKey extends QueryKey> = {
   queryKey: TQueryKey;
-  path: string;
-  schema: SchemaLike<T>;
-  params?: QueryParams;
+  queryFn: () => Promise<T>;
   keepPrevious?: boolean;
 };
 
@@ -75,14 +67,12 @@ export function createAppQueryClient() {
 
 export function createSchemaQueryOptions<T, TQueryKey extends QueryKey>({
   queryKey,
-  path,
-  schema,
-  params,
+  queryFn,
   keepPrevious = false,
 }: CreateSchemaQueryOptionsParams<T, TQueryKey>) {
   return queryOptions({
     queryKey,
-    queryFn: () => apiGetWithSchema(buildPathWithQuery(path, params), schema),
+    queryFn,
     ...(keepPrevious ? { placeholderData: keepPreviousData } : {}),
   });
 }
@@ -94,13 +84,4 @@ export function createHistoryListQueryOptions<T, TQueryKey extends QueryKey>(
     ...params,
     keepPrevious: true,
   });
-}
-
-function buildPathWithQuery(path: string, params?: QueryParams): string {
-  if (!params) {
-    return path;
-  }
-
-  const query = buildQueryString(params);
-  return query.length > 0 ? `${path}?${query}` : path;
 }

--- a/apps/web/src/lib/rpc.ts
+++ b/apps/web/src/lib/rpc.ts
@@ -1,0 +1,73 @@
+import { agentApiContract } from "@kagami/agent-api/contract";
+import { consoleApiContract } from "@kagami/console-api/contract";
+import { authApiContract } from "@kagami/llm-api/auth-contract";
+import { metricApiContract } from "@kagami/metric-api/contract";
+import { ossConsoleContract } from "@kagami/oss-api/contract";
+import { createClient, type CreateClientOptions } from "@kagami/rpc-client/client";
+import { resolveApiBaseUrl } from "@/lib/api";
+
+// === 前端 → 后端的 typed RPC client（issue #499）===
+//
+// 后端 acl 层早已全面用 @kagami/rpc-client；本模块把前端这最后一个手写 fetch 的消费者也接上：
+// 用 client.method(input) 一步取代「contractUrl 取 path + 手传 schema + apiGetWithSchema」，
+// path / response schema / 入参类型全部从契约派生。
+//
+// baseUrl 统一 /api：gateway 按 path 前缀分流（/llm-chat-call→console、/auth→llm、/metric→metric、
+// 其余→agent），契约 path 自带前缀，故所有契约共用一个 baseUrl，URL 与迁移前逐字一致、路由不变。
+
+const FALLBACK_ERROR_MESSAGE = "请求失败，请稍后再试";
+
+/**
+ * 从非 2xx 响应体里抽人类可读的错误文案，镜像旧 lib/api.ts 的 ApiError 抽取逻辑（依次找
+ * message / error / detail，及嵌套 error.message）。让 getApiErrorMessage(error) 继续复用。
+ */
+function readApiErrorBodyMessage(body: unknown): string | null {
+  if (typeof body === "string") {
+    const trimmed = body.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  if (typeof body !== "object" || body === null) {
+    return null;
+  }
+
+  const recordBody = body as Record<string, unknown>;
+
+  for (const key of ["message", "error", "detail"]) {
+    const value = recordBody[key];
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed.length > 0) {
+        return trimmed;
+      }
+    }
+  }
+
+  const nestedError =
+    typeof recordBody.error === "object" && recordBody.error !== null
+      ? (recordBody.error as Record<string, unknown>)
+      : null;
+  if (nestedError && typeof nestedError.message === "string") {
+    const trimmed = nestedError.message.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  return null;
+}
+
+// 自定义错误解码：非 2xx 时优先用响应体里的文案（保留旧前端的错误展示保真），否则退化成
+// 「请求失败 (状态码)」。不可达 / 超时 / 坏响应体走 createClient 默认兜底（unreachableMessage）。
+const clientOptions: CreateClientOptions = {
+  baseUrl: resolveApiBaseUrl(),
+  unreachableMessage: FALLBACK_ERROR_MESSAGE,
+  decodeError: (status, body) => {
+    const message = readApiErrorBodyMessage(body);
+    return new Error(message ?? `请求失败 (${status})`);
+  },
+};
+
+export const consoleClient = createClient(consoleApiContract, clientOptions);
+export const agentClient = createClient(agentApiContract, clientOptions);
+export const authClient = createClient(authApiContract, clientOptions);
+export const metricClient = createClient(metricApiContract, clientOptions);
+export const ossConsoleClient = createClient(ossConsoleContract, clientOptions);

--- a/apps/web/src/lib/search-params.ts
+++ b/apps/web/src/lib/search-params.ts
@@ -57,25 +57,6 @@ export function areSearchParamsEqual(left: URLSearchParams, right: URLSearchPara
   return toComparableSearchParams(left) === toComparableSearchParams(right);
 }
 
-export function buildQueryString(params: Record<string, string | number | undefined>): string {
-  const searchParams = new URLSearchParams();
-
-  for (const [key, value] of Object.entries(params)) {
-    if (value === undefined) {
-      continue;
-    }
-
-    const normalizedValue = String(value);
-    if (normalizedValue.length === 0) {
-      continue;
-    }
-
-    searchParams.set(key, normalizedValue);
-  }
-
-  return searchParams.toString();
-}
-
 function toComparableSearchParams(params: URLSearchParams): string {
   const clone = new URLSearchParams(params);
   clone.sort();

--- a/apps/web/src/pages/app-log-history/useAppLogList.ts
+++ b/apps/web/src/pages/app-log-history/useAppLogList.ts
@@ -1,29 +1,26 @@
-import { contractUrl } from "@kagami/http/url";
-import { consoleApiContract } from "@kagami/console-api/contract";
-import { AppLogListResponseSchema, type AppLogListQuery } from "@kagami/console-api/app-log";
+import { type AppLogListQuery } from "@kagami/console-api/app-log";
 import { useQuery } from "@tanstack/react-query";
 import { createHistoryListQueryOptions, queryKeys } from "@/lib/query";
+import { consoleClient } from "@/lib/rpc";
 
 type AppLogListFilters = Omit<AppLogListQuery, "page" | "pageSize">;
 
 export function useAppLogList(page: number, pageSize: number, filters: AppLogListFilters) {
   const params = {
-    page: String(page),
-    pageSize: String(pageSize),
+    page,
+    pageSize,
     level: filters.level,
     traceId: filters.traceId,
     message: filters.message,
     source: filters.source,
     startAt: filters.startAt,
     endAt: filters.endAt,
-  } satisfies Record<string, string | undefined>;
+  };
 
   return useQuery(
     createHistoryListQueryOptions({
       queryKey: queryKeys.appLog.historyList(params),
-      path: contractUrl(consoleApiContract.queryAppLogs),
-      schema: AppLogListResponseSchema,
-      params,
+      queryFn: () => consoleClient.queryAppLogs(params),
     }),
   );
 }

--- a/apps/web/src/pages/auth/AuthPage.tsx
+++ b/apps/web/src/pages/auth/AuthPage.tsx
@@ -1,17 +1,10 @@
-import { contractUrl } from "@kagami/http/url";
-import { authApiContract } from "@kagami/llm-api/auth-contract";
 import {
-  AuthLoginUrlResponseSchema,
-  AuthRefreshResponseSchema,
-  AuthStatusResponseSchema,
-  AuthUsageLimitsResponseSchema,
   type AuthProvider,
   type AuthStatus,
   type AuthStatusResponse,
   type AuthUsageLimitsResponse,
 } from "@kagami/llm-api/auth";
 import {
-  AuthUsageTrendResponseSchema,
   type AuthUsageTrendRange,
   type AuthUsageTrendResponse,
 } from "@kagami/llm-api/auth-usage-trend";
@@ -30,9 +23,9 @@ import {
   ChartTooltipContent,
   type ChartConfig,
 } from "@/components/ui/chart";
-import { apiPost, apiPostWithSchema } from "@/lib/api";
 import { formatOptionalDateTime } from "@/lib/format";
 import { createSchemaQueryOptions, queryKeys } from "@/lib/query";
+import { authClient } from "@/lib/rpc";
 import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
 
 type PrimaryAuthStatus = Exclude<AuthStatus, "refresh_failed">;
@@ -106,49 +99,40 @@ export function AuthPage() {
   const statusQuery = useQuery({
     ...createSchemaQueryOptions({
       queryKey: queryKeys.auth.status(providerConfig.key),
-      path: buildAuthEndpoint(providerConfig.key, "status"),
-      schema: AuthStatusResponseSchema,
+      queryFn: () =>
+        authClient.getAuthStatus({ params: { provider: providerConfig.key }, input: {} }),
     }),
   });
 
   const usageLimitsQuery = useQuery({
     ...createSchemaQueryOptions({
       queryKey: queryKeys.auth.usageLimits(providerConfig.key),
-      path: buildAuthEndpoint(providerConfig.key, "usage-limits"),
-      schema: AuthUsageLimitsResponseSchema,
+      queryFn: () =>
+        authClient.getAuthUsageLimits({ params: { provider: providerConfig.key }, input: {} }),
     }),
   });
   const usageTrendQuery = useQuery({
     ...createSchemaQueryOptions({
       queryKey: queryKeys.auth.usageTrend(providerConfig.key, trendRange),
-      path: buildAuthEndpoint(providerConfig.key, "usage-trend"),
-      schema: AuthUsageTrendResponseSchema,
-      params: {
-        range: trendRange,
-      },
+      queryFn: () =>
+        authClient.getAuthUsageTrend({
+          params: { provider: providerConfig.key },
+          input: { range: trendRange },
+        }),
     }),
   });
 
   const loginMutation = useMutation({
-    mutationFn: async () => {
-      return apiPostWithSchema(
-        buildAuthEndpoint(providerConfig.key, "login-url"),
-        {},
-        AuthLoginUrlResponseSchema,
-      );
-    },
+    mutationFn: () =>
+      authClient.createAuthLoginUrl({ params: { provider: providerConfig.key }, input: {} }),
     onSuccess: data => {
       window.location.assign(data.loginUrl);
     },
   });
 
   const refreshMutation = useMutation({
-    mutationFn: async () =>
-      apiPostWithSchema(
-        buildAuthEndpoint(providerConfig.key, "refresh"),
-        {},
-        AuthRefreshResponseSchema,
-      ),
+    mutationFn: () =>
+      authClient.authRefresh({ params: { provider: providerConfig.key }, input: {} }),
     onSuccess: async () => {
       await queryClient.invalidateQueries({
         queryKey: queryKeys.auth.provider(providerConfig.key),
@@ -158,7 +142,7 @@ export function AuthPage() {
 
   const logoutMutation = useMutation({
     mutationFn: async () => {
-      await apiPost(buildAuthEndpoint(providerConfig.key, "logout"), {});
+      await authClient.authLogout({ params: { provider: providerConfig.key }, input: {} });
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
@@ -653,22 +637,6 @@ function UsageLimitCard({
 
 function isAuthProvider(value: string): value is AuthProvider {
   return value === "codex" || value === "claude-code";
-}
-
-const AUTH_ACTION_ROUTES = {
-  status: authApiContract.getAuthStatus,
-  "login-url": authApiContract.createAuthLoginUrl,
-  logout: authApiContract.authLogout,
-  refresh: authApiContract.authRefresh,
-  "usage-limits": authApiContract.getAuthUsageLimits,
-  "usage-trend": authApiContract.getAuthUsageTrend,
-} as const;
-
-function buildAuthEndpoint(
-  provider: AuthProvider,
-  action: keyof typeof AUTH_ACTION_ROUTES,
-): string {
-  return contractUrl(AUTH_ACTION_ROUTES[action], { params: { provider } });
 }
 
 function StatusChip({ status, tone }: { status: string; tone: "success" | "warning" | "neutral" }) {

--- a/apps/web/src/pages/control-panel/useCompactMainAgentContext.ts
+++ b/apps/web/src/pages/control-panel/useCompactMainAgentContext.ts
@@ -1,23 +1,11 @@
-import { contractUrl } from "@kagami/http/url";
-import { agentApiContract } from "@kagami/agent-api/contract";
-import {
-  MainAgentContextCompactionResultSchema,
-  type MainAgentContextCompactionResult,
-} from "@kagami/agent-api/main-agent-context";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { apiPostWithSchema } from "@/lib/api";
 import { queryKeys } from "@/lib/query";
+import { agentClient } from "@/lib/rpc";
 
 export function useCompactMainAgentContext() {
   const queryClient = useQueryClient();
-  return useMutation<MainAgentContextCompactionResult>({
-    mutationFn: async () => {
-      return await apiPostWithSchema(
-        contractUrl(agentApiContract.compactMainAgentContext),
-        {},
-        MainAgentContextCompactionResultSchema,
-      );
-    },
+  return useMutation({
+    mutationFn: () => agentClient.compactMainAgentContext({}),
     onSuccess: () => {
       // 压缩会重建上下文，主动让上下文快照重新拉取一次。
       void queryClient.invalidateQueries({ queryKey: queryKeys.mainAgentContext.recent() });

--- a/apps/web/src/pages/inner-thought/useInnerThoughtList.ts
+++ b/apps/web/src/pages/inner-thought/useInnerThoughtList.ts
@@ -1,11 +1,7 @@
-import { contractUrl } from "@kagami/http/url";
-import { consoleApiContract } from "@kagami/console-api/contract";
-import {
-  InnerThoughtListResponseSchema,
-  type InnerThoughtOutcome,
-} from "@kagami/console-api/inner-thought";
+import { type InnerThoughtOutcome } from "@kagami/console-api/inner-thought";
 import { useQuery } from "@tanstack/react-query";
 import { createHistoryListQueryOptions, queryKeys } from "@/lib/query";
+import { consoleClient } from "@/lib/rpc";
 
 export function useInnerThoughtList(
   page: number,
@@ -13,17 +9,15 @@ export function useInnerThoughtList(
   outcome: InnerThoughtOutcome | undefined,
 ) {
   const params = {
-    page: String(page),
-    pageSize: String(pageSize),
+    page,
+    pageSize,
     outcome,
-  } satisfies Record<string, string | undefined>;
+  };
 
   return useQuery(
     createHistoryListQueryOptions({
       queryKey: queryKeys.innerThought.historyList(params),
-      path: contractUrl(consoleApiContract.queryInnerThoughts),
-      schema: InnerThoughtListResponseSchema,
-      params,
+      queryFn: () => consoleClient.queryInnerThoughts(params),
     }),
   );
 }

--- a/apps/web/src/pages/llm-history/LlmHistoryPage.tsx
+++ b/apps/web/src/pages/llm-history/LlmHistoryPage.tsx
@@ -1,7 +1,4 @@
-import { contractUrl } from "@kagami/http/url";
-import { agentApiContract } from "@kagami/agent-api/contract";
 import { type LlmChatCallStatus, type LlmChatCallSummary } from "@kagami/console-api/llm-chat-call";
-import { LlmProviderListResponseSchema } from "@kagami/llm-api/llm-chat";
 import { useQuery } from "@tanstack/react-query";
 import { type FormEvent, useMemo } from "react";
 import { HistoryListPageLayout } from "@/components/layout/HistoryListPageLayout";
@@ -26,6 +23,7 @@ import {
 import { useHistoryListPageState } from "@/hooks/useHistoryListPageState";
 import { formatDateTime } from "@/lib/format";
 import { createSchemaQueryOptions, queryKeys } from "@/lib/query";
+import { agentClient } from "@/lib/rpc";
 import { normalizeOptionalText, setIfNonEmpty } from "@/lib/search-params";
 import { cn } from "@/lib/utils";
 import { LlmChatCallDetailPanel } from "./LlmChatCallDetailPanel";
@@ -48,8 +46,7 @@ export function LlmHistoryPage() {
   const providersQuery = useQuery({
     ...createSchemaQueryOptions({
       queryKey: queryKeys.llm.providers(),
-      path: contractUrl(agentApiContract.listProviders),
-      schema: LlmProviderListResponseSchema,
+      queryFn: () => agentClient.listProviders({}),
     }),
   });
   const {

--- a/apps/web/src/pages/llm-history/useLlmChatCallDetail.ts
+++ b/apps/web/src/pages/llm-history/useLlmChatCallDetail.ts
@@ -1,22 +1,13 @@
-import { contractUrl } from "@kagami/http/url";
-import { consoleApiContract } from "@kagami/console-api/contract";
-import {
-  type LlmChatCallDetailResponse,
-  LlmChatCallDetailResponseSchema,
-} from "@kagami/console-api/llm-chat-call";
 import { useQuery } from "@tanstack/react-query";
 import { createSchemaQueryOptions, queryKeys } from "@/lib/query";
+import { consoleClient } from "@/lib/rpc";
 
 export function useLlmChatCallDetail(id: number | null) {
   return useQuery({
-    ...createSchemaQueryOptions<
-      LlmChatCallDetailResponse,
-      ReturnType<typeof queryKeys.llm.historyDetail>
-    >({
+    ...createSchemaQueryOptions({
       queryKey: queryKeys.llm.historyDetail(id ?? 0),
       // id 为 null 时 enabled=false 不会发请求；占位 1 只为通过 params 的 positive 校验。
-      path: contractUrl(consoleApiContract.getLlmChatCallDetail, { params: { id: id ?? 1 } }),
-      schema: LlmChatCallDetailResponseSchema,
+      queryFn: () => consoleClient.getLlmChatCallDetail({ params: { id: id ?? 1 }, input: {} }),
     }),
     enabled: id !== null,
   });

--- a/apps/web/src/pages/llm-history/useLlmChatCallList.ts
+++ b/apps/web/src/pages/llm-history/useLlmChatCallList.ts
@@ -1,12 +1,7 @@
-import { contractUrl } from "@kagami/http/url";
-import { consoleApiContract } from "@kagami/console-api/contract";
-import {
-  type LlmChatCallListQuery,
-  type LlmChatCallListResponse,
-  LlmChatCallListResponseSchema,
-} from "@kagami/console-api/llm-chat-call";
+import { type LlmChatCallListQuery } from "@kagami/console-api/llm-chat-call";
 import { useQuery } from "@tanstack/react-query";
 import { createHistoryListQueryOptions, queryKeys } from "@/lib/query";
+import { consoleClient } from "@/lib/rpc";
 
 type LlmChatCallListFilters = Omit<LlmChatCallListQuery, "page" | "pageSize">;
 
@@ -16,22 +11,17 @@ export function useLlmChatCallList(
   filters: LlmChatCallListFilters,
 ) {
   const params = {
-    page: String(page),
-    pageSize: String(pageSize),
+    page,
+    pageSize,
     provider: filters.provider,
     model: filters.model,
     status: filters.status,
-  } satisfies Record<string, string | undefined>;
+  };
 
   return useQuery(
-    createHistoryListQueryOptions<
-      LlmChatCallListResponse,
-      ReturnType<typeof queryKeys.llm.historyList>
-    >({
+    createHistoryListQueryOptions({
       queryKey: queryKeys.llm.historyList(params),
-      path: contractUrl(consoleApiContract.queryLlmChatCalls),
-      schema: LlmChatCallListResponseSchema,
-      params,
+      queryFn: () => consoleClient.queryLlmChatCalls(params),
     }),
   );
 }

--- a/apps/web/src/pages/main-agent-context/useMainAgentContext.ts
+++ b/apps/web/src/pages/main-agent-context/useMainAgentContext.ts
@@ -1,14 +1,11 @@
-import { contractUrl } from "@kagami/http/url";
-import { agentApiContract } from "@kagami/agent-api/contract";
-import { MainAgentContextSnapshotSchema } from "@kagami/agent-api/main-agent-context";
 import { useQuery } from "@tanstack/react-query";
 import { createSchemaQueryOptions, queryKeys } from "@/lib/query";
+import { agentClient } from "@/lib/rpc";
 
 export function useMainAgentContext() {
   const queryOptions = createSchemaQueryOptions({
     queryKey: queryKeys.mainAgentContext.recent(),
-    path: contractUrl(agentApiContract.getRecentMainAgentContext),
-    schema: MainAgentContextSnapshotSchema,
+    queryFn: () => agentClient.getRecentMainAgentContext({}),
   });
 
   return useQuery({

--- a/apps/web/src/pages/napcat-event-history/useNapcatEventList.ts
+++ b/apps/web/src/pages/napcat-event-history/useNapcatEventList.ts
@@ -1,11 +1,7 @@
-import { contractUrl } from "@kagami/http/url";
-import { consoleApiContract } from "@kagami/console-api/contract";
-import {
-  NapcatEventListResponseSchema,
-  type NapcatEventListQuery,
-} from "@kagami/console-api/napcat-event";
+import { type NapcatEventListQuery } from "@kagami/console-api/napcat-event";
 import { useQuery } from "@tanstack/react-query";
 import { createHistoryListQueryOptions, queryKeys } from "@/lib/query";
+import { consoleClient } from "@/lib/rpc";
 
 type NapcatEventListFilters = Omit<NapcatEventListQuery, "page" | "pageSize">;
 
@@ -15,21 +11,19 @@ export function useNapcatEventList(
   filters: NapcatEventListFilters,
 ) {
   const params = {
-    page: String(page),
-    pageSize: String(pageSize),
+    page,
+    pageSize,
     postType: filters.postType,
     messageType: filters.messageType,
     userId: filters.userId,
     startAt: filters.startAt,
     endAt: filters.endAt,
-  } satisfies Record<string, string | undefined>;
+  };
 
   return useQuery(
     createHistoryListQueryOptions({
       queryKey: queryKeys.napcatEvent.historyList(params),
-      path: contractUrl(consoleApiContract.queryNapcatEvents),
-      schema: NapcatEventListResponseSchema,
-      params,
+      queryFn: () => consoleClient.queryNapcatEvents(params),
     }),
   );
 }

--- a/apps/web/src/pages/napcat-group-message-history/useNapcatGroupMessageList.ts
+++ b/apps/web/src/pages/napcat-group-message-history/useNapcatGroupMessageList.ts
@@ -1,11 +1,7 @@
-import { contractUrl } from "@kagami/http/url";
-import { consoleApiContract } from "@kagami/console-api/contract";
-import {
-  NapcatQqMessageListResponseSchema,
-  type NapcatQqMessageListQuery,
-} from "@kagami/console-api/napcat-group-message";
+import { type NapcatQqMessageListQuery } from "@kagami/console-api/napcat-group-message";
 import { useQuery } from "@tanstack/react-query";
 import { createHistoryListQueryOptions, queryKeys } from "@/lib/query";
+import { consoleClient } from "@/lib/rpc";
 
 type NapcatGroupMessageListFilters = Omit<NapcatQqMessageListQuery, "page" | "pageSize">;
 
@@ -15,8 +11,8 @@ export function useNapcatGroupMessageList(
   filters: NapcatGroupMessageListFilters,
 ) {
   const params = {
-    page: String(page),
-    pageSize: String(pageSize),
+    page,
+    pageSize,
     messageType: filters.messageType,
     groupId: filters.groupId,
     userId: filters.userId,
@@ -24,14 +20,12 @@ export function useNapcatGroupMessageList(
     keyword: filters.keyword,
     startAt: filters.startAt,
     endAt: filters.endAt,
-  } satisfies Record<string, string | undefined>;
+  };
 
   return useQuery(
     createHistoryListQueryOptions({
       queryKey: queryKeys.napcatGroupMessage.historyList(params),
-      path: contractUrl(consoleApiContract.queryNapcatQqMessages),
-      schema: NapcatQqMessageListResponseSchema,
-      params,
+      queryFn: () => consoleClient.queryNapcatQqMessages(params),
     }),
   );
 }

--- a/apps/web/src/pages/oss-objects/useOssObjectList.ts
+++ b/apps/web/src/pages/oss-objects/useOssObjectList.ts
@@ -1,11 +1,6 @@
-import { contractUrl } from "@kagami/http/url";
-import { ossConsoleContract } from "@kagami/oss-api/contract";
-import {
-  type OssObjectListResponse,
-  OssObjectListResponseSchema,
-} from "@kagami/oss-api/oss-object";
 import { useQuery } from "@tanstack/react-query";
 import { createHistoryListQueryOptions, queryKeys } from "@/lib/query";
+import { ossConsoleClient } from "@/lib/rpc";
 
 export type OssObjectListFilters = {
   mime?: string;
@@ -13,20 +8,15 @@ export type OssObjectListFilters = {
 
 export function useOssObjectList(page: number, pageSize: number, filters: OssObjectListFilters) {
   const params = {
-    page: String(page),
-    pageSize: String(pageSize),
+    page,
+    pageSize,
     mime: filters.mime,
-  } satisfies Record<string, string | undefined>;
+  };
 
   return useQuery(
-    createHistoryListQueryOptions<
-      OssObjectListResponse,
-      ReturnType<typeof queryKeys.ossObject.historyList>
-    >({
+    createHistoryListQueryOptions({
       queryKey: queryKeys.ossObject.historyList(params),
-      path: contractUrl(ossConsoleContract.queryObjects),
-      schema: OssObjectListResponseSchema,
-      params,
+      queryFn: () => ossConsoleClient.queryObjects(params),
     }),
   );
 }

--- a/apps/web/src/pages/oss-objects/useOssStats.ts
+++ b/apps/web/src/pages/oss-objects/useOssStats.ts
@@ -1,15 +1,12 @@
-import { contractUrl } from "@kagami/http/url";
-import { ossConsoleContract } from "@kagami/oss-api/contract";
-import { type OssStatsResponse, OssStatsResponseSchema } from "@kagami/oss-api/oss-object";
 import { useQuery } from "@tanstack/react-query";
 import { createSchemaQueryOptions, queryKeys } from "@/lib/query";
+import { ossConsoleClient } from "@/lib/rpc";
 
 export function useOssStats() {
   return useQuery(
-    createSchemaQueryOptions<OssStatsResponse, ReturnType<typeof queryKeys.ossObject.stats>>({
+    createSchemaQueryOptions({
       queryKey: queryKeys.ossObject.stats(),
-      path: contractUrl(ossConsoleContract.getStats),
-      schema: OssStatsResponseSchema,
+      queryFn: () => ossConsoleClient.getStats({}),
     }),
   );
 }

--- a/apps/web/src/pages/scheduler-tasks/useSchedulerTasks.ts
+++ b/apps/web/src/pages/scheduler-tasks/useSchedulerTasks.ts
@@ -1,17 +1,13 @@
-import { contractUrl } from "@kagami/http/url";
-import { agentApiContract } from "@kagami/agent-api/contract";
-import { SchedulerTaskListResponseSchema } from "@kagami/agent-api/scheduler";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { apiPost } from "@/lib/api";
 import { createSchemaQueryOptions } from "@/lib/query";
+import { agentClient } from "@/lib/rpc";
 
 const QUERY_KEY = ["scheduler", "tasks"] as const;
 
 export function useSchedulerTasks() {
   const queryOptions = createSchemaQueryOptions({
     queryKey: QUERY_KEY,
-    path: contractUrl(agentApiContract.listSchedulerTasks),
-    schema: SchedulerTaskListResponseSchema,
+    queryFn: () => agentClient.listSchedulerTasks({}),
   });
 
   return useQuery({
@@ -27,7 +23,7 @@ export function useTriggerSchedulerTask() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (name: string) => {
-      await apiPost(contractUrl(agentApiContract.triggerSchedulerTask, { params: { name } }));
+      await agentClient.triggerSchedulerTask({ params: { name }, input: {} });
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: QUERY_KEY });

--- a/apps/web/src/pages/todos/useTodoList.ts
+++ b/apps/web/src/pages/todos/useTodoList.ts
@@ -1,24 +1,21 @@
-import { contractUrl } from "@kagami/http/url";
-import { consoleApiContract } from "@kagami/console-api/contract";
-import { TodoListResponseSchema, type TodoListQuery } from "@kagami/console-api/todo";
+import { type TodoListQuery } from "@kagami/console-api/todo";
 import { useQuery } from "@tanstack/react-query";
 import { createHistoryListQueryOptions, queryKeys } from "@/lib/query";
+import { consoleClient } from "@/lib/rpc";
 
 type TodoListFilters = Omit<TodoListQuery, "page" | "pageSize">;
 
 export function useTodoList(page: number, pageSize: number, filters: TodoListFilters) {
   const params = {
-    page: String(page),
-    pageSize: String(pageSize),
+    page,
+    pageSize,
     status: filters.status,
-  } satisfies Record<string, string | undefined>;
+  };
 
   return useQuery(
     createHistoryListQueryOptions({
       queryKey: queryKeys.todo.historyList(params),
-      path: contractUrl(consoleApiContract.queryTodos),
-      schema: TodoListResponseSchema,
-      params,
+      queryFn: () => consoleClient.queryTodos(params),
     }),
   );
 }

--- a/apps/web/test/search-params.test.ts
+++ b/apps/web/test/search-params.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
   areSearchParamsEqual,
-  buildQueryString,
   isoToLocalDateTime,
   localDateTimeToIso,
   normalizeOptionalText,
@@ -50,11 +49,7 @@ describe("isoToLocalDateTime / localDateTimeToIso", () => {
   });
 });
 
-describe("buildQueryString / setIfNonEmpty / areSearchParamsEqual", () => {
-  it("undefined 与空串字段跳过，数字转字符串", () => {
-    expect(buildQueryString({ a: 1, b: "x", c: undefined, d: "" })).toBe("a=1&b=x");
-  });
-
+describe("setIfNonEmpty / areSearchParamsEqual", () => {
   it("setIfNonEmpty 忽略空白值", () => {
     const params = new URLSearchParams();
     setIfNonEmpty(params, "k", "  ");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -484,6 +484,9 @@ importers:
       '@kagami/oss-api':
         specifier: workspace:*
         version: link:../../packages/oss-api
+      '@kagami/rpc-client':
+        specifier: workspace:*
+        version: link:../../packages/rpc-client
       '@radix-ui/react-select':
         specifier: ^2.2.6
         version: 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)


### PR DESCRIPTION
Closes #499

## 背景

后端 acl 层早已全面用 `@kagami/rpc-client` 的 `createClient(contract)`（agent 的 7 个 client、metric-client、scheduler-client...），前端是**唯一**还在手写 `lib/api.ts`（`apiGetWithSchema` / `apiPostWithSchema`）的消费者。而且前端**已高度契约化**:几乎每个调用点都 `contractUrl(contract.method)` 取 path、再手传 response schema——只差最后一层没走 `createClient`。

本 PR 把这最后一层接上:用 `client.method(input)` 一步取代「`contractUrl` 取 path + 手传 schema + `apiGetWithSchema`」,path、response schema、**入参类型**全部从契约派生。改契约 output/input,前端调用点直接编译报错——补上前端→后端这一跳的类型空洞。

（姊妹路线 gateway 静态自包含 #496 / #498 已合并,与本 PR 正交。）

## 改动

- **新增 `apps/web/src/lib/rpc.ts`**:按契约建 5 个 typed client（console / agent / auth / metric / ossConsole）。
  - **baseUrl 统一 `/api`**:gateway 按 path 前缀分流（`/llm-chat-call`→console、`/auth`→llm、`/metric`→metric、其余→agent），契约 path 自带前缀,故所有契约共用一个 baseUrl,URL 与迁移前**逐字一致**、路由不变（复刻 `buildApiUrl`,含 `VITE_API_BASE_URL` 覆盖）。
  - **自定义 `decodeError`**:镜像旧 `ApiError` 的 body 文案抽取（message / error / detail / 嵌套 error.message），使 `getApiErrorMessage(error)` 零改动复用、错误展示保真。
- **`lib/query.ts`**:`createSchemaQueryOptions` 从收 `{ path, schema, params }` 改为收 `{ queryFn }`;`queryKeys`（缓存键）不动。
- **16 个 hook/组件调用点**迁到 typed client（console 查询 ×7、agent ×4、oss ×2、metric ×2、auth 的 3 query + 3 mutation）;list hook 的 `page`/`pageSize` 改传 `number`。
- **`lib/api.ts`** 删到只剩 `resolveApiBaseUrl` / `buildApiUrl`（OSS 预览图 src）/ `getApiErrorMessage`;删死代码 `buildQueryString` 及其测试;清 `AuthPage` 的 `buildAuthEndpoint` helper。

净删 339 行。

## 验证

- 五件套（build / typecheck / lint / format / knip）全绿;web 单测 30 passed。
- **URL 保真**:所有调用点 baseUrl `/api` + 契约 path 与迁移前逐字一致,带 `:param` 路由（`:provider`/`:id`/`:name`）经同一 `interpolatePath` 插值;gateway 路由不受影响。
- **响应校验保真**:逐个核对 `contract.output` 与旧手传 schema 为同一个。
- **错误保真**:`decodeError` 复刻旧抽取逻辑;无组件依赖 `ApiError.status`/`.body`（错误消费全走 `getApiErrorMessage`）。
- 对抗性 code-review（opus，六维:URL/入参/条件查询/响应校验/错误/死代码）**零发现**。
- 唯一非破坏性差异:错误无可抽文案时的兜底丢了 `statusText`（`请求失败 (500 Bad Gateway)`→`请求失败 (500)`),后端均回 JSON,极罕见。

> 纯前端改动,无 DB 迁移。上线走全量 `pnpm build` + `pnpm app:deploy gateway`（#498 后 gateway 部署会连 web 一起重建）。未经明确要求不部署。