### PR TITLE
feat(scheduler): 统一触发 — scheduler trigger 路由 + 反向 callback（#493 P3）

### DIFF
--- a/apps/agent/src/app/scheduler-trigger-callback.handler.ts
+++ b/apps/agent/src/app/scheduler-trigger-callback.handler.ts
@@ -1,0 +1,48 @@
+import type { FastifyInstance } from "fastify";
+import { registerJsonRoute } from "@kagami/http/register";
+import {
+  schedulerTriggerCallbackContract,
+  type SchedulerTriggerCallbackResponse,
+} from "@kagami/scheduler-api/trigger";
+import type { SchedulerClient } from "@kagami/scheduler-client/scheduler-client";
+
+type SchedulerTriggerCallbackHandlerDeps = {
+  schedulerClient: SchedulerClient;
+};
+
+/**
+ * 统一触发的反向回调端点（scheduler B P3，issue #493）。scheduler 收到前端手动触发后反向 POST
+ * 到本进程的 `/internal/scheduler-trigger`，这里收 taskName → 调 SDK triggerNowDetached 同步受理 +
+ * 后台跑 handler → 把受理结果映射成回调判别联合回给 scheduler（它再原样透传回前端）：
+ *
+ * - `{ ok: true }` → `{ outcome: "accepted" }`
+ * - `{ ok: false, reason }` → `{ outcome: "rejected", reason }`（unknown_task / overlap）
+ *
+ * 用 **detached** 触发（非 triggerNow）：callback 契约 5s 硬超时，必须**立即**回受理、handler 后台跑，
+ * 否则长任务（data-retention 分块删）会被 scheduler 误判 owner_unreachable。owner 侧从不产生
+ * owner_unreachable——那是 scheduler 对 callback 失败的归一。前端旧路径（agent-api
+ * triggerSchedulerTask，仍用阻塞式 triggerNow）并存到 P5 才拆。
+ */
+export class SchedulerTriggerCallbackHandler {
+  private readonly schedulerClient: SchedulerClient;
+
+  public constructor({ schedulerClient }: SchedulerTriggerCallbackHandlerDeps) {
+    this.schedulerClient = schedulerClient;
+  }
+
+  public register(app: FastifyInstance): void {
+    registerJsonRoute(
+      app,
+      schedulerTriggerCallbackContract.triggerCallback,
+      ({ input }): SchedulerTriggerCallbackResponse => {
+        // detached：同步返回受理结果（accepted / unknown_task / overlap），handler 后台跑。绝不能
+        // await 满整个 handler——callback 契约 5s 硬超时，长任务（data-retention）会被误判 unreachable。
+        const result = this.schedulerClient.triggerNowDetached(input.taskName);
+        if (result.ok) {
+          return { outcome: "accepted" };
+        }
+        return { outcome: "rejected", reason: result.reason };
+      },
+    );
+  }
+}

--- a/apps/agent/src/app/server-runtime.ts
+++ b/apps/agent/src/app/server-runtime.ts
@@ -26,6 +26,7 @@ import { buildIthomeScheduledTasks } from "../agent/capabilities/ithome/applicat
 import { SchedulerClient } from "@kagami/scheduler-client/scheduler-client";
 import { buildDataRetentionTasks } from "../agent/capabilities/data-retention/data-retention-scheduled-tasks.js";
 import { SchedulerViewHandler } from "./scheduler-view.handler.js";
+import { SchedulerTriggerCallbackHandler } from "./scheduler-trigger-callback.handler.js";
 import { AppStateOccurrenceStore } from "./app-state-occurrence-store.js";
 import { HttpOssClient } from "../acl/oss-client.js";
 import { HttpBrowserClient } from "../acl/browser-client.js";
@@ -229,6 +230,10 @@ export async function buildServerRuntime(): Promise<ServerRuntime> {
   const schedulerClient = new SchedulerClient({
     baseUrl: `http://${config.services.scheduler.host}:${config.services.scheduler.port}`,
     ownerId: "agent",
+    // 反向回调根地址（统一触发 #493 P3）：从 services.agent 派生（host 是 reachable host，
+    // scheduler 同机据此 reach 本进程）。scheduler 收到前端手动触发后反向 POST 回这里的
+    // /internal/scheduler-trigger 端点（见 SchedulerTriggerCallbackHandler）。
+    callbackBaseUrl: `http://${config.services.agent.host}:${config.services.agent.port}`,
     occurrenceStore: new AppStateOccurrenceStore({
       appStateStore: new PrismaAppStateStore({ database }),
     }),
@@ -251,6 +256,7 @@ export async function buildServerRuntime(): Promise<ServerRuntime> {
         mainAgentContextQueryService: agentRuntime.mainAgentContextQueryService,
       }),
       new SchedulerViewHandler({ schedulerClient }),
+      new SchedulerTriggerCallbackHandler({ schedulerClient }),
     ],
   });
 

--- a/apps/llm/src/app/llm-service-runtime.ts
+++ b/apps/llm/src/app/llm-service-runtime.ts
@@ -136,6 +136,10 @@ export async function buildLlmServiceRuntime(): Promise<LlmServiceRuntime> {
   const schedulerClient = new SchedulerClient({
     baseUrl: `http://${config.services.scheduler.host}:${config.services.scheduler.port}`,
     ownerId: "llm-service",
+    // 统一触发（#493 P3）要求 owner 自报反向回调根地址。llm 的 GC 任务不面向前端手动触发，
+    // 这里如实上报自身地址即可（万一被触发，callback 无 /internal/scheduler-trigger 端点 →
+    // scheduler 归一 owner_unreachable，不影响 GC 的定时 tick 派发）。
+    callbackBaseUrl: `http://${config.services.llm.host}:${config.services.llm.port}`,
   });
   if (claudeCodeConfig.fileCacheGcEnabled) {
     schedulerClient.register(

--- a/apps/scheduler/package.json
+++ b/apps/scheduler/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@kagami/http": "workspace:*",
     "@kagami/kernel": "workspace:*",
+    "@kagami/rpc-client": "workspace:*",
     "@kagami/scheduler-api": "workspace:*",
     "@prisma/adapter-better-sqlite3": "^7.8.0",
     "@prisma/client": "^7.6.0",

--- a/apps/scheduler/src/app/scheduler-runtime.ts
+++ b/apps/scheduler/src/app/scheduler-runtime.ts
@@ -9,6 +9,7 @@ import { TickBroadcaster } from "../application/tick-broadcaster.js";
 import { SchedulerRegisterHandler } from "../http/scheduler-register.handler.js";
 import { SchedulerRunsHandler } from "../http/scheduler-runs.handler.js";
 import { SchedulerTicksHandler } from "../http/scheduler-ticks.handler.js";
+import { SchedulerTriggerHandler } from "../http/scheduler-trigger.handler.js";
 import { closeDb, configureSqlite, createDbClient, type Database } from "../infra/db/client.js";
 import { TaskRunStore } from "../infra/db/task-run-store.js";
 
@@ -51,6 +52,7 @@ export async function buildSchedulerRuntime(): Promise<SchedulerRuntime> {
       new SchedulerRegisterHandler({ engine, store }),
       new SchedulerTicksHandler({ broadcaster, engine }),
       new SchedulerRunsHandler({ store }),
+      new SchedulerTriggerHandler({ engine }),
     ],
   });
 

--- a/apps/scheduler/src/application/scheduler-engine.ts
+++ b/apps/scheduler/src/application/scheduler-engine.ts
@@ -29,6 +29,8 @@ type TaskEntry = {
 type OwnerState = {
   generation: number;
   clientInstanceId: string;
+  /** owner 自报的反向回调根地址（统一触发 #493 P3）：scheduler 据此反向 POST 回 owner。 */
+  callbackBaseUrl: string;
   tasks: Map<string, TaskEntry>;
 };
 
@@ -86,6 +88,7 @@ export class SchedulerEngine {
     this.owners.set(request.ownerId, {
       generation: request.generation,
       clientInstanceId: request.clientInstanceId,
+      callbackBaseUrl: request.callbackBaseUrl,
       tasks: nextTasks,
     });
     logger.info("owner registered", {
@@ -143,6 +146,14 @@ export class SchedulerEngine {
         lastEmittedAt: entry.lastEmittedAt ? entry.lastEmittedAt.toISOString() : null,
       })),
     };
+  }
+
+  /**
+   * 查一个 owner 自报的反向回调根地址（统一触发 #493 P3）。未注册 / 未连过 → null，触发入口据此
+   * 直接回 owner_unreachable。
+   */
+  public getCallbackBaseUrl(ownerId: string): string | null {
+    return this.owners.get(ownerId)?.callbackBaseUrl ?? null;
   }
 
   /** 停掉所有 driver（进程关停）。in-flight 的 handler 在使用方进程，与本引擎无关。 */

--- a/apps/scheduler/src/http/scheduler-trigger.handler.ts
+++ b/apps/scheduler/src/http/scheduler-trigger.handler.ts
@@ -1,0 +1,75 @@
+import type { FastifyInstance } from "fastify";
+import { AppLogger } from "@kagami/kernel/logger/logger";
+import { registerJsonRoute } from "@kagami/http/register";
+import { createClient } from "@kagami/rpc-client/client";
+import {
+  schedulerTriggerContract,
+  schedulerTriggerCallbackContract,
+  type SchedulerTriggerResponse,
+} from "@kagami/scheduler-api/trigger";
+import type { SchedulerEngine } from "../application/scheduler-engine.js";
+
+const logger = new AppLogger({ source: "scheduler.trigger" });
+
+type FetchLike = typeof fetch;
+
+type SchedulerTriggerHandlerDeps = {
+  engine: SchedulerEngine;
+  /** 反向 callback 用的 fetch（测试可注入 mock）。缺省全局 fetch。 */
+  fetch?: FetchLike;
+};
+
+/**
+ * 统一触发入口路由（scheduler B P3，issue #493）。前端 → scheduler 的手动触发：
+ *
+ * 1. 查 engine.getCallbackBaseUrl(ownerId)。null（owner 未注册/未连）→ 直接回 owner_unreachable。
+ * 2. 有 → 现构造一个指向该 callbackBaseUrl 的 client，反向 POST 回 owner 的 triggerCallback 端点
+ *    （contract.timeoutMs=5s、不重试）。owner 本地跑 handler（SDK triggerNow），回 accepted / rejected。
+ * 3. callback 成功 → 把 owner 的判别联合原样透传（两者 accepted/rejected 形状相同）。
+ * 4. callback 连不上/超时/非 2xx/响应无效 → createClient 兜底抛错，这里 catch 后归一为 owner_unreachable。
+ *
+ * baseUrl 每 owner 不同（且可能重启换端口）：createClient 只支持构造期 baseUrl，故每次触发现 new 一个
+ * 指向当前 callbackBaseUrl 的 client；client 无状态、构造极廉价。5s 超时由契约 timeoutMs 承载
+ * （rpc-client 走 AbortSignal.timeout）。前端此阶段还不切（P4 才切），本 P3 只把这条链路建好。
+ */
+export class SchedulerTriggerHandler {
+  private readonly engine: SchedulerEngine;
+  private readonly fetchImpl: FetchLike | undefined;
+
+  public constructor({ engine, fetch: fetchImpl }: SchedulerTriggerHandlerDeps) {
+    this.engine = engine;
+    this.fetchImpl = fetchImpl;
+  }
+
+  public register(app: FastifyInstance): void {
+    registerJsonRoute(
+      app,
+      schedulerTriggerContract.triggerTask,
+      async ({ params }): Promise<SchedulerTriggerResponse> => {
+        const { ownerId, taskName } = params;
+        const callbackBaseUrl = this.engine.getCallbackBaseUrl(ownerId);
+        if (callbackBaseUrl === null) {
+          return { outcome: "owner_unreachable" };
+        }
+        const callback = createClient(schedulerTriggerCallbackContract, {
+          baseUrl: callbackBaseUrl,
+          ...(this.fetchImpl === undefined ? {} : { fetch: this.fetchImpl }),
+        });
+        try {
+          // owner 的判别联合（accepted / rejected）与触发入口前两支同形，直接透传。
+          return await callback.triggerCallback({ taskName });
+        } catch (error) {
+          // 连不上/超时/非 2xx/坏响应：createClient 已把三种成因归一成抛出的 Error，这里统一
+          // 归一为 owner_unreachable（owner 侧从不产生这个 outcome）。
+          logger.warn("scheduler trigger callback failed, treated as owner_unreachable", {
+            event: "scheduler.trigger.callback_failed",
+            ownerId,
+            taskName,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return { outcome: "owner_unreachable" };
+        }
+      },
+    );
+  }
+}

--- a/apps/scheduler/test/scheduler-engine.test.ts
+++ b/apps/scheduler/test/scheduler-engine.test.ts
@@ -52,6 +52,7 @@ describe("SchedulerEngine", () => {
     engine.register({
       ownerId: "agent",
       clientInstanceId: "c1",
+      callbackBaseUrl: "http://127.0.0.1:20003",
       generation: 1,
       tasks: [intervalTask("t", 1_000, "latest")],
     });
@@ -68,6 +69,7 @@ describe("SchedulerEngine", () => {
     engine.register({
       ownerId: "agent",
       clientInstanceId: "c1",
+      callbackBaseUrl: "http://127.0.0.1:20003",
       generation: 1,
       tasks: [intervalTask("t", 100, "latest")],
     });
@@ -85,6 +87,7 @@ describe("SchedulerEngine", () => {
     engine.register({
       ownerId: "agent",
       clientInstanceId: "c1",
+      callbackBaseUrl: "http://127.0.0.1:20003",
       generation: 1,
       tasks: [intervalTask("t", 100, "drop")],
     });
@@ -102,6 +105,7 @@ describe("SchedulerEngine", () => {
     engine.register({
       ownerId: "agent",
       clientInstanceId: "c1",
+      callbackBaseUrl: "http://127.0.0.1:20003",
       generation: 1,
       tasks: [intervalTask("t", 100, "catchup", 2)],
     });
@@ -119,17 +123,30 @@ describe("SchedulerEngine", () => {
     const tasks = [intervalTask("t", 1_000, "latest")];
 
     expect(
-      engine.register({ ownerId: "agent", clientInstanceId: "c1", generation: 5, tasks }).accepted,
+      engine.register({
+        ownerId: "agent",
+        clientInstanceId: "c1",
+        callbackBaseUrl: "http://127.0.0.1:20003",
+        generation: 5,
+        tasks,
+      }).accepted,
     ).toBe(true);
     const stale = engine.register({
       ownerId: "agent",
       clientInstanceId: "c2",
+      callbackBaseUrl: "http://127.0.0.1:20003",
       generation: 3,
       tasks,
     });
     expect(stale.accepted).toBe(false);
     expect(
-      engine.register({ ownerId: "agent", clientInstanceId: "c3", generation: 6, tasks }).accepted,
+      engine.register({
+        ownerId: "agent",
+        clientInstanceId: "c3",
+        callbackBaseUrl: "http://127.0.0.1:20003",
+        generation: 6,
+        tasks,
+      }).accepted,
     ).toBe(true);
   });
 
@@ -142,6 +159,7 @@ describe("SchedulerEngine", () => {
     engine.register({
       ownerId: "agent",
       clientInstanceId: "c1",
+      callbackBaseUrl: "http://127.0.0.1:20003",
       generation: 1,
       tasks: [intervalTask("a", 100, "latest"), intervalTask("b", 100, "latest")],
     });
@@ -149,6 +167,7 @@ describe("SchedulerEngine", () => {
     engine.register({
       ownerId: "agent",
       clientInstanceId: "c1",
+      callbackBaseUrl: "http://127.0.0.1:20003",
       generation: 2,
       tasks: [intervalTask("a", 100, "latest")],
     });
@@ -166,6 +185,7 @@ describe("SchedulerEngine", () => {
     engine.register({
       ownerId: "agent",
       clientInstanceId: "c1",
+      callbackBaseUrl: "http://127.0.0.1:20003",
       generation: 1,
       tasks: [intervalTask("t", 1_000, "latest")],
     });
@@ -174,5 +194,31 @@ describe("SchedulerEngine", () => {
     expect(status.tasks[0]!.name).toBe("t");
     expect(status.tasks[0]!.nextRunAt).not.toBeNull();
     expect(engine.status("nobody").tasks).toHaveLength(0);
+  });
+
+  it("stores and returns callbackBaseUrl per owner, updating it on replace-all (#493 P3)", () => {
+    const broadcaster = new TickBroadcaster();
+    const engine = new SchedulerEngine({ broadcaster });
+    // 未注册 → null。
+    expect(engine.getCallbackBaseUrl("agent")).toBeNull();
+
+    engine.register({
+      ownerId: "agent",
+      clientInstanceId: "c1",
+      callbackBaseUrl: "http://127.0.0.1:20003",
+      generation: 1,
+      tasks: [intervalTask("t", 1_000, "latest")],
+    });
+    expect(engine.getCallbackBaseUrl("agent")).toBe("http://127.0.0.1:20003");
+
+    // 重连换地址（进程重启换端口）：replace-all 时更新。
+    engine.register({
+      ownerId: "agent",
+      clientInstanceId: "c2",
+      callbackBaseUrl: "http://127.0.0.1:29999",
+      generation: 2,
+      tasks: [intervalTask("t", 1_000, "latest")],
+    });
+    expect(engine.getCallbackBaseUrl("agent")).toBe("http://127.0.0.1:29999");
   });
 });

--- a/apps/scheduler/test/scheduler-register.handler.test.ts
+++ b/apps/scheduler/test/scheduler-register.handler.test.ts
@@ -36,6 +36,7 @@ function registerBody(generation: number): Record<string, unknown> {
     ownerId: "agent",
     clientInstanceId: "inst-1",
     generation,
+    callbackBaseUrl: "http://127.0.0.1:20003",
     tasks: [
       { name: "ithome-poll", schedule: { kind: "interval", intervalMs: 1000 }, misfire: "latest" },
     ],

--- a/apps/scheduler/test/scheduler-trigger.handler.test.ts
+++ b/apps/scheduler/test/scheduler-trigger.handler.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { AppLogger } from "@kagami/kernel/logger/logger";
+import { initLoggerRuntime } from "@kagami/kernel/logger/runtime";
+import { createServiceApp } from "@kagami/kernel/http/service-app";
+import type { FastifyInstance } from "fastify";
+import { SchedulerEngine } from "../src/application/scheduler-engine.js";
+import { TickBroadcaster } from "../src/application/tick-broadcaster.js";
+import { SchedulerTriggerHandler } from "../src/http/scheduler-trigger.handler.js";
+
+beforeAll(() => {
+  initLoggerRuntime({ sinks: [{ write: () => {} }] });
+});
+
+/** 注册一个 owner（带 callbackBaseUrl），使 engine.getCallbackBaseUrl 有值。 */
+function registerOwner(engine: SchedulerEngine, callbackBaseUrl: string): void {
+  engine.register({
+    ownerId: "agent",
+    clientInstanceId: "c1",
+    generation: 1,
+    callbackBaseUrl,
+    tasks: [
+      { name: "ithome-poll", schedule: { kind: "interval", intervalMs: 1000 }, misfire: "latest" },
+    ],
+  });
+}
+
+/**
+ * 造一个只认 owner callback（POST /internal/scheduler-trigger）的 fetch mock：按预设回应答体，
+ * 或抛错模拟连不上。记录被打到的 URL 供断言「反向 POST 打到了 owner 的 callbackBaseUrl」。
+ */
+function makeCallbackFetch(
+  behavior:
+    | { kind: "respond"; body: unknown }
+    | { kind: "throw" }
+    | { kind: "bad_status"; status: number },
+): {
+  fetch: typeof fetch;
+  calls: string[];
+} {
+  const calls: string[] = [];
+  const fetchImpl = (async (url: string) => {
+    calls.push(String(url));
+    if (behavior.kind === "throw") {
+      throw new Error("ECONNREFUSED");
+    }
+    if (behavior.kind === "bad_status") {
+      return { ok: false, status: behavior.status, json: async () => ({}) } as Response;
+    }
+    return { ok: true, status: 200, json: async () => behavior.body } as Response;
+  }) as unknown as typeof fetch;
+  return { fetch: fetchImpl, calls };
+}
+
+function buildApp(engine: SchedulerEngine, fetchImpl: typeof fetch): FastifyInstance {
+  return createServiceApp({
+    logger: new AppLogger({ source: "scheduler-trigger-test" }),
+    handlers: [new SchedulerTriggerHandler({ engine, fetch: fetchImpl })],
+  });
+}
+
+describe("POST /scheduler/tasks/:ownerId/:taskName/trigger — unified trigger (#493 P3)", () => {
+  let app: FastifyInstance;
+
+  afterEach(async () => {
+    if (app) {
+      await app.close();
+    }
+  });
+
+  it("owner_unreachable when the owner is not registered (no callbackBaseUrl)", async () => {
+    const engine = new SchedulerEngine({ broadcaster: new TickBroadcaster() });
+    const { fetch: f, calls } = makeCallbackFetch({
+      kind: "respond",
+      body: { outcome: "accepted" },
+    });
+    app = buildApp(engine, f);
+    await app.ready();
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/scheduler/tasks/agent/ithome-poll/trigger",
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ outcome: "owner_unreachable" });
+    // owner 未注册 → 根本不发起 callback。
+    expect(calls).toHaveLength(0);
+  });
+
+  it("passes through accepted from the owner callback", async () => {
+    const engine = new SchedulerEngine({ broadcaster: new TickBroadcaster() });
+    const { fetch: f, calls } = makeCallbackFetch({
+      kind: "respond",
+      body: { outcome: "accepted" },
+    });
+    app = buildApp(engine, f);
+    registerOwner(engine, "http://owner.local:20003");
+    await app.ready();
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/scheduler/tasks/agent/ithome-poll/trigger",
+    });
+    expect(res.json()).toEqual({ outcome: "accepted" });
+    // 反向 POST 打到了 owner 自报的 callbackBaseUrl 的回调路径。
+    expect(calls[0]).toBe("http://owner.local:20003/internal/scheduler-trigger");
+  });
+
+  it("passes through rejected(unknown_task) from the owner callback", async () => {
+    const engine = new SchedulerEngine({ broadcaster: new TickBroadcaster() });
+    const { fetch: f } = makeCallbackFetch({
+      kind: "respond",
+      body: { outcome: "rejected", reason: "unknown_task" },
+    });
+    app = buildApp(engine, f);
+    registerOwner(engine, "http://owner.local:20003");
+    await app.ready();
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/scheduler/tasks/agent/ithome-poll/trigger",
+    });
+    expect(res.json()).toEqual({ outcome: "rejected", reason: "unknown_task" });
+  });
+
+  it("passes through rejected(overlap) from the owner callback", async () => {
+    const engine = new SchedulerEngine({ broadcaster: new TickBroadcaster() });
+    const { fetch: f } = makeCallbackFetch({
+      kind: "respond",
+      body: { outcome: "rejected", reason: "overlap" },
+    });
+    app = buildApp(engine, f);
+    registerOwner(engine, "http://owner.local:20003");
+    await app.ready();
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/scheduler/tasks/agent/ithome-poll/trigger",
+    });
+    expect(res.json()).toEqual({ outcome: "rejected", reason: "overlap" });
+  });
+
+  it("owner_unreachable when the callback connection fails", async () => {
+    const engine = new SchedulerEngine({ broadcaster: new TickBroadcaster() });
+    const { fetch: f } = makeCallbackFetch({ kind: "throw" });
+    app = buildApp(engine, f);
+    registerOwner(engine, "http://owner.local:20003");
+    await app.ready();
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/scheduler/tasks/agent/ithome-poll/trigger",
+    });
+    expect(res.json()).toEqual({ outcome: "owner_unreachable" });
+  });
+
+  it("owner_unreachable when the callback returns a non-2xx status", async () => {
+    const engine = new SchedulerEngine({ broadcaster: new TickBroadcaster() });
+    const { fetch: f } = makeCallbackFetch({ kind: "bad_status", status: 404 });
+    app = buildApp(engine, f);
+    registerOwner(engine, "http://owner.local:20003");
+    await app.ready();
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/scheduler/tasks/agent/ithome-poll/trigger",
+    });
+    expect(res.json()).toEqual({ outcome: "owner_unreachable" });
+  });
+});

--- a/packages/scheduler-api/src/contract.ts
+++ b/packages/scheduler-api/src/contract.ts
@@ -29,12 +29,18 @@ export type SchedulerTaskManifest = z.infer<typeof SchedulerTaskManifestSchema>;
  * - `ownerId`：使用方稳定标识（agent = "agent"）。
  * - `clientInstanceId`：本次进程启动的随机 UUID，标识化身。
  * - `generation`：进程启动时刻毫秒时间戳，天然单调；调度器只保留见过的最大 generation。
+ * - `callbackBaseUrl`：owner 自描述的反向回调根地址（如 `http://127.0.0.1:20003`）。统一触发
+ *   （#493 P3）里，前端 → scheduler 的手动触发经此地址反向 POST 回 owner 的 triggerCallback 端点，
+ *   由 owner 本地跑 handler。owner 每次（重）连自报，replace-all 时更新（进程可能换端口/重启）。
  */
 export const SchedulerRegisterRequestSchema = z
   .object({
     ownerId: z.string().min(1),
     clientInstanceId: z.string().min(1),
     generation: z.number().int().nonnegative(),
+    // url()：scheduler 会据此现构造 client 反向 POST，做个基本格式护栏（拒非 URL 垃圾）。owner 是
+    // 本机可信服务、scheduler 绑 127.0.0.1 只本机可 register，故不做更严的 host allowlist。
+    callbackBaseUrl: z.string().url(),
     tasks: z.array(SchedulerTaskManifestSchema),
   })
   .strict();

--- a/packages/scheduler-api/src/trigger.ts
+++ b/packages/scheduler-api/src/trigger.ts
@@ -1,0 +1,98 @@
+import { defineJsonRoute } from "@kagami/http/contract";
+import { z } from "zod";
+
+/**
+ * 统一触发 wire（scheduler B P3，issue #493）。手动触发从「前端直接调 owner 本地」改成
+ * 「前端 → scheduler → 反向 callback 回 owner」两跳：
+ *
+ * 1. **触发入口**（前端 → scheduler，经 gateway）：`triggerTask`。scheduler 收到后查该 owner
+ *    自报的 callbackBaseUrl，反向 POST 回它的 triggerCallback 端点，把 owner 的判别联合原样透传
+ *    回前端；owner 未注册/连不上则归一为 `owner_unreachable`。
+ * 2. **反向回调**（scheduler → owner，owner 实现）：`triggerCallback`。owner 收到 taskName 后
+ *    本地跑对应 handler（SDK triggerNow），回 accepted / rejected。owner 侧从不产生
+ *    `owner_unreachable`——那是 scheduler 对 callback 失败的归一。
+ *
+ * 两条路由的判别联合形状**均 HTTP 200**（in-band 判别联合，沿袭 register accepted:false 风格，
+ * 不用 4xx），让前端 / scheduler 无需自定义 error-handler 就能读到结构化结果。
+ */
+
+/** owner 侧触发结果：accepted（已本地起跑）| rejected（未知任务 / 与在跑任务重叠）。 */
+export const SchedulerTriggerCallbackResponseSchema = z.discriminatedUnion("outcome", [
+  z.object({ outcome: z.literal("accepted") }).strict(),
+  z
+    .object({
+      outcome: z.literal("rejected"),
+      reason: z.enum(["unknown_task", "overlap"]),
+    })
+    .strict(),
+]);
+
+export type SchedulerTriggerCallbackResponse = z.infer<
+  typeof SchedulerTriggerCallbackResponseSchema
+>;
+
+/**
+ * 触发入口响应（前端可见）：在 owner 侧两种结果之外多一种 `owner_unreachable`——owner 未注册 /
+ * callback 连不上 / 超时 / 非 2xx / 响应无效时由 scheduler 归一产生。前端据此提示「调度未连」。
+ */
+export const SchedulerTriggerResponseSchema = z.discriminatedUnion("outcome", [
+  z.object({ outcome: z.literal("accepted") }).strict(),
+  z
+    .object({
+      outcome: z.literal("rejected"),
+      reason: z.enum(["unknown_task", "overlap"]),
+    })
+    .strict(),
+  z.object({ outcome: z.literal("owner_unreachable") }).strict(),
+]);
+
+export type SchedulerTriggerResponse = z.infer<typeof SchedulerTriggerResponseSchema>;
+
+/** 触发入口路径参数：ownerId + taskName（都进路径段）。 */
+export const SchedulerTriggerParamsSchema = z
+  .object({
+    ownerId: z.string().min(1),
+    taskName: z.string().min(1),
+  })
+  .strict();
+
+export type SchedulerTriggerParams = z.infer<typeof SchedulerTriggerParamsSchema>;
+
+/**
+ * 触发入口契约（前端 → scheduler，经 gateway）。本 P3 先把路由建好，前端仍走旧路径（P4 才切）。
+ * 无请求体（触发意图全在路径参数里），input 建模成空对象（registerJsonRoute 已把 POST 空 body
+ * 归一化成 {}）。
+ */
+export const schedulerTriggerContract = {
+  triggerTask: defineJsonRoute({
+    method: "POST",
+    path: "/scheduler/tasks/:ownerId/:taskName/trigger",
+    params: SchedulerTriggerParamsSchema,
+    input: z.object({}).strict(),
+    output: SchedulerTriggerResponseSchema,
+  }),
+} as const;
+
+/** 反向回调请求（scheduler → owner）：只带待触发的 taskName。 */
+export const SchedulerTriggerCallbackRequestSchema = z
+  .object({
+    taskName: z.string().min(1),
+  })
+  .strict();
+
+export type SchedulerTriggerCallbackRequest = z.infer<typeof SchedulerTriggerCallbackRequestSchema>;
+
+/**
+ * 反向回调契约（scheduler 消费、owner 实现）。scheduler 每次触发向该 owner 的 callbackBaseUrl 现
+ * 构造一个指向它的 client（每 owner 地址不同）；5s 超时、不重试（手动触发要快速失败）。
+ */
+export const schedulerTriggerCallbackContract = {
+  triggerCallback: defineJsonRoute({
+    method: "POST",
+    path: "/internal/scheduler-trigger",
+    input: SchedulerTriggerCallbackRequestSchema,
+    output: SchedulerTriggerCallbackResponseSchema,
+    // 手动触发要快速失败：callback 5s 无响应即归一为 owner_unreachable，绝不拖长前端等待。
+    timeoutMs: 5_000,
+  }),
+} as const;

--- a/packages/scheduler-client/src/scheduler-client.ts
+++ b/packages/scheduler-client/src/scheduler-client.ts
@@ -40,6 +40,11 @@ type SchedulerClientDeps = {
   baseUrl: string;
   /** 使用方稳定标识（agent = "agent"）。 */
   ownerId: string;
+  /**
+   * 本进程的反向回调根地址（统一触发 #493 P3），如 `http://127.0.0.1:20003`。register 时上报给
+   * 调度器，前端手动触发经它反向 POST 回本进程的 triggerCallback 端点。
+   */
+  callbackBaseUrl: string;
   /** occurrence 去重持久化（仅当有 dedupe 任务时需要）。 */
   occurrenceStore?: OccurrenceStore;
   historySize?: number;
@@ -58,6 +63,7 @@ type SchedulerClientDeps = {
 export class SchedulerClient {
   private readonly baseUrl: string;
   private readonly ownerId: string;
+  private readonly callbackBaseUrl: string;
   private readonly occurrenceStore: OccurrenceStore | undefined;
   private readonly historySize: number;
   private readonly fetchImpl: FetchLike;
@@ -85,12 +91,14 @@ export class SchedulerClient {
   public constructor({
     baseUrl,
     ownerId,
+    callbackBaseUrl,
     occurrenceStore,
     historySize,
     fetch: fetchImpl,
   }: SchedulerClientDeps) {
     this.baseUrl = baseUrl.replace(/\/+$/, "");
     this.ownerId = ownerId;
+    this.callbackBaseUrl = callbackBaseUrl;
     this.occurrenceStore = occurrenceStore;
     this.historySize = historySize ?? DEFAULT_HISTORY_SIZE;
     this.fetchImpl = fetchImpl ?? fetch;
@@ -172,6 +180,49 @@ export class SchedulerClient {
   }
 
   /**
+   * detached 人工触发（统一触发 #493 P3）：同步做受理判定（unknown_task / overlap）+ 占锁，**立即**
+   * 返回受理结果，然后把 handler 丢到后台跑（不 await）。给统一触发的反向 callback 端点用——scheduler
+   * → owner 的 callback 契约有 5s 硬超时，绝不能等 handler 跑完（data-retention 分块删可远超 5s），
+   * 否则长任务会被 scheduler 误判成 owner_unreachable。后台 run 的结果照常经两阶段回报落库。
+   *
+   * 与 {@link triggerNow} 的唯一区别是「不等 handler」：受理判定 + 占锁仍同步完成（保住与 SSE tick
+   * 的互斥），锁在后台 run 的 finally 释放；后台 promise 带 catch 防 unhandledRejection（runClaimed
+   * 正常不抛，但 occurrenceStore 读写可能抛）。
+   */
+  public triggerNowDetached(name: string): TriggerNowResult {
+    const entry = this.registry.get(name);
+    if (!entry) {
+      return { ok: false, reason: "unknown_task" };
+    }
+    // 与 triggerNow 同：运行中判定 + 占锁全程同步，杜绝并发 tick / 触发对同一任务并跑。
+    if (entry.running) {
+      return { ok: false, reason: "overlap" };
+    }
+    entry.running = true;
+    const now = new Date().toISOString();
+    const tick: SchedulerTick = {
+      taskName: name,
+      occurrenceId: `${name}@${now}`,
+      scheduledAt: now,
+      emittedAt: now,
+      manual: true,
+    };
+    void this.runClaimed(entry, tick)
+      .catch(error => {
+        logger.warn("detached manual trigger run failed", {
+          event: "scheduler_client.detached_trigger_failed",
+          taskName: name,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      })
+      .finally(() => {
+        entry.running = false;
+        entry.abortController = null;
+      });
+    return { ok: true };
+  }
+
+  /**
    * 合成一个任务的完整状态视图：schedule / recentRuns / isRunning 来自本地，nextRunAt 查调度器
    * status（不可达则降级 null）。web 观测页的数据源。
    */
@@ -239,6 +290,7 @@ export class SchedulerClient {
       ownerId: this.ownerId,
       clientInstanceId: this.clientInstanceId,
       generation: this.generation,
+      callbackBaseUrl: this.callbackBaseUrl,
       tasks: manifests,
     });
     if (!registered.accepted) {

--- a/packages/scheduler-client/test/scheduler-client.test.ts
+++ b/packages/scheduler-client/test/scheduler-client.test.ts
@@ -15,6 +15,7 @@ function makeClient(occurrenceStore?: OccurrenceStore): SchedulerClient {
   return new SchedulerClient({
     baseUrl: "http://127.0.0.1:1",
     ownerId: "agent",
+    callbackBaseUrl: "http://127.0.0.1:2",
     fetch: OFFLINE_FETCH,
     ...(occurrenceStore ? { occurrenceStore } : {}),
   });
@@ -152,6 +153,44 @@ describe("SchedulerClient dispatch", () => {
     expect(await client.triggerNow("ghost")).toEqual({ ok: false, reason: "unknown_task" });
   });
 
+  it("triggerNowDetached returns the receipt without awaiting the handler", async () => {
+    const client = makeClient();
+    const gate = deferred();
+    let started = false;
+    let finished = false;
+    client.register(
+      reg({
+        handler: async () => {
+          started = true;
+          await gate.promise;
+          finished = true;
+        },
+      }),
+    );
+
+    // 同步受理：立即回 accepted，不等 handler 跑完（P3 修复的核心——callback 5s 超时不能等长任务）。
+    expect(client.triggerNowDetached("t")).toEqual({ ok: true });
+    await Promise.resolve(); // 放行一个 microtask 让后台 handler 起跑
+    expect(started).toBe(true);
+    expect(finished).toBe(false); // handler 仍阻塞在 gate，受理已返回
+
+    // 在跑中 → 第二次 detached 触发被判 overlap（与 SSE tick 共用同一把同步锁）。
+    expect(client.triggerNowDetached("t")).toEqual({ ok: false, reason: "overlap" });
+
+    gate.resolve();
+    await gate.promise;
+    await new Promise(resolve => setTimeout(resolve, 0)); // 等后台 runClaimed 收尾 + finally 释放锁
+    expect(finished).toBe(true);
+    // 锁已释放 → 可再次触发。
+    expect(client.triggerNowDetached("t")).toEqual({ ok: true });
+  });
+
+  it("triggerNowDetached reports unknown_task for unregistered names", () => {
+    const client = makeClient();
+    client.register(reg({ handler: async () => {} }));
+    expect(client.triggerNowDetached("ghost")).toEqual({ ok: false, reason: "unknown_task" });
+  });
+
   it("records error runs when a handler throws", async () => {
     const client = makeClient();
     client.register(
@@ -201,7 +240,12 @@ function makeReportFetch(opts: { failFirst?: number } = {}): {
 }
 
 function makeReportClient(fetchImpl: typeof fetch): SchedulerClient {
-  return new SchedulerClient({ baseUrl: "http://127.0.0.1:1", ownerId: "agent", fetch: fetchImpl });
+  return new SchedulerClient({
+    baseUrl: "http://127.0.0.1:1",
+    ownerId: "agent",
+    callbackBaseUrl: "http://127.0.0.1:2",
+    fetch: fetchImpl,
+  });
 }
 
 describe("SchedulerClient run reporting", () => {
@@ -281,6 +325,42 @@ describe("SchedulerClient run reporting", () => {
     // 只有真跑的那次两阶段上报；skipped_overlap 不产生任何上报。
     expect(reports.filter(r => r.status === "running")).toHaveLength(1);
     expect(reports).toHaveLength(2);
+  });
+
+  it("reports callbackBaseUrl in the register request (#493 P3)", async () => {
+    // 造一个只认 POST /scheduler/register 的 fetch mock：捕获 register body，回 accepted，然后让
+    // 后续 SSE 打开失败（回 500）以尽快退出 connectOnce，避免真去长连。
+    let registerBody: Record<string, unknown> | undefined;
+    const fetchImpl = (async (url: string, init?: RequestInit) => {
+      if (String(url).endsWith("/scheduler/register")) {
+        registerBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ accepted: true, generation: registerBody!.generation }),
+        } as Response;
+      }
+      // SSE 打开：回非 2xx 让 connectOnce 抛出、loop 退避（测试里随即 stop）。
+      return { ok: false, status: 500, body: null } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    const client = new SchedulerClient({
+      baseUrl: "http://127.0.0.1:1",
+      ownerId: "agent",
+      callbackBaseUrl: "http://127.0.0.1:20003",
+      fetch: fetchImpl,
+    });
+    client.register(reg({ handler: async () => {} }));
+    client.start();
+    // 轮询等 register 发生（后台循环异步）。
+    for (let i = 0; i < 50 && registerBody === undefined; i += 1) {
+      await new Promise(r => setTimeout(r, 5));
+    }
+    client.stop();
+
+    expect(registerBody).toBeDefined();
+    expect(registerBody!.callbackBaseUrl).toBe("http://127.0.0.1:20003");
+    expect(registerBody!.ownerId).toBe("agent");
   });
 
   it("buffers a failed report and re-pushes it on the next report attempt (at-least-once)", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -413,6 +413,9 @@ importers:
       '@kagami/kernel':
         specifier: workspace:*
         version: link:../../packages/kernel
+      '@kagami/rpc-client':
+        specifier: workspace:*
+        version: link:../../packages/rpc-client
       '@kagami/scheduler-api':
         specifier: workspace:*
         version: link:../../packages/scheduler-api


### PR DESCRIPTION
scheduler B 方向重构（#493）**P3**：把手动触发从「前端直接调 agent 本地」改成「前端 → scheduler → 反向 callback 回 owner」。**前端此阶段还不切（P4 才切）**，本 P3 建好 scheduler trigger 路由 + 双向 callback 链路 + register 上报 callbackBaseUrl + agent 回调端点，旧路径并存。

## 改动
- **scheduler-api**：`trigger.ts` 两契约——触发入口 `POST /scheduler/tasks/:ownerId/:taskName/trigger`（判别联合 `accepted | rejected(unknown_task|overlap) | owner_unreachable`，均 HTTP 200）+ 反向回调 `POST /internal/scheduler-trigger`（`timeoutMs: 5s`、不重试）。register 加 `callbackBaseUrl`。
- **scheduler**：engine 存 `callbackBaseUrl`（replace-all 刷新）+ `getCallbackBaseUrl`；trigger handler 现构造指向该 owner 的 client 反向 POST，owner 判别联合原样透传，连不上/超时/坏响应归一 `owner_unreachable`。
- **agent**：从 `config.services.agent` 派生 callbackBaseUrl 传 SDK；挂 `/internal/scheduler-trigger` 端点。

## /review 抓到并修复（Claude 对抗 agent + Codex 双跑，双源确认）
**CRITICAL — callback 端点 await 满整个 handler**：原实现 `await triggerNow`，而 triggerNow 等 handler 完整跑完才返回；callback 契约 5s 硬超时——`data-retention` 分块删循环（`while(!signal.aborted)`）等长任务远超 5s，会被 scheduler 误判 `owner_unreachable`，而任务其实已在跑。→ 新增 `triggerNowDetached`（同步做受理判定 + 占锁、立即返回受理结果，handler 后台跑，`.catch` 防 unhandledRejection、`finally` 释放锁），callback 端点改用它。结果照常经 P2 两阶段回报落库。另加 `callbackBaseUrl` `.url()` 格式护栏。

## 已知限制（非本 PR 范围，已在代码/commit 说明）
- **agent 绑 `0.0.0.0` 且 `/internal/scheduler-trigger` 无鉴权**：是**既有全局姿态**——agent 整个 HTTP 面（旧 `triggerSchedulerTask`、`napcat` 发送等）早就在 0.0.0.0 无鉴权暴露。属独立安全课题，不在 P3 里给单个端点加鉴权（会与其余 agent API 不一致）。建议后续单独立一个「agent HTTP 面收口 / 鉴权」的 spec。
- **llm owner 无 callback 端点**：llm 注册了 callbackBaseUrl 但没实现 `/internal/scheduler-trigger`，触发它回 `owner_unreachable`。前端只触发 agent，无 live 路径；可接受。

## 验证
六项全绿（build/typecheck/lint/format/knip/test，含 detached 3 新测试 + trigger handler 6 路径）。

分 PR：P1(#497)→P2(#501)→**P3(本)**→P4 全局查询+gateway+前端→P5 拆除。Related: #493