### PR TITLE
feat(scheduler): SDK 两阶段回报 + 未 ack 缓冲 + interrupted 自愈 + 历史 GC（#493 P2）

### DIFF
--- a/apps/napcat/test/napcat-gateway.test-helper.ts
+++ b/apps/napcat/test/napcat-gateway.test-helper.ts
@@ -101,7 +101,13 @@ export function createConfigManager(): ConfigManager {
       spire: { host: "127.0.0.1", port: 20011 },
       napcat: { host: "127.0.0.1", port: 20013 },
       pixel: { host: "127.0.0.1", port: 20012 },
-      scheduler: { host: "127.0.0.1", port: 20014, databaseUrl: "file::memory:" },
+      scheduler: {
+        host: "127.0.0.1",
+        port: 20014,
+        databaseUrl: "file::memory:",
+        historyRetentionCount: 200,
+        historyRetentionDays: 90,
+      },
     },
     server: {
       databaseUrl: "file::memory:",

--- a/apps/scheduler/src/app/scheduler-runtime.ts
+++ b/apps/scheduler/src/app/scheduler-runtime.ts
@@ -14,11 +14,16 @@ import { TaskRunStore } from "../infra/db/task-run-store.js";
 
 const logger = new AppLogger({ source: "scheduler-bootstrap" });
 
+// 历史 GC 周期（#493 P2）：启动后延迟一个周期再首跑，避免启动风暴。
+const HISTORY_GC_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
 export type SchedulerRuntime = {
   app: FastifyInstance;
   engine: SchedulerEngine;
   database: Database;
   port: number;
+  /** 关停时清掉历史 GC 定时器。 */
+  stopHistoryGc: () => void;
 };
 
 /**
@@ -43,17 +48,31 @@ export async function buildSchedulerRuntime(): Promise<SchedulerRuntime> {
     logger,
     handlers: [
       new HealthHandler(),
-      new SchedulerRegisterHandler({ engine }),
+      new SchedulerRegisterHandler({ engine, store }),
       new SchedulerTicksHandler({ broadcaster, engine }),
       new SchedulerRunsHandler({ store }),
     ],
   });
+
+  // 历史 GC（#493 P2）：进程内周期 prune TaskRun。延迟一个周期首跑避免启动风暴；unref 不挡进程退出。
+  const retentionCount = config.services.scheduler.historyRetentionCount;
+  const retentionDays = config.services.scheduler.historyRetentionDays;
+  const historyGcTimer = setInterval(() => {
+    void store.pruneHistory({ retentionCount, retentionDays }).catch(error => {
+      logger.warn("scheduler history GC failed", {
+        event: "scheduler.history_gc_failed",
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  }, HISTORY_GC_INTERVAL_MS);
+  historyGcTimer.unref?.();
 
   return {
     app,
     engine,
     database,
     port: config.services.scheduler.port,
+    stopHistoryGc: () => clearInterval(historyGcTimer),
   };
 }
 

--- a/apps/scheduler/src/http/scheduler-register.handler.ts
+++ b/apps/scheduler/src/http/scheduler-register.handler.ts
@@ -2,26 +2,38 @@ import type { FastifyInstance } from "fastify";
 import { registerJsonRoute } from "@kagami/http/register";
 import { schedulerApiContract } from "@kagami/scheduler-api/contract";
 import type { SchedulerEngine } from "../application/scheduler-engine.js";
+import type { TaskRunStore } from "../infra/db/task-run-store.js";
 
 type SchedulerRegisterHandlerDeps = {
   engine: SchedulerEngine;
+  store: TaskRunStore;
 };
 
 /**
  * 注册 + 状态查询路由（issue #428）。register：使用方提交完整任务集，引擎 replace-all。
  * status：按 ownerId 回 tick 侧状态（nextRunAt / lastScheduledAt / lastEmittedAt）；使用方 SDK
  * 会把它与本地执行历史合并成 web 观测视图。
+ *
+ * interrupted 自愈（#493 P2）：register 被**接受**时，把上一代（owner_generation < 入参 generation）
+ * 还挂着 running 的行标 interrupted——agent 重启（generation 递增）会留下未收到终态的孤儿 running 行。
+ * 只标更旧代次，同代重连（scheduler 重启、generation 不变）不误杀在跑的 run。stale register 不处理。
  */
 export class SchedulerRegisterHandler {
   private readonly engine: SchedulerEngine;
+  private readonly store: TaskRunStore;
 
-  public constructor({ engine }: SchedulerRegisterHandlerDeps) {
+  public constructor({ engine, store }: SchedulerRegisterHandlerDeps) {
     this.engine = engine;
+    this.store = store;
   }
 
   public register(app: FastifyInstance): void {
-    registerJsonRoute(app, schedulerApiContract.register, ({ input }) => {
-      return this.engine.register(input);
+    registerJsonRoute(app, schedulerApiContract.register, async ({ input }) => {
+      const result = this.engine.register(input);
+      if (result.accepted) {
+        await this.store.markInterruptedBelow(input.ownerId, input.generation);
+      }
+      return result;
     });
 
     registerJsonRoute(app, schedulerApiContract.status, ({ input }) => {

--- a/apps/scheduler/src/index.ts
+++ b/apps/scheduler/src/index.ts
@@ -13,8 +13,12 @@ runService({
       // 仅绑 127.0.0.1：只有使用方（agent）在同机 reach 它，绝不对外。
       bindHost: "127.0.0.1",
       port: runtime.port,
-      // 关停：停掉所有 driver（in-flight handler 在使用方进程，与本引擎无关）+ 断开库连接。
-      cleanup: [() => runtime.engine.stop(), () => closeDb(runtime.database)],
+      // 关停：停掉所有 driver（in-flight handler 在使用方进程，与本引擎无关）+ 停历史 GC + 断库连接。
+      cleanup: [
+        () => runtime.engine.stop(),
+        () => runtime.stopHistoryGc(),
+        () => closeDb(runtime.database),
+      ],
     };
   },
 });

--- a/apps/scheduler/src/infra/db/task-run-store.ts
+++ b/apps/scheduler/src/infra/db/task-run-store.ts
@@ -5,10 +5,19 @@ type TaskRunStoreDeps = {
   database: Database;
 };
 
+type PruneHistoryOptions = {
+  retentionCount: number;
+  retentionDays: number;
+};
+
 /**
- * TaskRun 执行历史存储（issue #493 P1）。scheduler 独占的 Prisma 库，按 runId 幂等 upsert：
- * 同一 id 先后到（running → 终态）只留一行，终态覆盖 running。wire 层的 ISO 字符串在这里转成
- * Date，number 型 ownerGeneration 转成 BigInt 落库。
+ * TaskRun 执行历史存储（issue #493）。scheduler 独占的 Prisma 库，按 runId 幂等 upsert。
+ *
+ * P2 状态感知：上报乱序/重试可能让迟到的 running 抹回已写入的终态。故按 request.status 分支——
+ * - running：**存在即不覆盖**（空 update：缺则建、已存在 no-op），迟到 running 绝不覆盖已有行。
+ * - 终态（success/failure/interrupted）：完整 upsert（缺则建、已存在全字段覆盖），终态永远赢。
+ *
+ * wire 层的 ISO 字符串在这里转成 Date，number 型 ownerGeneration 转成 BigInt 落库。
  */
 export class TaskRunStore {
   private readonly database: Database;
@@ -31,13 +40,68 @@ export class TaskRunStore {
       error: record.error ?? null,
     };
 
+    // running 上报：迟到到达的 running 绝不覆盖已有的 running/终态，故 update 留空（no-op）。
+    // 终态上报：终态永远赢，缺则建、已存在全字段覆盖。
     await this.database.taskRun.upsert({
       where: { id: record.id },
       create: { id: record.id, ...data },
-      update: data,
+      update: record.status === "running" ? {} : data,
     });
   }
+
+  /**
+   * owner 带更大 generation 重连时，把上一代还挂着 running 的行标 interrupted（#493 P2）。
+   * 只标 `owner_generation < generation` 的行：同代重连（scheduler 重启、agent 存活、generation
+   * 不变）不误杀正在跑的 run；agent 重启（generation 递增）才标上一代残留。
+   */
+  public async markInterruptedBelow(ownerId: string, generation: number): Promise<void> {
+    await this.database.taskRun.updateMany({
+      where: {
+        ownerId,
+        status: "running",
+        ownerGeneration: { lt: BigInt(generation) },
+      },
+      data: {
+        status: "interrupted",
+        finishedAt: new Date(),
+      },
+    });
+  }
+
+  /**
+   * 历史 GC（#493 P2）。删除一条当且仅当 **(在其 (owner_id, task_name) 分组内按 started_at desc
+   * 排名 > N) 或 (started_at 早于 now - days)**，即保留「排名≤N 且 days 内」。绝不删 running 行。
+   * 用一条 SQL（window function）选出超额行，与超期行做并集后 DELETE，避免 N+1。
+   */
+  public async pruneHistory({ retentionCount, retentionDays }: PruneHistoryOptions): Promise<void> {
+    const cutoff = new Date(Date.now() - retentionDays * MS_PER_DAY);
+    // running 行永不删（NOT ('running')）。超额（rank > N）与超期（started_at < cutoff）取并集删。
+    await this.database.$executeRawUnsafe(
+      `
+      DELETE FROM "task_run"
+      WHERE "status" <> 'running'
+        AND "id" IN (
+          SELECT "id" FROM (
+            SELECT
+              "id",
+              "started_at",
+              ROW_NUMBER() OVER (
+                PARTITION BY "owner_id", "task_name"
+                ORDER BY "started_at" DESC, "id" DESC
+              ) AS "rank"
+            FROM "task_run"
+            WHERE "status" <> 'running'
+          )
+          WHERE "rank" > ? OR "started_at" < ?
+        )
+      `,
+      retentionCount,
+      cutoff.toISOString(),
+    );
+  }
 }
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 /** wire 的 ISO 字符串（可空 / 可缺省）转 Date；缺省与 null 一律落 null。 */
 function toDateOrNull(value: string | null | undefined): Date | null {

--- a/apps/scheduler/test/scheduler-register.handler.test.ts
+++ b/apps/scheduler/test/scheduler-register.handler.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { AppLogger } from "@kagami/kernel/logger/logger";
+import { initLoggerRuntime } from "@kagami/kernel/logger/runtime";
+import { createServiceApp } from "@kagami/kernel/http/service-app";
+import type { FastifyInstance } from "fastify";
+import type { SchedulerReportRunRequest } from "@kagami/scheduler-api/run";
+import { SchedulerEngine } from "../src/application/scheduler-engine.js";
+import { TickBroadcaster } from "../src/application/tick-broadcaster.js";
+import { SchedulerRegisterHandler } from "../src/http/scheduler-register.handler.js";
+import { TaskRunStore } from "../src/infra/db/task-run-store.js";
+import { createTaskRunTestDb, type TaskRunTestDb } from "./helpers/task-run-db.js";
+
+beforeAll(() => {
+  initLoggerRuntime({ sinks: [{ write: () => {} }] });
+});
+
+function runningRecord(over: Partial<SchedulerReportRunRequest>): SchedulerReportRunRequest {
+  return {
+    id: "seed",
+    ownerId: "agent",
+    taskName: "ithome-poll",
+    ownerGeneration: 100,
+    status: "running",
+    trigger: "scheduled",
+    scheduledAt: "2026-07-06T10:00:00.000Z",
+    startedAt: "2026-07-06T10:00:01.000Z",
+    finishedAt: null,
+    durationMs: null,
+    error: null,
+    ...over,
+  };
+}
+
+function registerBody(generation: number): Record<string, unknown> {
+  return {
+    ownerId: "agent",
+    clientInstanceId: "inst-1",
+    generation,
+    tasks: [
+      { name: "ithome-poll", schedule: { kind: "interval", intervalMs: 1000 }, misfire: "latest" },
+    ],
+  };
+}
+
+describe("POST /scheduler/register — interrupted self-heal (#493 P2)", () => {
+  let db: TaskRunTestDb;
+  let store: TaskRunStore;
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    db = await createTaskRunTestDb();
+    store = new TaskRunStore({ database: db.database });
+    const engine = new SchedulerEngine({ broadcaster: new TickBroadcaster() });
+    app = createServiceApp({
+      logger: new AppLogger({ source: "scheduler-register-test" }),
+      handlers: [new SchedulerRegisterHandler({ engine, store })],
+    });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    await db.cleanup();
+  });
+
+  it("marks prior-generation running rows interrupted when a newer generation registers", async () => {
+    await store.upsertRun(runningRecord({ id: "gen100", ownerGeneration: 100 }));
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/scheduler/register",
+      payload: registerBody(200),
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ accepted: true });
+
+    const row = (await db.database.taskRun.findMany())[0]!;
+    expect(row.status).toBe("interrupted");
+    expect(row.finishedAt).not.toBeNull();
+  });
+
+  it("does not heal when the register is stale (rejected)", async () => {
+    // 先让 generation=200 在册。
+    await app.inject({ method: "POST", url: "/scheduler/register", payload: registerBody(200) });
+    await store.upsertRun(runningRecord({ id: "gen150", ownerGeneration: 150 }));
+
+    // 迟到的 generation=100 register：被拒（stale），不触发自愈。
+    const res = await app.inject({
+      method: "POST",
+      url: "/scheduler/register",
+      payload: registerBody(100),
+    });
+    expect(res.json()).toMatchObject({ accepted: false });
+
+    const row = (await db.database.taskRun.findMany())[0]!;
+    expect(row.status).toBe("running");
+  });
+});

--- a/apps/scheduler/test/task-run-store.test.ts
+++ b/apps/scheduler/test/task-run-store.test.ts
@@ -65,4 +65,122 @@ describe("TaskRunStore", () => {
     const rows = await db.database.taskRun.findMany();
     expect(rows).toHaveLength(2);
   });
+
+  it("does not let a late running report overwrite an already-written terminal state", async () => {
+    // 先终态 success，再迟到 running（乱序到达）：终态不被退回。
+    await store.upsertRun(
+      runningRecord({
+        status: "success",
+        finishedAt: "2026-07-06T10:00:05.000Z",
+        durationMs: 4000,
+      }),
+    );
+    await store.upsertRun(runningRecord()); // 迟到的 running 上报，同 id
+
+    const rows = await db.database.taskRun.findMany();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.status).toBe("success");
+    expect(rows[0]!.finishedAt).not.toBeNull();
+    expect(rows[0]!.durationMs).toBe(4000);
+  });
+
+  describe("markInterruptedBelow", () => {
+    async function seedRunning(id: string, generation: number): Promise<void> {
+      await store.upsertRun(runningRecord({ id, ownerGeneration: generation }));
+    }
+
+    it("marks stale-generation running rows interrupted, spares same/newer generations", async () => {
+      await seedRunning("old", 100);
+      await seedRunning("same", 200);
+      await store.upsertRun(
+        runningRecord({ id: "other-owner", ownerId: "napcat", ownerGeneration: 100 }),
+      );
+
+      // agent 带 generation=200 重连：只标 generation < 200 且 status=running 的 agent 行。
+      await store.markInterruptedBelow("agent", 200);
+
+      const byId = new Map((await db.database.taskRun.findMany()).map(r => [r.id, r] as const));
+      expect(byId.get("old")!.status).toBe("interrupted");
+      expect(byId.get("old")!.finishedAt).not.toBeNull();
+      // 同代（200 不 < 200）不误杀；别的 owner 也不动。
+      expect(byId.get("same")!.status).toBe("running");
+      expect(byId.get("other-owner")!.status).toBe("running");
+    });
+
+    it("does not touch terminal rows even from older generations", async () => {
+      await store.upsertRun(
+        runningRecord({
+          id: "done",
+          ownerGeneration: 100,
+          status: "success",
+          finishedAt: "2026-07-06T10:00:05.000Z",
+          durationMs: 4000,
+        }),
+      );
+      await store.markInterruptedBelow("agent", 200);
+      const row = (await db.database.taskRun.findMany())[0]!;
+      expect(row.status).toBe("success");
+    });
+  });
+
+  describe("pruneHistory", () => {
+    async function seed(
+      id: string,
+      taskName: string,
+      startedAt: string,
+      status = "success",
+    ): Promise<void> {
+      await store.upsertRun(
+        runningRecord({
+          id,
+          taskName,
+          status: status as "success",
+          startedAt,
+          finishedAt: startedAt,
+          durationMs: 1,
+        }),
+      );
+    }
+
+    it("keeps only the most recent N per (owner, task) and drops rows older than the window", async () => {
+      const now = Date.now();
+      const iso = (offsetDays: number): string =>
+        new Date(now - offsetDays * 24 * 60 * 60 * 1000).toISOString();
+
+      // taskA：4 条近期（0/1/2/3 天前），保留最近 N=2 → 删 2 条最旧的（rank>2）。
+      await seed("a0", "taskA", iso(0));
+      await seed("a1", "taskA", iso(1));
+      await seed("a2", "taskA", iso(2));
+      await seed("a3", "taskA", iso(3));
+      // taskB：1 条超期（100 天前）→ 按天数删。
+      await seed("b0", "taskB", iso(100));
+      // running 行超期也不删。
+      await store.upsertRun(
+        runningRecord({ id: "r0", taskName: "taskC", status: "running", startedAt: iso(200) }),
+      );
+
+      await store.pruneHistory({ retentionCount: 2, retentionDays: 90 });
+
+      const ids = new Set((await db.database.taskRun.findMany()).map(r => r.id));
+      // taskA 只留最近 2 条。
+      expect(ids.has("a0")).toBe(true);
+      expect(ids.has("a1")).toBe(true);
+      expect(ids.has("a2")).toBe(false);
+      expect(ids.has("a3")).toBe(false);
+      // taskB 超期被删。
+      expect(ids.has("b0")).toBe(false);
+      // running 行永不删。
+      expect(ids.has("r0")).toBe(true);
+    });
+
+    it("deletes a within-count row that is nonetheless older than the day window", async () => {
+      const now = Date.now();
+      const iso = (offsetDays: number): string =>
+        new Date(now - offsetDays * 24 * 60 * 60 * 1000).toISOString();
+      // 组内仅 1 条（rank=1，未超额），但超过天数窗 → 仍删（并集语义）。
+      await seed("old", "taskA", iso(100));
+      await store.pruneHistory({ retentionCount: 200, retentionDays: 90 });
+      expect(await db.database.taskRun.findMany()).toHaveLength(0);
+    });
+  });
 });

--- a/config.yaml
+++ b/config.yaml
@@ -21,6 +21,8 @@ services:
     host: 127.0.0.1
     port: 20014
     databaseUrl: file:./data/sqlite/scheduler.db # scheduler 独占 SQLite 库（TaskRun 执行历史，#493），与主库 kagami.db 同目录不同文件
+    historyRetentionCount: 200 # 历史 GC：每 (owner, task) 分组保留最近多少条（#493 P2）
+    historyRetentionDays: 90 # 历史 GC：删除早于多少天的行（与 count 取交集=更严；running 行永不删）
 
 server:
   databaseUrl: file:./data/sqlite/kagami.db # SQLite 库文件，相对仓库根；运行时与 Prisma CLI 解析为绝对路径

--- a/packages/kernel/src/config/config.loader.ts
+++ b/packages/kernel/src/config/config.loader.ts
@@ -21,6 +21,9 @@ const DEFAULT_AGENT_RESOURCE_MAX_BYTES = 4 * 1024 * 1024;
 // fileMaxBytes 32 MiB 独立于上下文 cap（4 MiB）——文件不进上下文，可更大，但压在 OSS 50MB 请求上限下。
 const DEFAULT_AGENT_RESOURCE_FILE_ROOT = "~/kagami";
 const DEFAULT_AGENT_RESOURCE_FILE_MAX_BYTES = 32 * 1024 * 1024;
+// scheduler 历史 GC 保留窗口（#493 P2）：每 (owner, task) 分组保留最近 N 条，且删除早于 M 天的行。
+const DEFAULT_SCHEDULER_HISTORY_RETENTION_COUNT = 200;
+const DEFAULT_SCHEDULER_HISTORY_RETENTION_DAYS = 90;
 const DEFAULT_ITHOME_POLL_INTERVAL_MS = 5 * 60 * 1000;
 const DEFAULT_ITHOME_RECENT_ARTICLE_LIMIT = 8;
 const DEFAULT_ITHOME_ARTICLE_MAX_CHARS = 8000;
@@ -205,8 +208,11 @@ const ServicesSchema = z
     pixel: ServiceEndpointSchema,
     // scheduler 除 host/port 外还持有独立 Prisma 库（issue #493）：TaskRun 执行历史落它自己的
     // SQLite 文件，与主库 server.databaseUrl 物理分离。databaseUrl 非隐私，进 config.yaml。
+    // historyRetentionCount / historyRetentionDays 是历史 GC 的保留窗口（#493 P2，取交集=更严）。
     scheduler: ServiceEndpointSchema.extend({
       databaseUrl: DatabaseUrlSchema,
+      historyRetentionCount: PositiveIntSchema.default(DEFAULT_SCHEDULER_HISTORY_RETENTION_COUNT),
+      historyRetentionDays: PositiveIntSchema.default(DEFAULT_SCHEDULER_HISTORY_RETENTION_DAYS),
     }),
   })
   .strict();

--- a/packages/scheduler-client/src/scheduler-client.ts
+++ b/packages/scheduler-client/src/scheduler-client.ts
@@ -3,6 +3,7 @@ import { AppLogger } from "@kagami/kernel/logger/logger";
 import { createClient, type JsonClient } from "@kagami/rpc-client/client";
 import { schedulerApiContract, type SchedulerTaskManifest } from "@kagami/scheduler-api/contract";
 import { SchedulerTickEventSchema, SCHEDULER_TICKS_SSE_PATH } from "@kagami/scheduler-api/event";
+import type { SchedulerReportRunRequest } from "@kagami/scheduler-api/run";
 import type { SchedulerTaskStatus } from "@kagami/scheduler-api/schedule";
 import { TaskRunHistory, toWireRun, type TaskRun } from "./task-run.js";
 import type {
@@ -20,6 +21,8 @@ const MAX_BACKOFF_MS = 30_000;
 // 30s 内无任何帧（含 15s 心跳）判半开：主动 abort 重连。留 2 个心跳周期裕量（复刻 napcat）。
 const DEAD_CONNECTION_TIMEOUT_MS = 30_000;
 const DEFAULT_HISTORY_SIZE = 10;
+// 未 ack 的 run 上报缓冲上限（#493 P2）：内存 at-least-once，超量丢最旧并 warn。
+const UNACKED_REPORT_BUFFER_CAP = 100;
 
 type FetchLike = typeof fetch;
 
@@ -66,6 +69,18 @@ export class SchedulerClient {
   private started = false;
   private running = false;
   private controller: AbortController | null = null;
+  /**
+   * 未 ack 的 run 上报缓冲（#493 P2）：内存 at-least-once，无磁盘 outbox。按 runId 去重合并——同一
+   * runId 的 running 后又来 terminal 只留最新那条（terminal 覆盖 running，避免重推把终态退回 running）。
+   * 上报失败留在这里，下次上报前 + register 重连后各 flush 一次；scheduler 侧幂等 upsert 保证重推安全。
+   */
+  private readonly unackedReports = new Map<string, SchedulerReportRunRequest>();
+  /**
+   * 在途的 run 上报 promise（#493 P2）：回报是**旁路遥测**，绝不能挤上 handler 的关键路径。故
+   * runHandler 只 fire-and-forget 派发上报（不 await），把 promise 记在这里；`settleReports` 供测试
+   * 与将来的 graceful drain 等待其排空。回报本身永不抛（reportRun 内部 catch + 缓冲）。
+   */
+  private readonly pendingReports = new Set<Promise<void>>();
 
   public constructor({
     baseUrl,
@@ -240,6 +255,9 @@ export class SchedulerClient {
       return;
     }
 
+    // 重连成功（SSE 即将订阅）：把断连期间攒下的未 ack 上报冲一次。
+    await this.flushUnackedReports();
+
     const controller = new AbortController();
     this.controller = controller;
 
@@ -403,17 +421,42 @@ export class SchedulerClient {
   /**
    * 跑一次 handler 并记录执行历史。返回 handler 是否成功（供 runClaimed 决定要不要推进去重游标）。
    * running 锁的占用/释放归调用方（onTick / triggerNow）。
+   *
+   * 两阶段回报（#493 P2）：开始时生成 runId 上报一次 running，结束时用**同一 runId**再上报终态
+   * （success/failure）。上报失败进未 ack 缓冲、绝不阻塞 handler 主流程结果。只有真跑了的 run 才回报——
+   * skipped_overlap 从没真跑（且 wire 无此枚举），不在这里产生。
    */
   private async runHandler(entry: RegistryEntry, tick: SchedulerTick): Promise<boolean> {
     const abortController = new AbortController();
+    const runId = randomUUID();
+    const startedAt = new Date();
     const run: TaskRun = {
-      startedAt: new Date(),
+      startedAt,
       finishedAt: null,
       durationMs: null,
       status: "running",
     };
     entry.abortController = abortController;
     const startedAtMs = Date.now();
+    const trigger: SchedulerReportRunRequest["trigger"] = tick.manual ? "manual" : "scheduled";
+    const startedAtIso = startedAt.toISOString();
+    // 开始：上报 running（scheduledAt 仅 scheduled 触发有意义，manual 为 null）。
+    // fire-and-forget：绝不 await——回报是旁路遥测，不能阻塞 handler 启动（scheduler 不可达时
+    // reportRun 会走满 30s 超时）。失败自动进未 ack 缓冲，靠状态感知 upsert 保序、幂等重推。
+    const runningReport = this.reportRun({
+      id: runId,
+      ownerId: this.ownerId,
+      taskName: entry.reg.name,
+      ownerGeneration: this.generation,
+      status: "running",
+      trigger,
+      scheduledAt: tick.manual ? null : tick.scheduledAt,
+      startedAt: startedAtIso,
+      finishedAt: null,
+      durationMs: null,
+      error: null,
+    });
+    this.trackReport(runningReport);
     try {
       const metadata = await entry.reg.handler(abortController.signal, tick);
       run.status = "success";
@@ -431,9 +474,110 @@ export class SchedulerClient {
       });
       return false;
     } finally {
-      run.finishedAt = new Date();
+      const finishedAt = new Date();
+      run.finishedAt = finishedAt;
       run.durationMs = Date.now() - startedAtMs;
+      const finishedAtIso = finishedAt.toISOString();
+      const durationMs = run.durationMs;
       entry.history.push(run);
+      // 结束：同 runId 再上报终态（本地 error → wire failure）。同样不阻塞 handler（此刻 handler 已
+      // 返回），但**chain 在 running 上报之后**——保证同一 run 的两次上报有序：running 先落库/先进缓冲，
+      // terminal 的 flush 才能带上它，否则 instant handler 下二者并发竞争会让失败的 running 滞留缓冲。
+      // running 上报永不抛，故 .then 恒执行。若进程恰在终态 POST in-flight 时 stop（既没进缓冲也没
+      // 落库），该 run 停在 running，靠下次异代重连的 markInterruptedBelow 兜底标 interrupted——这正是
+      // interrupted 自愈的设计目的。
+      const terminalStatus = run.status === "success" ? "success" : "failure";
+      this.trackReport(
+        runningReport.then(() =>
+          this.reportRun({
+            id: runId,
+            ownerId: this.ownerId,
+            taskName: entry.reg.name,
+            ownerGeneration: this.generation,
+            status: terminalStatus,
+            trigger,
+            scheduledAt: tick.manual ? null : tick.scheduledAt,
+            startedAt: startedAtIso,
+            finishedAt: finishedAtIso,
+            durationMs,
+            error: run.errorMessage ?? null,
+          }),
+        ),
+      );
+    }
+  }
+
+  // === run 上报（两阶段回报 + 未 ack 缓冲，#493 P2）===
+
+  /** 追踪一个在途上报 promise，完成即摘除。回报永不抛，故无需 catch。 */
+  private trackReport(promise: Promise<void>): void {
+    this.pendingReports.add(promise);
+    void promise.finally(() => this.pendingReports.delete(promise));
+  }
+
+  /** 等所有在途上报排空（测试与将来的 graceful drain 用）。等待期间新增的上报也一并等到。 */
+  public async settleReports(): Promise<void> {
+    while (this.pendingReports.size > 0) {
+      await Promise.all([...this.pendingReports]);
+    }
+  }
+
+  /**
+   * 上报一条 run 执行历史。上报**永不抛**（不能让上报失败搞崩 handler 主流程）：先 flush 未 ack 缓冲，
+   * 再 POST 本条；失败则进缓冲等重推。同 runId 去重合并（terminal 覆盖 running）由 buffer 保证。
+   */
+  private async reportRun(payload: SchedulerReportRunRequest): Promise<void> {
+    // 先尝试冲掉此前攒下的未 ack 上报，保序（旧的先走）。
+    await this.flushUnackedReports();
+    try {
+      await this.api.reportRun(payload);
+    } catch (error) {
+      this.bufferUnackedReport(payload);
+      logger.warn("scheduler run report failed, buffered for retry", {
+        event: "scheduler_client.report_failed",
+        taskName: payload.taskName,
+        status: payload.status,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  /** 把一条上报放进未 ack 缓冲：按 runId 去重合并（后到覆盖），超量丢最旧并 warn。 */
+  private bufferUnackedReport(payload: SchedulerReportRunRequest): void {
+    // 已存在同 runId 先删再插，让它落到 Map 末尾（保持插入序 = 重推序，terminal 覆盖 running）。
+    this.unackedReports.delete(payload.id);
+    this.unackedReports.set(payload.id, payload);
+    while (this.unackedReports.size > UNACKED_REPORT_BUFFER_CAP) {
+      const oldest = this.unackedReports.keys().next().value;
+      if (oldest === undefined) {
+        break;
+      }
+      this.unackedReports.delete(oldest);
+      logger.warn("scheduler unacked report buffer full, dropped oldest", {
+        event: "scheduler_client.report_buffer_overflow",
+        droppedRunId: oldest,
+      });
+    }
+  }
+
+  /** 冲一次未 ack 缓冲：逐条重推，成功的移除，失败的留下等下次；重推安全（scheduler 幂等）。 */
+  private async flushUnackedReports(): Promise<void> {
+    if (this.unackedReports.size === 0) {
+      return;
+    }
+    for (const [runId, payload] of [...this.unackedReports]) {
+      try {
+        await this.api.reportRun(payload);
+        // compare-and-delete：只在这条仍是缓冲里那一条时才删。await 期间另一个 handler 可能已把同
+        // runId 换成更新的 terminal（bufferUnackedReport 的 delete+set）——那时无条件 delete 会把
+        // terminal 误删、让 run 永远停在 running。用引用相等守住：被替换了就不删，留给下次 flush。
+        if (this.unackedReports.get(runId) === payload) {
+          this.unackedReports.delete(runId);
+        }
+      } catch {
+        // 仍失败：留在缓冲，下次再冲。中止本轮 flush（连接大概率还没恢复），避免空转。
+        return;
+      }
     }
   }
 }

--- a/packages/scheduler-client/test/scheduler-client.test.ts
+++ b/packages/scheduler-client/test/scheduler-client.test.ts
@@ -168,3 +168,134 @@ describe("SchedulerClient dispatch", () => {
     expect(runs.at(-1)!.errorMessage).toContain("boom");
   });
 });
+
+// === run 上报（两阶段回报 + 未 ack 缓冲，#493 P2）===
+
+type CapturedReport = Record<string, unknown>;
+
+/**
+ * 造一个只认 POST /scheduler/runs 的 fetch mock：把请求体收集起来，可控制某几次调用失败（模拟离线）。
+ * `failFirst` 让开头 N 次上报抛错，进未 ack 缓冲；其余成功返回 { ok: true }。
+ */
+function makeReportFetch(opts: { failFirst?: number } = {}): {
+  fetch: typeof fetch;
+  reports: CapturedReport[];
+} {
+  const reports: CapturedReport[] = [];
+  let calls = 0;
+  const failFirst = opts.failFirst ?? 0;
+  const fetchImpl = (async (_url: string, init?: RequestInit) => {
+    calls += 1;
+    if (calls <= failFirst) {
+      throw new Error("offline");
+    }
+    const body = init?.body ? (JSON.parse(String(init.body)) as CapturedReport) : {};
+    reports.push(body);
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true }),
+    } as Response;
+  }) as unknown as typeof fetch;
+  return { fetch: fetchImpl, reports };
+}
+
+function makeReportClient(fetchImpl: typeof fetch): SchedulerClient {
+  return new SchedulerClient({ baseUrl: "http://127.0.0.1:1", ownerId: "agent", fetch: fetchImpl });
+}
+
+describe("SchedulerClient run reporting", () => {
+  it("reports running then a terminal success under the same run id (two-phase)", async () => {
+    const { fetch: f, reports } = makeReportFetch();
+    const client = makeReportClient(f);
+    client.register(reg({ handler: async () => {} }));
+
+    await client.onTick(tick("2026-07-05T00:00:00.000Z"));
+    await client.settleReports(); // 回报是 fire-and-forget，等在途上报排空再断言。
+
+    expect(reports).toHaveLength(2);
+    expect(reports[0]!.status).toBe("running");
+    expect(reports[1]!.status).toBe("success");
+    // 同一 runId 两次上报。
+    expect(reports[0]!.id).toBe(reports[1]!.id);
+    expect(reports[1]!.finishedAt).toBeTypeOf("string");
+    expect(reports[1]!.durationMs).toBeTypeOf("number");
+    // scheduled 触发带 scheduledAt，trigger=scheduled。
+    expect(reports[0]!.trigger).toBe("scheduled");
+    expect(reports[0]!.scheduledAt).toBe("2026-07-05T00:00:00.000Z");
+  });
+
+  it("maps a thrown handler to a failure terminal report with the error message", async () => {
+    const { fetch: f, reports } = makeReportFetch();
+    const client = makeReportClient(f);
+    client.register(
+      reg({
+        handler: async () => {
+          throw new Error("kaboom");
+        },
+      }),
+    );
+
+    await client.onTick(tick("2026-07-05T00:00:00.000Z"));
+    await client.settleReports();
+
+    expect(reports).toHaveLength(2);
+    expect(reports[0]!.status).toBe("running");
+    expect(reports[1]!.status).toBe("failure");
+    expect(reports[1]!.error).toContain("kaboom");
+  });
+
+  it("reports manual triggerNow with trigger=manual and null scheduledAt", async () => {
+    const { fetch: f, reports } = makeReportFetch();
+    const client = makeReportClient(f);
+    client.register(reg({ handler: async () => {} }));
+
+    await client.triggerNow("t");
+    await client.settleReports();
+
+    expect(reports).toHaveLength(2);
+    expect(reports[0]!.trigger).toBe("manual");
+    expect(reports[0]!.scheduledAt).toBeNull();
+  });
+
+  it("does not report skipped_overlap runs (never truly ran)", async () => {
+    const { fetch: f, reports } = makeReportFetch();
+    const client = makeReportClient(f);
+    const gate = deferred();
+    client.register(
+      reg({
+        overlap: "skip",
+        handler: async () => {
+          await gate.promise;
+        },
+      }),
+    );
+
+    const first = client.triggerNow("t"); // 占锁，阻塞在 gate
+    const second = await client.triggerNow("t"); // running → overlap，不跑不上报
+    expect(second).toEqual({ ok: false, reason: "overlap" });
+    gate.resolve();
+    await first;
+    await client.settleReports();
+
+    // 只有真跑的那次两阶段上报；skipped_overlap 不产生任何上报。
+    expect(reports.filter(r => r.status === "running")).toHaveLength(1);
+    expect(reports).toHaveLength(2);
+  });
+
+  it("buffers a failed report and re-pushes it on the next report attempt (at-least-once)", async () => {
+    // 让前 1 次上报失败（running 进缓冲），后续成功：下一次上报前会先 flush 掉缓冲里的 running。
+    const { fetch: f, reports } = makeReportFetch({ failFirst: 1 });
+    const client = makeReportClient(f);
+    client.register(reg({ handler: async () => {} }));
+
+    await client.onTick(tick("2026-07-05T00:00:00.000Z"));
+    await client.settleReports();
+
+    // running 首发失败→缓冲；终态上报前 flush 出 running，再发终态 → 共 2 条成功落地。
+    expect(reports).toHaveLength(2);
+    const statuses = reports.map(r => r.status);
+    expect(statuses).toContain("running");
+    expect(statuses).toContain("success");
+  });
+});


### PR DESCRIPTION
scheduler B 方向重构（#493）**P2**：让使用方 SDK 真正把执行历史两阶段回报给 scheduler，并加缓冲重推、interrupted 自愈、历史 GC。P1 建好的 `POST /scheduler/runs` 端点在此接上真实生产者。

## 改动

**SDK（scheduler-client）**
- 每次跑 handler 生成 runId：开始报 `running`、结束报终态（本地 `error`→wire `failure`）；`skipped_overlap` 不报（从没真跑）。
- 回报是**旁路遥测，不阻塞 handler**：running fire-and-forget，终态 chain 在 running 之后（保 per-run 有序、不占关键路径）。失败进内存未 ack 缓冲，下次上报前 + register 重连后 flush 重推。
- `settleReports()` 暴露给测试 / 将来 graceful drain。

**scheduler 服务**
- 状态感知 upsert：`running` 走空 update（迟到 running 绝不覆盖已写入的终态）、终态全覆盖（终态永远赢）。
- interrupted 自愈：register 被接受时 `markInterruptedBelow(ownerId, generation)`——标 `owner_generation < 入参` 的残留 running。同代重连（scheduler 重启、agent 存活）不误杀；agent 重启（generation 递增）才标上一代孤儿。
- 历史 GC：进程内 24h `setInterval` prune（window function：保留每 (owner,task) 最近 N 条且 M 天内，`running` 永不删，`started_at DESC, id DESC` tie-breaker）。`historyRetentionCount`(200)/`historyRetentionDays`(90) 落 config 三处同步。

## /review 抓到并修复（Claude 对抗 agent + Codex 双跑）

1. **回报阻塞 handler 关键路径**（真回归）：running/终态回报原本 `await`、默认 30s 超时——scheduler 不可达时每次 run 卡最多 30s×2、running 锁多持有致误判 overlap 丢 tick，违背「两进程互不打断」。→ 改 fire-and-forget（终态 chain 在 running 后保序）。
2. **未 ack 缓冲 stale-delete 丢 terminal**：flush 的 `await` 期间另一 handler 把同 runId 换成 terminal，flush 成功后无条件 delete 误删 terminal → run 永停 running。→ compare-and-delete（引用相等才删）。
3. GC `ORDER BY started_at DESC` 无 tie-breaker → 加 `id DESC`。

## 验证

六项全绿（build/typecheck/lint/format/knip/test，1360+ 测试）。DateTime ISO-text 存储 + 字典序比较已实测确认。

分 PR：P1(#497 已合)→ **P2(本 PR)** → P3 触发 callback → P4 全局查询+gateway+前端 → P5 拆除。Related: #493