### PR TITLE
fix(rpc-client): 默认 fetch 绑定 globalThis，修浏览器 Illegal invocation

### DIFF
--- a/packages/rpc-client/src/binary-client.ts
+++ b/packages/rpc-client/src/binary-client.ts
@@ -63,7 +63,9 @@ export function createBinaryClient<TContracts extends BinaryContractMap>(
   options: CreateClientOptions,
 ): BinaryClient<TContracts> {
   const baseUrl = options.baseUrl.replace(/\/+$/, "");
-  const fetchImpl = options.fetch ?? fetch;
+  // 与 client.ts 同因：默认 fetch 会被存进 ctx 再以 `ctx.fetchImpl(...)` 调用，接收者变成 ctx，
+  // 浏览器的 `fetch` brand-check 会抛 `Illegal invocation`。bind 到 globalThis 修掉。
+  const fetchImpl = options.fetch ?? fetch.bind(globalThis);
   const unreachableMessage = options.unreachableMessage ?? DEFAULT_UNREACHABLE_MESSAGE;
   const decodeError = options.decodeError ?? decodeBizErrorWire;
   const mapFallbackError =

--- a/packages/rpc-client/src/client.ts
+++ b/packages/rpc-client/src/client.ts
@@ -72,7 +72,10 @@ export function createClient<TContracts extends JsonContractMap>(
   options: CreateClientOptions,
 ): JsonClient<TContracts> {
   const baseUrl = options.baseUrl.replace(/\/+$/, "");
-  const fetchImpl = options.fetch ?? fetch;
+  // 默认 fetch 必须 bind 到 globalThis：下面它被存进 ctx 再以 `ctx.fetchImpl(...)` 调用，
+  // 接收者会变成 ctx。浏览器的 `fetch` 有 brand-check，`this !== Window` 时抛
+  // `TypeError: Illegal invocation`（Node/undici 无此检查，故后端与单测不受影响）。
+  const fetchImpl = options.fetch ?? fetch.bind(globalThis);
   const defaultTimeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const unreachableMessage = options.unreachableMessage ?? DEFAULT_UNREACHABLE_MESSAGE;
   const decodeError = options.decodeError ?? decodeBizErrorWire;

--- a/packages/rpc-client/test/binary-client.test.ts
+++ b/packages/rpc-client/test/binary-client.test.ts
@@ -140,6 +140,39 @@ describe("createBinaryClient — binary-raw", () => {
   });
 });
 
+describe("createBinaryClient — 默认 fetch 绑定 globalThis", () => {
+  // 与 client.test.ts 同理：模拟浏览器 brand-check，守住默认 fetch 路径不以 ctx 为接收者调用。
+  function installBrowserFetch(response: Response): () => void {
+    const original = globalThis.fetch;
+    const browserFetch = function (this: unknown): Promise<Response> {
+      if (this !== globalThis) {
+        throw new TypeError("Failed to execute 'fetch' on 'Window': Illegal invocation");
+      }
+      return Promise.resolve(response);
+    };
+    globalThis.fetch = browserFetch as unknown as typeof fetch;
+    return () => {
+      globalThis.fetch = original;
+    };
+  }
+
+  it("不传 options.fetch → 默认 fetch 以 globalThis 为接收者调用（挡住 Illegal invocation 回归）", async () => {
+    const restore = installBrowserFetch(jsonResponse({ key: "res-9" }, 201));
+    try {
+      const client = createBinaryClient(contracts, { baseUrl: "http://svc" });
+      await expect(
+        client.putObject({
+          params: {},
+          headers: { "content-type": "image/png" },
+          bytes: new Uint8Array([1, 2, 3]),
+        }),
+      ).resolves.toEqual({ key: "res-9" });
+    } finally {
+      restore();
+    }
+  });
+});
+
 describe("notReadyFallbackMapper — 文案字节基线", () => {
   const mapper = notReadyFallbackMapper("测试服务", message => new Error(message));
 

--- a/packages/rpc-client/test/client.test.ts
+++ b/packages/rpc-client/test/client.test.ts
@@ -127,6 +127,37 @@ describe("createClient", () => {
   });
 });
 
+describe("createClient — 默认 fetch 绑定 globalThis", () => {
+  // 复现浏览器 brand-check：`fetch` 的 this 必须是 Window/globalThis，否则抛 Illegal invocation。
+  // Node/undici 无此检查，故必须在测试里手动模拟——否则默认 fetch 路径（不传 options.fetch）
+  // 在浏览器里 `ctx.fetchImpl(...)` 以 ctx 为接收者调用会炸，而 Node 测试永远绿，bug 就此溜过。
+  function installBrowserFetch(response: Response): () => void {
+    const original = globalThis.fetch;
+    const browserFetch = function (this: unknown): Promise<Response> {
+      if (this !== globalThis) {
+        throw new TypeError("Failed to execute 'fetch' on 'Window': Illegal invocation");
+      }
+      return Promise.resolve(response);
+    };
+    globalThis.fetch = browserFetch as unknown as typeof fetch;
+    return () => {
+      globalThis.fetch = original;
+    };
+  }
+
+  it("不传 options.fetch → 默认 fetch 以 globalThis 为接收者调用（挡住 Illegal invocation 回归）", async () => {
+    const restore = installBrowserFetch(jsonResponse({ greeting: "hi kagami" }));
+    try {
+      const client = createClient(contracts, { baseUrl: "http://svc" });
+      await expect(client.getGreeting({ name: "kagami" })).resolves.toEqual({
+        greeting: "hi kagami",
+      });
+    } finally {
+      restore();
+    }
+  });
+});
+
 describe("createClient — params 通道", () => {
   const paramContracts = {
     getDetail: defineJsonRoute({


### PR DESCRIPTION
## 问题

部署后管理台**所有走 `@kagami/rpc-client` 的页面集体加载失败**（待办 / LLM 历史 / 念头 / 应用日志 / NapCat / QQ / 主 Agent 上下文…），表现为「加载失败，请检查后端服务是否运行」，且浏览器**一个后端请求都没发出**——但 Console / Gateway 后端本身健康（页面内手动 `fetch('/api/...')` 返回 200）。

## 根因

`createClient` / `createBinaryClient` 里：

```ts
const fetchImpl = options.fetch ?? fetch;   // 存下裸 fetch
```

`fetchImpl` 被放进 `ctx` 对象，随后以 `ctx.fetchImpl(url, init)` 调用——**接收者成了 `ctx`**。浏览器的 `fetch` 有 brand-check，`this !== Window` 时直接抛：

```
TypeError: Failed to execute 'fetch' on 'Window': Illegal invocation
```

在真正发请求前就挂掉，被 client 兜底成 `reason: "unreachable"`。

**为什么一直没暴露**：Node/undici 的 `fetch` 不做这个 brand-check，接收者是谁都能跑，所以后端 acl 层与全部单测长期绿。[#500](https://github.com/KisinTheFlame/kagami/pull/500) 把前端最后一个手写 fetch 换成本 client 后，才在浏览器引爆。

## 修复

默认 fetch 走 `fetch.bind(globalThis)`（`client.ts` + `binary-client.ts` 各一行）。只绑默认路径，显式传 `options.fetch` 的后端调用点不受影响（Node 本就无所谓）。

## 回归点

两个 client 各补一个「默认 fetch 路径」测试（现有测试全都显式传 mock fetch，从不走默认路径，正是 bug 溜过去的原因）。测试用一个模拟浏览器 brand-check 的 fetch stub（`this !== globalThis` 即抛 `Illegal invocation`）真实复现——去掉 `.bind` 即精确变红。

## 验证

- 浏览器实测：页面内 `ctx.f = window.fetch` 当方法调 → `Illegal invocation`；`window.fetch.bind(window)` → 200。
- 五件套全绿：build / typecheck / lint(0 error) / format / knip(exit 0)。
- 全量测试 1371 passed；rpc-client 25 passed。
- 去 bind 复跑 → 新回归点精确报 `Illegal invocation` 变红，恢复即绿。

影响面仅前端消费端，无 DB / 配置变更。上线只需 `pnpm build` 后 `app:deploy gateway`（重建 web dist）。