### PR TITLE
feat(llm): 生图模型抽象层 + openai-codex 生图 provider（走 ChatGPT 订阅额度）

### DIFF
--- a/apps/llm/src/app/llm-service-runtime.ts
+++ b/apps/llm/src/app/llm-service-runtime.ts
@@ -22,6 +22,7 @@ import {
   type LlmClient,
 } from "@kagami/llm-client";
 import { createEmbeddingClient, type EmbeddingClient } from "@kagami/llm-client/embedding";
+import { createImageClient, type ImageClient } from "@kagami/llm-client/image";
 import { HttpMetricClient } from "@kagami/metric-client/client";
 import { SchedulerClient } from "@kagami/scheduler-client/scheduler-client";
 import { recordLlmCallMetrics } from "./llm-metrics.js";
@@ -124,6 +125,13 @@ export async function buildLlmServiceRuntime(): Promise<LlmServiceRuntime> {
     cacheDao: embeddingCacheDao,
   });
 
+  // 生图 client：openai-codex provider 复用 chat 侧同一 codexAuthStore（OAuth，ChatGPT 订阅额度）。
+  const imageClient: ImageClient = createImageClient({
+    config: config.server.llm.image,
+    timeoutMs: llmTimeoutMs,
+    codexAuthStore,
+  });
+
   // auth 刷新 + usage 刷新在本进程用自己的 timer 驱动（裸 setInterval，非通用调度）。
   const authRefreshTimers = startAuthRefreshTimers({
     refreshSchedulers: authModule.authRefreshSchedulers,
@@ -157,7 +165,7 @@ export async function buildLlmServiceRuntime(): Promise<LlmServiceRuntime> {
   const app = createLlmServiceApp({
     handlers: [
       new HealthHandler(),
-      new InternalLlmHandler({ llmClient, embeddingClient }),
+      new InternalLlmHandler({ llmClient, embeddingClient, imageClient }),
       authModule.authHandler,
     ],
   });

--- a/apps/llm/src/http/internal-llm.handler.ts
+++ b/apps/llm/src/http/internal-llm.handler.ts
@@ -5,6 +5,8 @@ import type { LlmProviderId } from "@kagami/llm";
 import type { LlmUsageId } from "@kagami/kernel/contracts/llm";
 import type { LlmClient, LlmChatRequest } from "@kagami/llm-client";
 import type { EmbeddingClient, EmbeddingRequest } from "@kagami/llm-client/embedding";
+import type { ImageClient, ImageGenerationRequest } from "@kagami/llm-client/image";
+import type { GenerateImageResult } from "@kagami/llm-api/image";
 
 // Agent-facing 内部 RPC，全量走 @kagami/llm-api 契约（单一事实源，与 agent 侧 createClient 共享 schema）。
 // chat/chat-direct/embed 的 request 是可信内部契约（agent 直连、仅 localhost）的复杂 union（LlmMessage/
@@ -13,16 +15,20 @@ import type { EmbeddingClient, EmbeddingRequest } from "@kagami/llm-client/embed
 export class InternalLlmHandler {
   private readonly llmClient: LlmClient;
   private readonly embeddingClient: EmbeddingClient;
+  private readonly imageClient: ImageClient;
 
   public constructor({
     llmClient,
     embeddingClient,
+    imageClient,
   }: {
     llmClient: LlmClient;
     embeddingClient: EmbeddingClient;
+    imageClient: ImageClient;
   }) {
     this.llmClient = llmClient;
     this.embeddingClient = embeddingClient;
+    this.imageClient = imageClient;
   }
 
   public register(app: FastifyInstance): void {
@@ -49,6 +55,20 @@ export class InternalLlmHandler {
 
     registerJsonRoute(app, llmApiContract.embed, async ({ input }) => {
       return await this.embeddingClient.embed(input.request as EmbeddingRequest);
+    });
+
+    // 生图：抽象层回原始字节，这里在 HTTP 边界 base64 化成 GenerateImageResult wire DTO。
+    registerJsonRoute(app, llmApiContract.generateImage, async ({ input }) => {
+      const result = await this.imageClient.generate(input.request as ImageGenerationRequest);
+      const wire: GenerateImageResult = {
+        provider: result.provider,
+        model: result.model,
+        mimeType: result.image.mimeType,
+        imageBase64: Buffer.from(result.image.data).toString("base64"),
+        ...(result.revisedPrompt ? { revisedPrompt: result.revisedPrompt } : {}),
+        ...(result.size ? { size: result.size } : {}),
+      };
+      return wire;
     });
   }
 }

--- a/apps/llm/test/internal-llm.handler.test.ts
+++ b/apps/llm/test/internal-llm.handler.test.ts
@@ -4,12 +4,14 @@ import { BizError } from "@kagami/kernel/errors/biz-error";
 import { isBizErrorWire } from "@kagami/kernel/errors/biz-error-wire";
 import type { LlmClient } from "@kagami/llm-client";
 import type { EmbeddingClient } from "@kagami/llm-client/embedding";
+import type { ImageClient } from "@kagami/llm-client/image";
 import { createLlmServiceApp } from "../src/app/llm-service-runtime.js";
 import { InternalLlmHandler } from "../src/http/internal-llm.handler.js";
 
 function buildApp(overrides?: {
   llmClient?: Partial<LlmClient>;
   embeddingClient?: Partial<EmbeddingClient>;
+  imageClient?: Partial<ImageClient>;
 }): FastifyInstance {
   const llmClient = {
     chat: vi.fn(),
@@ -21,8 +23,12 @@ function buildApp(overrides?: {
     embed: vi.fn(),
     ...overrides?.embeddingClient,
   } as unknown as EmbeddingClient;
+  const imageClient = {
+    generate: vi.fn(),
+    ...overrides?.imageClient,
+  } as unknown as ImageClient;
   return createLlmServiceApp({
-    handlers: [new InternalLlmHandler({ llmClient, embeddingClient })],
+    handlers: [new InternalLlmHandler({ llmClient, embeddingClient, imageClient })],
   });
 }
 
@@ -99,5 +105,33 @@ describe("InternalLlmHandler", () => {
 
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual({ provider: "google", model: "e", embedding: [0.1] });
+  });
+
+  it("routes /internal/generate-image and base64-encodes the raw bytes", async () => {
+    const generate = vi.fn().mockResolvedValue({
+      provider: "openai-codex",
+      model: "gpt-5.4",
+      image: { data: new Uint8Array([1, 2, 3]), mimeType: "image/png" },
+      revisedPrompt: "a red circle",
+      size: "1024x1024",
+    });
+    app = buildApp({ imageClient: { generate } });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/internal/generate-image",
+      payload: { request: { prompt: "a red circle" } },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      provider: "openai-codex",
+      model: "gpt-5.4",
+      mimeType: "image/png",
+      imageBase64: Buffer.from([1, 2, 3]).toString("base64"),
+      revisedPrompt: "a red circle",
+      size: "1024x1024",
+    });
+    expect(generate).toHaveBeenCalledWith({ prompt: "a red circle" });
   });
 });

--- a/apps/napcat/test/napcat-gateway.test-helper.ts
+++ b/apps/napcat/test/napcat-gateway.test-helper.ts
@@ -154,6 +154,11 @@ export function createConfigManager(): ConfigManager {
           model: "gemini-embedding-001",
           outputDimensionality: 768,
         },
+        image: {
+          provider: "openai-codex",
+          baseUrl: "https://chatgpt.com/backend-api/codex/responses",
+          model: "gpt-5.4",
+        },
         codexAuth: {
           enabled: true,
           publicBaseUrl: "http://localhost:20004",

--- a/config.yaml
+++ b/config.yaml
@@ -60,6 +60,13 @@ server:
       baseUrl: http://127.0.0.1:20008
       model: google/embeddinggemma-300m
       outputDimensionality: 768
+    # 生图：LLM 网关持有 image client，走 openai-codex OAuth（ChatGPT 订阅额度），无需 platform API key。
+    # model 是 responses 路由模型（gpt-5.x）；出图后端 gpt-image-2 由 provider 写死。codex 忽略尺寸/质量
+    # （固定回 1254×1254），故不在此配 size/quality。
+    image:
+      provider: openai-codex
+      baseUrl: https://chatgpt.com/backend-api/codex/responses
+      model: gpt-5.4
     codexAuth:
       enabled: true
       publicBaseUrl: http://localhost:20004

--- a/packages/kernel/src/config/config.loader.ts
+++ b/packages/kernel/src/config/config.loader.ts
@@ -49,6 +49,7 @@ const DEFAULT_CLAUDE_CODE_REFRESH_CHECK_INTERVAL_MS = 300_000;
 const DEFAULT_GEMINI_EMBEDDING_BASE_URL = "https://generativelanguage.googleapis.com";
 const DEFAULT_GEMINI_EMBEDDING_MODEL = "gemini-embedding-001";
 const DEFAULT_GEMINI_EMBEDDING_OUTPUT_DIMENSIONALITY = 768;
+const DEFAULT_OPENAI_CODEX_IMAGE_MODEL = "gpt-5.4";
 const DEFAULT_AGENT_ASYNC_TASK_MAX_DURATION_MS = 10 * 60 * 1000;
 
 const UrlSchema = z.string().url();
@@ -127,6 +128,16 @@ const EmbeddingConfigSchema = z.preprocess(
   },
   z.discriminatedUnion("provider", [GoogleEmbeddingConfigSchema, TeiEmbeddingGemmaConfigSchema]),
 );
+// 生图 provider 配置。openai-codex 走 OAuth（同 chat 的 openaiCodex），故无 apiKey 字段——凭据由
+// runtime 注入 authModule.authServices.codex。判别联合当前仅一个成员，未来加 openai 平台生图再补。
+// 只配 model（responses 路由模型 gpt-5.x）；不配 size/quality——codex 忽略它们（固定 1254×1254），
+// 配了是误导性假旋钮。未来标准-API provider 才认尺寸，届时随该 provider 的 config 变体加。
+const OpenAiCodexImageConfigSchema = z.object({
+  provider: z.literal("openai-codex"),
+  baseUrl: UrlSchema.default(DEFAULT_OPENAI_CODEX_BASE_URL),
+  model: NonEmptyStringSchema.default(DEFAULT_OPENAI_CODEX_IMAGE_MODEL),
+});
+const ImageConfigSchema = z.discriminatedUnion("provider", [OpenAiCodexImageConfigSchema]);
 const LlmUsageAttemptConfigSchema = z.object({
   provider: LlmProviderSchema,
   model: NonEmptyStringSchema,
@@ -315,6 +326,9 @@ const ConfigSchema = z.object({
       // 文本向量化配置：LLM 网关（apps/llm）持有 embedding client，agent 经 HTTP 调用。
       // 与任何具体上层能力（记忆等）解耦，是网关的通用能力配置。
       embedding: EmbeddingConfigSchema,
+      // 生图配置：LLM 网关持有 image client，走 openai-codex OAuth（ChatGPT 订阅额度），agent 经 HTTP 调用。
+      // 给 openai-codex 默认（内层字段各有默认），省略整段也能起——不给新必填字段炸掉既有 config。
+      image: ImageConfigSchema.default({ provider: "openai-codex" }),
       codexAuth: z
         .object({
           enabled: z.boolean().default(DEFAULT_CODEX_AUTH_ENABLED),

--- a/packages/llm-api/src/contract.ts
+++ b/packages/llm-api/src/contract.ts
@@ -9,6 +9,8 @@ import { z } from "zod";
 const CHAT_TIMEOUT_MS = 600_000;
 const QUERY_TIMEOUT_MS = 30_000;
 const EMBED_TIMEOUT_MS = 60_000;
+// 生图是多秒级操作（模型思考 + 渲染），给 5 分钟兜底超时，远高于现实单次生图时长。
+const GENERATE_IMAGE_TIMEOUT_MS = 300_000;
 
 /**
  * chat / chat-direct / embed 的 `request` 是复杂 union（LlmMessage / Tool / EmbeddingRequest），刻意
@@ -64,5 +66,14 @@ export const llmApiContract = {
     input: z.object({ request: EnvelopeRequest }),
     output: z.unknown(),
     timeoutMs: EMBED_TIMEOUT_MS,
+  }),
+  // request 是 ImageGenerationRequest（信封级 z.unknown()，同 chat/embed）；output 是 base64 化的
+  // GenerateImageResult（见 llm-api/image），亦走信封级、消费端按类型断言。
+  generateImage: defineJsonRoute({
+    method: "POST",
+    path: "/internal/generate-image",
+    input: z.object({ request: EnvelopeRequest }),
+    output: z.unknown(),
+    timeoutMs: GENERATE_IMAGE_TIMEOUT_MS,
   }),
 };

--- a/packages/llm-api/src/image.ts
+++ b/packages/llm-api/src/image.ts
@@ -1,0 +1,16 @@
+/**
+ * 生图路由（`/internal/generate-image`）的 HTTP 响应体（wire 形态）。抽象层的 `ImageGenerationResult`
+ * 带原始字节 `Uint8Array`，跨 HTTP 无法直接序列化，故 handler 在传输边界把字节 base64 化成本 DTO。
+ * base64 传输沿用 chat 路径既有做法（该 llm-service 本就承载 base64 图片，见 bodyLimit 注释）。
+ *
+ * 纯 type（非 zod schema）：本路由 output 与 chat/embed 一致走信封级 `z.unknown()`，wire 结构不进
+ * Zod 运行时校验、消费端按类型断言，故这里只需编译期形状、不留装饰性 schema value。
+ */
+export type GenerateImageResult = {
+  provider: string;
+  model: string;
+  mimeType: string;
+  imageBase64: string;
+  revisedPrompt?: string;
+  size?: string;
+};

--- a/packages/llm-client/package.json
+++ b/packages/llm-client/package.json
@@ -13,6 +13,10 @@
     "./embedding": {
       "types": "./dist/embedding/index.d.ts",
       "default": "./dist/embedding/index.js"
+    },
+    "./image": {
+      "types": "./dist/image/index.d.ts",
+      "default": "./dist/image/index.js"
     }
   },
   "scripts": {

--- a/packages/llm-client/src/image/client.ts
+++ b/packages/llm-client/src/image/client.ts
@@ -1,0 +1,66 @@
+import type { Config } from "@kagami/kernel/config/config.loader";
+import type { OpenAiCodexAuthProvider } from "../providers/openai-codex-auth.js";
+import { createOpenAiCodexImageProvider } from "./providers/openai-codex-image-provider.js";
+import type { ImageProvider } from "./provider.js";
+import type { ImageGenerationRequest, ImageGenerationResult } from "./types.js";
+
+type ImageConfig = Config["server"]["llm"]["image"];
+
+export interface ImageClient {
+  generate(request: ImageGenerationRequest): Promise<ImageGenerationResult>;
+}
+
+type CreateImageClientOptions = {
+  config: ImageConfig;
+  /** LLM 全局超时（复用 llm.timeoutMs）；生图为多秒级操作。 */
+  timeoutMs: number;
+  /** openai-codex provider 的 OAuth 凭据端口（同 chat runtime 注入 authModule.authServices.codex）。 */
+  codexAuthStore?: OpenAiCodexAuthProvider;
+  /** 测试 seam：直接注入 provider，绕过 config 选择。 */
+  provider?: ImageProvider;
+};
+
+/**
+ * 生图 client 工厂，与 [[embedding/client#createEmbeddingClient]] 对称。不做缓存——同 prompt
+ * 每次出图不同，缓存无意义（与 embedding 的确定性去重相反）。client 只做「按 config 兜默认参数 +
+ * 选 provider」，字节字节透传。
+ */
+export function createImageClient(options: CreateImageClientOptions): ImageClient {
+  const provider = options.provider ?? createImageProvider(options);
+
+  return {
+    async generate(request: ImageGenerationRequest): Promise<ImageGenerationResult> {
+      return await provider.generate(resolveImageRequest(request, options.config));
+    },
+  };
+}
+
+function resolveImageRequest(
+  request: ImageGenerationRequest,
+  config: ImageConfig,
+): ImageGenerationRequest {
+  // 只兜路由 model。size/quality 不给 config 默认：codex 忽略它们（固定 1254×1254），给默认只会
+  // 造成「配了就以为生效」的错觉。调用方显式传才透传，交由 provider / 未来标准-API provider 处理。
+  return {
+    prompt: request.prompt,
+    model: request.model ?? config.model,
+    ...(request.size ? { size: request.size } : {}),
+    ...(request.quality ? { quality: request.quality } : {}),
+  };
+}
+
+function createImageProvider(options: CreateImageClientOptions): ImageProvider {
+  // config 是 discriminatedUnion，当前仅 openai-codex 一个成员。
+  if (!options.codexAuthStore) {
+    throw new Error("openai-codex image provider requires a codex auth store");
+  }
+
+  return createOpenAiCodexImageProvider({
+    config: {
+      baseUrl: options.config.baseUrl,
+      model: options.config.model,
+      timeoutMs: options.timeoutMs,
+    },
+    authStore: options.codexAuthStore,
+  });
+}

--- a/packages/llm-client/src/image/index.ts
+++ b/packages/llm-client/src/image/index.ts
@@ -1,0 +1,18 @@
+import { createImageClient, type ImageClient } from "./client.js";
+import type { ImageProvider } from "./provider.js";
+import type {
+  ImageProviderId,
+  ImageGenerationRequest,
+  ImageGenerationResult,
+  GeneratedImage,
+} from "./types.js";
+
+export {
+  createImageClient,
+  type ImageClient,
+  type ImageProvider,
+  type ImageProviderId,
+  type ImageGenerationRequest,
+  type ImageGenerationResult,
+  type GeneratedImage,
+};

--- a/packages/llm-client/src/image/provider.ts
+++ b/packages/llm-client/src/image/provider.ts
@@ -1,0 +1,11 @@
+import type { ImageGenerationRequest, ImageGenerationResult, ImageProviderId } from "./types.js";
+
+/**
+ * 生图 provider 抽象，与 [[embedding/provider]] 对称。带可选 `isAvailable`（同 chat provider）：
+ * OAuth 型 provider（openai-codex）据此暴露「凭据是否就绪」。
+ */
+export interface ImageProvider {
+  id: ImageProviderId;
+  isAvailable?(): Promise<boolean>;
+  generate(request: ImageGenerationRequest): Promise<ImageGenerationResult>;
+}

--- a/packages/llm-client/src/image/providers/openai-codex-image-provider.ts
+++ b/packages/llm-client/src/image/providers/openai-codex-image-provider.ts
@@ -1,0 +1,374 @@
+import {
+  attachLlmProviderFailureContext,
+  toSerializableLlmNativeRecord,
+  toSerializableLlmNativeRecordOrNull,
+} from "../../provider.js";
+import { llmProviderUnavailableError, llmUpstreamCallFailedError } from "../../retryable-error.js";
+import { BizError } from "@kagami/kernel/errors/biz-error";
+import type { OpenAiCodexAuthProvider } from "../../providers/openai-codex-auth.js";
+import type { ImageProvider } from "../provider.js";
+import type { ImageGenerationRequest, ImageGenerationResult } from "../types.js";
+
+/**
+ * openai-codex 生图 provider。复用 chat 侧 openai-codex provider 同一套 OAuth 认证 + endpoint
+ * （`chatgpt.com/backend-api/codex/responses`）+ SSE，走 ChatGPT 订阅额度，无需 platform API key。
+ *
+ * 与 chat provider 的关键分歧：图片不在 `response.completed`（store:false 时其 output 为空数组），
+ * 而在流式的 `response.output_item.done`（item.type=image_generation_call 的 item.result）里 —— 故
+ * 生图不能复用 chat provider 的 completed-only 解析，必须走本文件的流式累积。
+ *
+ * 强制出图用 `tool_choice: { type: allowed_tools, mode: required }`（直接 `{type:image_generation}`
+ * 强制会被后端 400，allowed_tools 包装形式才生效），保证每轮必出图。tool 内显式 model=gpt-image-2。
+ *
+ * 实测确证（含照搬同类项目 xiaoni_cc 的完整请求形状复现）：codex 后端**忽略 size**，固定回
+ * 1254×1254，连竖版请求都被拉成正方形。size/quality 如实透传只为对齐未来标准-API provider。
+ */
+type OpenAiCodexImageProviderConfig = {
+  baseUrl: string;
+  model: string;
+  timeoutMs: number;
+};
+
+/** 出图后端模型（放进 image_generation tool 的 model 字段；顶层 request.model 是 responses 路由模型）。 */
+const IMAGE_BACKEND_MODEL = "gpt-image-2";
+
+const IMAGE_INSTRUCTIONS =
+  "Use the image_generation tool to create exactly the requested image. Return the image result, not explanatory text.";
+
+type CodexImagePayload = {
+  b64: string;
+  revisedPrompt?: string;
+  size?: string;
+  outputFormat?: string;
+};
+
+export function createOpenAiCodexImageProvider(input: {
+  config: OpenAiCodexImageProviderConfig;
+  authStore: OpenAiCodexAuthProvider;
+}): ImageProvider {
+  return {
+    id: "openai-codex",
+    isAvailable: async () => {
+      return await input.authStore.hasCredentials();
+    },
+    async generate(request: ImageGenerationRequest): Promise<ImageGenerationResult> {
+      try {
+        return await sendCodexImageRequest({
+          config: input.config,
+          authStore: input.authStore,
+          request,
+        });
+      } catch (error) {
+        if (error instanceof BizError) {
+          throw error;
+        }
+
+        throw attachLlmProviderFailureContext(
+          llmUpstreamCallFailedError({
+            meta: { provider: "openai-codex", capability: "image" },
+            cause: error,
+          }),
+          { nativeError: toSerializableLlmNativeRecord(error) },
+        );
+      }
+    },
+  };
+}
+
+async function sendCodexImageRequest(params: {
+  config: OpenAiCodexImageProviderConfig;
+  authStore: OpenAiCodexAuthProvider;
+  request: ImageGenerationRequest;
+}): Promise<ImageGenerationResult> {
+  const model = params.request.model ?? params.config.model;
+  const requestBody = toCodexImageRequestBody({ ...params.request, model });
+
+  const initialAuth = await params.authStore.getAuth();
+  let result = await fetchCodexImage({
+    config: params.config,
+    accessToken: initialAuth.accessToken,
+    accountId: initialAuth.accountId,
+    requestBody,
+  });
+
+  if (result.status === 401 || result.status === 403) {
+    const refreshedAuth = await params.authStore.getAuth({ forceRefresh: true });
+    result = await fetchCodexImage({
+      config: params.config,
+      accessToken: refreshedAuth.accessToken,
+      accountId: refreshedAuth.accountId,
+      requestBody,
+    });
+
+    if (result.status === 401 || result.status === 403) {
+      throw attachLlmProviderFailureContext(
+        llmProviderUnavailableError({
+          meta: { provider: "openai-codex", capability: "image", reason: "UNAUTHORIZED" },
+        }),
+        {
+          nativeRequestPayload: toSerializableLlmNativeRecord(requestBody),
+          nativeError: buildCodexNativeError({
+            status: result.status,
+            responseText: result.sseText,
+            reason: "UNAUTHORIZED",
+          }),
+        },
+      );
+    }
+  }
+
+  if (!result.ok) {
+    throw attachLlmProviderFailureContext(
+      llmUpstreamCallFailedError({
+        meta: {
+          provider: "openai-codex",
+          capability: "image",
+          reason: "HTTP_ERROR",
+          status: result.status,
+        },
+      }),
+      {
+        nativeRequestPayload: toSerializableLlmNativeRecord(requestBody),
+        nativeError: buildCodexNativeError({
+          status: result.status,
+          responseText: result.sseText,
+          reason: "HTTP_ERROR",
+        }),
+      },
+    );
+  }
+
+  const upstreamError = extractCodexUpstreamError(result.sseText);
+  if (upstreamError) {
+    throw attachLlmProviderFailureContext(
+      llmUpstreamCallFailedError({
+        meta: { provider: "openai-codex", capability: "image", reason: "UPSTREAM_ERROR" },
+      }),
+      {
+        nativeRequestPayload: toSerializableLlmNativeRecord(requestBody),
+        nativeError: buildCodexNativeError({
+          status: result.status,
+          responseText: upstreamError,
+          reason: "UPSTREAM_ERROR",
+        }),
+      },
+    );
+  }
+
+  const payload = extractCodexImageFromSse(result.sseText);
+  if (!payload) {
+    throw attachLlmProviderFailureContext(
+      llmUpstreamCallFailedError({
+        meta: { provider: "openai-codex", capability: "image", reason: "NO_IMAGE_OUTPUT" },
+      }),
+      {
+        nativeRequestPayload: toSerializableLlmNativeRecord(requestBody),
+        nativeResponsePayload: toSerializableLlmNativeRecordOrNull(
+          buildCodexNativeError({
+            status: result.status,
+            responseText: result.sseText,
+            reason: "NO_IMAGE_OUTPUT",
+          }),
+        ),
+      },
+    );
+  }
+
+  return {
+    provider: "openai-codex",
+    model,
+    image: {
+      data: Buffer.from(payload.b64, "base64"),
+      mimeType: `image/${payload.outputFormat ?? "png"}`,
+    },
+    ...(payload.revisedPrompt ? { revisedPrompt: payload.revisedPrompt } : {}),
+    ...(payload.size ? { size: payload.size } : {}),
+  };
+}
+
+async function fetchCodexImage(params: {
+  config: OpenAiCodexImageProviderConfig;
+  accessToken: string;
+  accountId?: string;
+  requestBody: Record<string, unknown>;
+}): Promise<{ status: number; ok: boolean; sseText: string }> {
+  let response: Response;
+  try {
+    response = await fetch(params.config.baseUrl, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${params.accessToken}`,
+        Accept: "text/event-stream",
+        "Content-Type": "application/json",
+        ...(params.accountId ? { "ChatGPT-Account-Id": params.accountId } : {}),
+        "User-Agent": "Kagami/1.0",
+      },
+      body: JSON.stringify(params.requestBody),
+      signal: AbortSignal.timeout(params.config.timeoutMs),
+    });
+  } catch (error) {
+    throw attachLlmProviderFailureContext(
+      llmUpstreamCallFailedError({
+        meta: { provider: "openai-codex", capability: "image" },
+        cause: error,
+      }),
+      {
+        nativeRequestPayload: toSerializableLlmNativeRecord(params.requestBody),
+        nativeError: toSerializableLlmNativeRecord(error),
+      },
+    );
+  }
+
+  const sseText = await response.text();
+  return { status: response.status, ok: response.ok, sseText };
+}
+
+export function toCodexImageRequestBody(request: ImageGenerationRequest): Record<string, unknown> {
+  // tool 内 model 显式指定出图后端模型（顶层 request.model 是 responses 路由模型 gpt-5.x）。
+  // size/quality 如实透传，但 codex 后端固定回 1254×1254、忽略尺寸——留着为对齐未来的标准-API
+  // provider（那条才认 size），并防后端某天开始支持（实测确证见文件头注释）。
+  const imageTool: Record<string, unknown> = {
+    type: "image_generation",
+    model: IMAGE_BACKEND_MODEL,
+    output_format: "png",
+  };
+  if (request.size) {
+    imageTool.size = request.size;
+  }
+  if (request.quality) {
+    imageTool.quality = request.quality;
+  }
+
+  return {
+    model: request.model,
+    instructions: IMAGE_INSTRUCTIONS,
+    input: [
+      {
+        role: "user",
+        content: [{ type: "input_text", text: request.prompt }],
+      },
+    ],
+    tools: [imageTool],
+    // allowed_tools + mode:required 是能生效的强制写法——直接 { type: "image_generation" } 强制会被
+    // 后端 400，而这个包装形式保证每轮必调工具、不会偶尔回纯文本。
+    tool_choice: {
+      type: "allowed_tools",
+      mode: "required",
+      tools: [{ type: "image_generation" }],
+    },
+    parallel_tool_calls: true,
+    stream: true,
+    store: false,
+  };
+}
+
+type CodexSseEvent = {
+  event: string;
+  data: Record<string, unknown> | null;
+};
+
+function* iterateCodexSseEvents(sseText: string): Generator<CodexSseEvent> {
+  const blocks = sseText
+    .split("\n\n")
+    .map(block => block.trim())
+    .filter(Boolean);
+
+  for (const block of blocks) {
+    const lines = block.split("\n");
+    const eventLine = lines.find(line => line.startsWith("event: "));
+    const dataStr = lines
+      .filter(line => line.startsWith("data: "))
+      .map(line => line.slice("data: ".length))
+      .join("\n");
+    if (!eventLine || dataStr.length === 0) {
+      continue;
+    }
+
+    yield { event: eventLine.slice("event: ".length), data: safeParseJson(dataStr) };
+  }
+}
+
+/**
+ * 从 SSE 提取最终图片。优先 `response.output_item.done`（item.type=image_generation_call 的
+ * item.result，权威终图），退回最后一个 `partial_image`（default 设置下 partial 即等于终图，
+ * 但显式请求 partial_images 时是低清中间帧，故仅作兜底）。导出供单测覆盖解析分支。
+ */
+export function extractCodexImageFromSse(sseText: string): CodexImagePayload | null {
+  let done: CodexImagePayload | null = null;
+  let partial: CodexImagePayload | null = null;
+
+  for (const { event, data } of iterateCodexSseEvents(sseText)) {
+    if (!data) {
+      continue;
+    }
+
+    if (event === "response.output_item.done") {
+      const item = data.item as Record<string, unknown> | undefined;
+      if (item?.type === "image_generation_call" && typeof item.result === "string") {
+        done = {
+          b64: item.result,
+          ...readImageMeta(item),
+        };
+      }
+      continue;
+    }
+
+    if (event === "response.image_generation_call.partial_image") {
+      if (typeof data.partial_image_b64 === "string") {
+        partial = {
+          b64: data.partial_image_b64,
+          ...readImageMeta(data),
+        };
+      }
+    }
+  }
+
+  return done ?? partial;
+}
+
+function readImageMeta(source: Record<string, unknown>): Omit<CodexImagePayload, "b64"> {
+  const meta: Omit<CodexImagePayload, "b64"> = {};
+  if (typeof source.revised_prompt === "string") {
+    meta.revisedPrompt = source.revised_prompt;
+  }
+  if (typeof source.size === "string") {
+    meta.size = source.size;
+  }
+  if (typeof source.output_format === "string") {
+    meta.outputFormat = source.output_format;
+  }
+  return meta;
+}
+
+export function extractCodexUpstreamError(sseText: string): string | null {
+  for (const { event, data } of iterateCodexSseEvents(sseText)) {
+    if (event === "response.completed" && data) {
+      const response = data.response as Record<string, unknown> | undefined;
+      const error = response?.error as { message?: string } | null | undefined;
+      if (error && typeof error.message === "string") {
+        return error.message;
+      }
+    }
+  }
+  return null;
+}
+
+function safeParseJson(value: string): Record<string, unknown> | null {
+  try {
+    return JSON.parse(value) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function buildCodexNativeError(input: {
+  status: number;
+  responseText: string;
+  reason: string;
+}): Record<string, unknown> {
+  return {
+    status: input.status,
+    reason: input.reason,
+    responseText: input.responseText.slice(0, 2_000),
+  };
+}

--- a/packages/llm-client/src/image/types.ts
+++ b/packages/llm-client/src/image/types.ts
@@ -1,0 +1,34 @@
+/**
+ * 生图（image generation）能力的抽象层类型，与 [[embedding/types]] 平级：都是「非 chat 的第二类
+ * LLM 能力」。抽象层保持纯粹——「给 prompt，回原始字节」，落 OSS / 发 QQ 属消费端职责，不进本包。
+ */
+export type ImageProviderId = "openai-codex";
+
+export type ImageGenerationRequest = {
+  prompt: string;
+  /**
+   * 目标尺寸，如 "1024x1024" | "1024x1536" | "1536x1024" | "auto"。**是否生效取决于 provider**：
+   * openai-codex 后端忽略它（固定回 1254×1254，实测确证）；未来的标准平台-API provider 才认。
+   */
+  size?: string;
+  /** 质量档，如 "low" | "medium" | "high" | "auto"。同 size，openai-codex 后端不认。 */
+  quality?: string;
+  /** 路由模型（如 gpt-5.4）；缺省由 client 从 config 兜。实际出图由后端 image 模型完成。 */
+  model?: string;
+};
+
+/** 进程内的原始图片字节（未 base64）。HTTP 边界的 base64 编码是传输层职责，不落在抽象层。 */
+export type GeneratedImage = {
+  data: Uint8Array;
+  mimeType: string;
+};
+
+export type ImageGenerationResult = {
+  provider: ImageProviderId;
+  model: string;
+  image: GeneratedImage;
+  /** 后端改写后的实际 prompt（若返回）。 */
+  revisedPrompt?: string;
+  /** 后端实际出图尺寸（若返回）。 */
+  size?: string;
+};

--- a/packages/llm-client/test/openai-codex-image-provider.test.ts
+++ b/packages/llm-client/test/openai-codex-image-provider.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractCodexImageFromSse,
+  extractCodexUpstreamError,
+  toCodexImageRequestBody,
+} from "../src/image/providers/openai-codex-image-provider.js";
+
+/** 把 (event, data) 组装成一段 codex responses SSE 文本（块间空行分隔），贴合真实流形态。 */
+function sse(events: Array<{ event: string; data: unknown }>): string {
+  return events.map(e => `event: ${e.event}\ndata: ${JSON.stringify(e.data)}`).join("\n\n");
+}
+
+const doneEvent = {
+  event: "response.output_item.done",
+  data: {
+    type: "response.output_item.done",
+    item: {
+      id: "ig_1",
+      type: "image_generation_call",
+      status: "generating",
+      result: "RE9ORV9CQVNFNjQ=",
+      revised_prompt: "一个红色的圆",
+      output_format: "png",
+      size: "1024x1024",
+    },
+  },
+};
+
+const partialEvent = {
+  event: "response.image_generation_call.partial_image",
+  data: {
+    type: "response.image_generation_call.partial_image",
+    partial_image_b64: "UEFSVElBTF9CQVNFNjQ=",
+    partial_image_index: 0,
+    output_format: "png",
+    size: "1254x1254",
+  },
+};
+
+describe("extractCodexImageFromSse", () => {
+  it("从 output_item.done 取终图与元数据", () => {
+    const payload = extractCodexImageFromSse(sse([partialEvent, doneEvent]));
+    expect(payload).toEqual({
+      b64: "RE9ORV9CQVNFNjQ=",
+      revisedPrompt: "一个红色的圆",
+      size: "1024x1024",
+      outputFormat: "png",
+    });
+  });
+
+  it("done 优先于 partial（default 下 partial 即终图，显式 partial_images 时是低清中间帧）", () => {
+    const payload = extractCodexImageFromSse(sse([doneEvent, partialEvent]));
+    expect(payload?.b64).toBe("RE9ORV9CQVNFNjQ=");
+  });
+
+  it("无 done 时退回 partial 兜底", () => {
+    const payload = extractCodexImageFromSse(sse([partialEvent]));
+    expect(payload?.b64).toBe("UEFSVElBTF9CQVNFNjQ=");
+    expect(payload?.size).toBe("1254x1254");
+  });
+
+  it("无任何图片事件返回 null（如纯文本轮或空 completed）", () => {
+    const text = sse([
+      { event: "response.created", data: { type: "response.created" } },
+      { event: "keepalive", data: {} },
+      {
+        event: "response.completed",
+        data: { type: "response.completed", response: { output: [] } },
+      },
+    ]);
+    expect(extractCodexImageFromSse(text)).toBeNull();
+  });
+
+  it("忽略无法解析的 data 块", () => {
+    const text = `event: response.output_item.done\ndata: {not-json`;
+    expect(extractCodexImageFromSse(text)).toBeNull();
+  });
+});
+
+describe("toCodexImageRequestBody", () => {
+  it("产出被后端 400 约束逼出来的 load-bearing 形状（防回归）", () => {
+    const body = toCodexImageRequestBody({ prompt: "画只猫", model: "gpt-5.4" });
+
+    // tool 内显式 image 后端模型；顶层 model 是 responses 路由模型。
+    expect(body.model).toBe("gpt-5.4");
+    expect(body.tools).toEqual([
+      { type: "image_generation", model: "gpt-image-2", output_format: "png" },
+    ]);
+    // 强制出图只能走 allowed_tools 包装形式（直接 {type:image_generation} 会被后端 400）。
+    expect(body.tool_choice).toEqual({
+      type: "allowed_tools",
+      mode: "required",
+      tools: [{ type: "image_generation" }],
+    });
+    expect(body.stream).toBe(true);
+    expect(body.store).toBe(false);
+  });
+
+  it("size/quality 有值才透传进 tool", () => {
+    const body = toCodexImageRequestBody({
+      prompt: "x",
+      model: "gpt-5.4",
+      size: "1024x1536",
+      quality: "high",
+    });
+    expect(body.tools).toEqual([
+      {
+        type: "image_generation",
+        model: "gpt-image-2",
+        output_format: "png",
+        size: "1024x1536",
+        quality: "high",
+      },
+    ]);
+  });
+});
+
+describe("extractCodexUpstreamError", () => {
+  it("取到 response.completed 内嵌的 error.message", () => {
+    const text = sse([
+      {
+        event: "response.completed",
+        data: { type: "response.completed", response: { error: { message: "上游炸了" } } },
+      },
+    ]);
+    expect(extractCodexUpstreamError(text)).toBe("上游炸了");
+  });
+
+  it("无 error 时返回 null", () => {
+    const text = sse([
+      {
+        event: "response.completed",
+        data: { type: "response.completed", response: { error: null, output: [] } },
+      },
+    ]);
+    expect(extractCodexUpstreamError(text)).toBeNull();
+  });
+});


### PR DESCRIPTION
## 做了什么

给 Kagami 加「生图大模型」能力，与 chat / embedding 抽象平级的第三类 LLM 能力。两个 commit：

1. **抽象契约**（`4658d0d2`）：`ImageProvider` 接口 + 请求/结果类型（抽象层回原始字节 `Uint8Array`，落 OSS / 发 QQ 属消费端职责，不进本包）、`@kagami/llm-client/image` 子路径、`config.server.llm.image` schema。刻意不做缓存（同 prompt 每次出图不同，与 embedding 确定性去重相反）。
2. **openai-codex provider**（`7c4d3d23`）：复用 chat 侧同一套 OAuth + `chatgpt.com/backend-api/codex/responses` + SSE，**无需 platform API key、走 ChatGPT 订阅额度**，实际出图由后端 gpt-image-2 完成。llm-service 装配 `imageClient` + `/internal/generate-image` 路由（字节在 HTTP 边界 base64 成 wire DTO，沿用 chat 既有 base64 图片传输）。

镜像了既有 embedding 垂直切片。**消费端（agent 生图工具 + OSS 落库 + 发 QQ）尚未做，是后续阶段。**

## 关键实测发现

- 强制出图用 `tool_choice: { type: allowed_tools, mode: required }`——直接 `{type:image_generation}` 强制会被后端 400，allowed_tools 包装形式才生效。tool 内显式 `model=gpt-image-2`。
- 图片在流式 `response.output_item.done` 里，**不在 `response.completed`**（`store:false` 下其 output 为空），故不能复用 chat 的 completed-only 解析。
- **codex 后端忽略 `size`/`quality`**，固定回 1254×1254（含复现同类项目 xiaoni_cc 完整请求形状证实）。`size?`/`quality?` 保留在抽象层留给未来标准平台-API provider，codex config 不配这俩假旋钮。

## 验证

- 五件套全绿：build / typecheck / lint(0 error) / format / knip。
- 真实 codex OAuth 端到端出图验证通过（跑的是本 PR 的真 provider 代码，非临时脚本）。
- 新增纯函数单测（SSE 提取、请求体 load-bearing 形状、上游 error 提取）+ handler 路由 base64 映射测试。

## Review

已过多模型 review（3 个专家子 Agent + codex 跨模型对抗）。无确认 CRITICAL；修了 dead-code zod schema（降为纯 type）、测试文件误放 src/ 未被执行（挪到 test/）、补齐 load-bearing 请求体测试。其余 codex 报的 High 均为对既有信封/bodyLimit/abort 模式的批评（本 PR 如实沿用 chat/embed 既定设计），逐条判定 won't-fix。

**含新增 workspace 子路径导出但无 DB 迁移。合并后不自动部署。**