### PR TITLE
feat(scheduler): 全局任务查询 + gateway 上游 + 前端改直连 scheduler（#493 P4）

### DIFF
--- a/apps/gateway/src/config.ts
+++ b/apps/gateway/src/config.ts
@@ -17,6 +17,8 @@ export interface GatewayConfig {
   metricTarget: URL;
   /** oss 上游基址，由 services.oss.host/port 拼出（管理台只读对象浏览 /oss-object 走它）。 */
   ossTarget: URL;
+  /** scheduler 上游基址，由 services.scheduler.host/port 拼出（调度任务全局查询 / 触发 /scheduler/tasks 走它）。 */
+  schedulerTarget: URL;
   /** 静态资源目录：gateway 自身产物下的 dist/public（构建期由 @kagami/web 的 dist 拷入，见 #496）。 */
   distDir: string;
 }
@@ -34,6 +36,7 @@ interface RawConfig {
     llm?: RawServiceEndpoint;
     metric?: RawServiceEndpoint;
     oss?: RawServiceEndpoint;
+    scheduler?: RawServiceEndpoint;
   };
 }
 
@@ -64,6 +67,7 @@ export function loadGatewayConfig(): GatewayConfig {
     llmTarget: resolveEndpoint(services?.llm, "llm"),
     metricTarget: resolveEndpoint(services?.metric, "metric"),
     ossTarget: resolveEndpoint(services?.oss, "oss"),
+    schedulerTarget: resolveEndpoint(services?.scheduler, "scheduler"),
     // 运行时 config.js 位于 apps/gateway/dist/，前端产物在同级 public/ 下（构建期拷入）。
     distDir: path.join(path.dirname(fileURLToPath(import.meta.url)), "public"),
   };

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -17,6 +17,7 @@ const consoleTarget = config.consoleTarget;
 const llmTarget = config.llmTarget;
 const metricTarget = config.metricTarget;
 const ossTarget = config.ossTarget;
+const schedulerTarget = config.schedulerTarget;
 // 这些前缀的 /api 请求路由到 console 进程（管理台后端，纯 DB 查询）；其余仍到 server（agent）。
 const CONSOLE_PATH_PREFIXES = [
   "/app-log",
@@ -35,6 +36,11 @@ const METRIC_PATH_PREFIXES = ["/metric/query", "/metric/derive"];
 // 管理台对象浏览器只读面路由到 kagami-oss 进程。仅 /oss-object（列表 / 统计 / 预览字节）过网关；
 // 写操作前缀 /objects（put/delete）刻意不在此，浏览器经网关够不到 OSS 的任何写路由。
 const OSS_PATH_PREFIXES = ["/oss-object"];
+// 调度任务面路由到 kagami-scheduler 进程（#493 P4）：全局查询 GET /scheduler/tasks 与手动触发
+// POST /scheduler/tasks/:o/:t/trigger 都落在 /scheduler/tasks 前缀下（后者是它的子路径）。register
+// / status / runs、SSE tick、/internal/scheduler-trigger 都是服务间内部路由，刻意不进网关前缀，
+// 前端经网关够不到它们。
+const SCHEDULER_PATH_PREFIXES = ["/scheduler/tasks"];
 const HASHED_ASSET_NAME_PATTERN = /(?:^|[-.])[a-z0-9]{8,}(?=\.)/i;
 // 上游响应超时：等待上游返回响应头的上限。命中即回 504，避免上游卡死 / 半开时前端连接
 // 永久悬挂、socket 句柄泄漏。只约束"拿到响应头"这一段——响应头一到就清除，故不会打断
@@ -161,6 +167,10 @@ function selectUpstreamTarget(upstreamPath: string): URL {
 
   if (matchesAnyPrefix(upstreamPath, OSS_PATH_PREFIXES)) {
     return ossTarget;
+  }
+
+  if (matchesAnyPrefix(upstreamPath, SCHEDULER_PATH_PREFIXES)) {
+    return schedulerTarget;
   }
 
   return apiTarget;

--- a/apps/scheduler/src/app/scheduler-runtime.ts
+++ b/apps/scheduler/src/app/scheduler-runtime.ts
@@ -8,6 +8,7 @@ import { SchedulerEngine } from "../application/scheduler-engine.js";
 import { TickBroadcaster } from "../application/tick-broadcaster.js";
 import { SchedulerRegisterHandler } from "../http/scheduler-register.handler.js";
 import { SchedulerRunsHandler } from "../http/scheduler-runs.handler.js";
+import { SchedulerTasksViewHandler } from "../http/scheduler-tasks-view.handler.js";
 import { SchedulerTicksHandler } from "../http/scheduler-ticks.handler.js";
 import { SchedulerTriggerHandler } from "../http/scheduler-trigger.handler.js";
 import { closeDb, configureSqlite, createDbClient, type Database } from "../infra/db/client.js";
@@ -52,6 +53,7 @@ export async function buildSchedulerRuntime(): Promise<SchedulerRuntime> {
       new SchedulerRegisterHandler({ engine, store }),
       new SchedulerTicksHandler({ broadcaster, engine }),
       new SchedulerRunsHandler({ store }),
+      new SchedulerTasksViewHandler({ engine, store }),
       new SchedulerTriggerHandler({ engine }),
     ],
   });

--- a/apps/scheduler/src/application/scheduler-engine.ts
+++ b/apps/scheduler/src/application/scheduler-engine.ts
@@ -15,6 +15,17 @@ const logger = new AppLogger({ source: "scheduler.engine" });
 
 type Driver = CronDriver | IntervalDriver;
 
+/**
+ * 一个活任务的 tick 侧状态（跨 owner 全局视图 #493 P4 用）：engine 拥有的部分——归属、名字、
+ * 周期、下次触发。执行历史（isRunning / recentRuns）在 DB 侧，由 handler 左连接补齐。
+ */
+export type SchedulerActiveTask = {
+  ownerId: string;
+  name: string;
+  schedule: SchedulerTaskSchedule;
+  nextRunAt: string | null;
+};
+
 type TaskEntry = {
   manifest: SchedulerTaskManifest;
   driver: Driver;
@@ -146,6 +157,26 @@ export class SchedulerEngine {
         lastEmittedAt: entry.lastEmittedAt ? entry.lastEmittedAt.toISOString() : null,
       })),
     };
+  }
+
+  /**
+   * 跨全部 owner 列出活任务的 tick 侧状态（全局观测视图 #493 P4）。status(ownerId) 的多 owner 版：
+   * 前端不再逐 owner 查，而是一次拿全部活任务，再由 handler 左连接执行历史。engine 是纯派生态，
+   * 只知道「谁有哪些任务、下次何时触发」，不碰 DB。
+   */
+  public listActiveTasks(): SchedulerActiveTask[] {
+    const result: SchedulerActiveTask[] = [];
+    for (const [ownerId, owner] of this.owners) {
+      for (const entry of owner.tasks.values()) {
+        result.push({
+          ownerId,
+          name: entry.manifest.name,
+          schedule: entry.manifest.schedule,
+          nextRunAt: entry.driver.peekNextRun()?.toISOString() ?? null,
+        });
+      }
+    }
+    return result;
   }
 
   /**

--- a/apps/scheduler/src/http/scheduler-tasks-view.handler.ts
+++ b/apps/scheduler/src/http/scheduler-tasks-view.handler.ts
@@ -1,0 +1,62 @@
+import type { FastifyInstance } from "fastify";
+import { registerJsonRoute } from "@kagami/http/register";
+import {
+  schedulerTasksViewContract,
+  type SchedulerTaskView,
+  type SchedulerTasksViewResponse,
+} from "@kagami/scheduler-api/tasks-view";
+import type { SchedulerEngine } from "../application/scheduler-engine.js";
+import { taskKeyString, type TaskRunStore } from "../infra/db/task-run-store.js";
+
+type SchedulerTasksViewHandlerDeps = {
+  engine: SchedulerEngine;
+  store: TaskRunStore;
+};
+
+/**
+ * 全局任务观测视图路由（scheduler B P4，issue #493）。前端第一次真正切到 scheduler：一次拿到全部
+ * owner 的活任务 + 执行历史，取代原先经 agent listSchedulerTasks 中转。
+ *
+ * 装配方式是「活任务左连接执行历史」：
+ * 1. engine.listActiveTasks() 拿跨全部 owner 的活任务（归属 / 名字 / 周期 / nextRunAt，纯派生态）。
+ * 2. store.getRecentRunsForTasks(keys) 用一条 window function SQL 批量拉这些 (ownerId, taskName)
+ *    的最近 N 条 run + isRunning（无 N+1）。
+ * 3. 以活任务为主拼装：查得到历史就填上，查不到就 recentRuns=[] / isRunning=false。孤儿历史行
+ *    （owner 已删该任务）不进 keys、也就不进视图。
+ */
+export class SchedulerTasksViewHandler {
+  private readonly engine: SchedulerEngine;
+  private readonly store: TaskRunStore;
+
+  public constructor({ engine, store }: SchedulerTasksViewHandlerDeps) {
+    this.engine = engine;
+    this.store = store;
+  }
+
+  public register(app: FastifyInstance): void {
+    registerJsonRoute(
+      app,
+      schedulerTasksViewContract.listTasks,
+      async (): Promise<SchedulerTasksViewResponse> => {
+        const activeTasks = this.engine.listActiveTasks();
+        const historyByKey = await this.store.getRecentRunsForTasks(
+          activeTasks.map(task => ({ ownerId: task.ownerId, taskName: task.name })),
+        );
+
+        const tasks: SchedulerTaskView[] = activeTasks.map(task => {
+          const history = historyByKey.get(taskKeyString(task.ownerId, task.name));
+          return {
+            ownerId: task.ownerId,
+            name: task.name,
+            schedule: task.schedule,
+            nextRunAt: task.nextRunAt,
+            isRunning: history?.isRunning ?? false,
+            recentRuns: history?.recentRuns ?? [],
+          };
+        });
+
+        return { tasks };
+      },
+    );
+  }
+}

--- a/apps/scheduler/src/infra/db/task-run-store.ts
+++ b/apps/scheduler/src/infra/db/task-run-store.ts
@@ -1,4 +1,6 @@
+import { RECENT_RUNS_PER_TASK, type SchedulerTaskViewRun } from "@kagami/scheduler-api/tasks-view";
 import type { SchedulerReportRunRequest } from "@kagami/scheduler-api/run";
+import type { SchedulerRunStatus, SchedulerRunTrigger } from "@kagami/scheduler-api/run";
 import type { Database } from "./client.js";
 
 type TaskRunStoreDeps = {
@@ -8,6 +10,32 @@ type TaskRunStoreDeps = {
 type PruneHistoryOptions = {
   retentionCount: number;
   retentionDays: number;
+};
+
+/** (ownerId, taskName) 复合键：全局视图左连接活任务与执行历史用。 */
+export type TaskKey = {
+  ownerId: string;
+  taskName: string;
+};
+
+/** 一个 (ownerId, taskName) 分组的历史投影：最近 N 条 run + 是否有 running 行。 */
+export type TaskRunHistory = {
+  recentRuns: SchedulerTaskViewRun[];
+  isRunning: boolean;
+};
+
+/** window function 选出的一行原始 run（rank ≤ N）。SQLite 驱动回的裸标量，手动映射到 wire。 */
+type RankedRunRow = {
+  owner_id: string;
+  task_name: string;
+  id: string;
+  status: string;
+  trigger: string;
+  scheduled_at: string | null;
+  started_at: string;
+  finished_at: string | null;
+  duration_ms: number | null;
+  error: string | null;
 };
 
 /**
@@ -47,6 +75,73 @@ export class TaskRunStore {
       create: { id: record.id, ...data },
       update: record.status === "running" ? {} : data,
     });
+  }
+
+  /**
+   * 批量查一组 (ownerId, taskName) 的执行历史投影（全局视图 #493 P4）：每个分组的最近
+   * RECENT_RUNS_PER_TASK 条 run（startedAt desc）+ 是否有 running 行。
+   *
+   * 避免 N+1：用一条 window function SQL（ROW_NUMBER() OVER PARTITION BY owner_id, task_name
+   * ORDER BY started_at DESC, id DESC，取 rank ≤ N）一次拉全部分组的近期 runs，进程内按 key
+   * 桶排。isRunning **只看每组 rank-1（最近一次 run）是否 running**——真正在跑的 run 必是最新一次
+   * （见循环内注释）；rank>1 的 running 行是漏报终态的陈旧孤儿，不算在跑。空组（无历史）不入 map，
+   * 由调用方左连接补 recentRuns=[] / isRunning=false。
+   *
+   * keys 为空时直接回空 map（跳过 SQL）。keys 由 engine 活任务派生，个数=活任务数（十几个量级），
+   * 不做参数分批。
+   */
+  public async getRecentRunsForTasks(keys: TaskKey[]): Promise<Map<string, TaskRunHistory>> {
+    const result = new Map<string, TaskRunHistory>();
+    if (keys.length === 0) {
+      return result;
+    }
+
+    // (owner_id, task_name) IN ((?,?), (?,?), ...)：只捞活任务分组的行，孤儿历史（owner 已删该
+    // 任务）不进 window，也就不进视图。
+    const tuplePlaceholders = keys.map(() => "(?, ?)").join(", ");
+    const params: (string | number)[] = [];
+    for (const key of keys) {
+      params.push(key.ownerId, key.taskName);
+    }
+    params.push(RECENT_RUNS_PER_TASK);
+
+    const rows = await this.database.$queryRawUnsafe<RankedRunRow[]>(
+      `
+      SELECT
+        "owner_id", "task_name", "id", "status", "trigger",
+        "scheduled_at", "started_at", "finished_at", "duration_ms", "error"
+      FROM (
+        SELECT
+          "owner_id", "task_name", "id", "status", "trigger",
+          "scheduled_at", "started_at", "finished_at", "duration_ms", "error",
+          ROW_NUMBER() OVER (
+            PARTITION BY "owner_id", "task_name"
+            ORDER BY "started_at" DESC, "id" DESC
+          ) AS "rank"
+        FROM "task_run"
+        WHERE ("owner_id", "task_name") IN (${tuplePlaceholders})
+      )
+      WHERE "rank" <= ?
+      ORDER BY "owner_id", "task_name", "started_at" DESC, "id" DESC
+      `,
+      ...params,
+    );
+
+    for (const row of rows) {
+      const key = taskKeyString(row.owner_id, row.task_name);
+      let bucket = result.get(key);
+      if (!bucket) {
+        // 首行即该分组 rank-1（最近一次 run，rows 已按 started_at DESC, id DESC 排序）。isRunning
+        // **只看 rank-1**：真正在跑的 run 必是最新一次（SDK running 锁保证同任务同时只有一个、且其
+        // started_at 最新）；rank>1 的 running 行只可能是「终态上报丢失」的陈旧孤儿，不代表任务在跑，
+        // 不据它判 isRunning（否则一个漏报终态的旧 run 会把已空闲的任务永远显示成运行中）。
+        bucket = { recentRuns: [], isRunning: row.status === "running" };
+        result.set(key, bucket);
+      }
+      bucket.recentRuns.push(toViewRun(row));
+    }
+
+    return result;
   }
 
   /**
@@ -106,4 +201,39 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000;
 /** wire 的 ISO 字符串（可空 / 可缺省）转 Date；缺省与 null 一律落 null。 */
 function toDateOrNull(value: string | null | undefined): Date | null {
   return value == null ? null : new Date(value);
+}
+
+/**
+ * 合成 (ownerId, taskName) 复合键的 map 键；调用方与桶排两侧共用，保证一致。用 JSON 元组而非裸
+ * 分隔符：ownerId/taskName 里的任何字符（含分隔符本身）都被 JSON 转义，两个不同 (owner,task) 绝不
+ * 拼成同一键——比曾用的 U+0000 分隔符稳，也不在源码里放字面 NUL。
+ */
+export function taskKeyString(ownerId: string, taskName: string): string {
+  return JSON.stringify([ownerId, taskName]);
+}
+
+/**
+ * SQLite DATETIME 列经 better-sqlite3 adapter 回来是 JS Date（见探测）；也兼容驱动升级后回 ISO
+ * 字符串的情形。null 透传 null，统一归一成 wire 的 ISO 字符串。
+ */
+function toIsoOrNull(value: Date | string | null): string | null {
+  if (value === null) {
+    return null;
+  }
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+/** window function 选出的裸行映射到 wire 的 SchedulerTaskViewRun（时间归一 ISO、状态/来源收窄）。 */
+function toViewRun(row: RankedRunRow): SchedulerTaskViewRun {
+  return {
+    id: row.id,
+    status: row.status as SchedulerRunStatus,
+    trigger: row.trigger as SchedulerRunTrigger,
+    scheduledAt: toIsoOrNull(row.scheduled_at),
+    // started_at NOT NULL：归一后必非空，兜底空串仅为收窄类型（实际不触达）。
+    startedAt: toIsoOrNull(row.started_at) ?? "",
+    finishedAt: toIsoOrNull(row.finished_at),
+    durationMs: row.duration_ms,
+    error: row.error,
+  };
 }

--- a/apps/scheduler/test/scheduler-tasks-view.handler.test.ts
+++ b/apps/scheduler/test/scheduler-tasks-view.handler.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppLogger } from "@kagami/kernel/logger/logger";
+import { initLoggerRuntime } from "@kagami/kernel/logger/runtime";
+import { createServiceApp } from "@kagami/kernel/http/service-app";
+import type { SchedulerTasksViewResponse } from "@kagami/scheduler-api/tasks-view";
+import type { FastifyInstance } from "fastify";
+import { SchedulerEngine } from "../src/application/scheduler-engine.js";
+import { TickBroadcaster } from "../src/application/tick-broadcaster.js";
+import { SchedulerTasksViewHandler } from "../src/http/scheduler-tasks-view.handler.js";
+import { TaskRunStore } from "../src/infra/db/task-run-store.js";
+import { createTaskRunTestDb, type TaskRunTestDb } from "./helpers/task-run-db.js";
+
+beforeAll(() => {
+  initLoggerRuntime({ sinks: [{ write: () => {} }] });
+});
+
+/** 注册一个 owner 的一组活任务（interval，misfire latest）到 engine。 */
+function registerOwner(engine: SchedulerEngine, ownerId: string, taskNames: string[]): void {
+  engine.register({
+    ownerId,
+    clientInstanceId: `${ownerId}-c1`,
+    generation: 1,
+    callbackBaseUrl: `http://${ownerId}.local:20003`,
+    tasks: taskNames.map(name => ({
+      name,
+      schedule: { kind: "interval" as const, intervalMs: 60_000 },
+      misfire: "latest" as const,
+    })),
+  });
+}
+
+describe("GET /scheduler/tasks — global view (#493 P4)", () => {
+  let db: TaskRunTestDb;
+  let store: TaskRunStore;
+  let engine: SchedulerEngine;
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    // fake timers 让 interval driver 不真实 fire；只关心 nextRunAt 派生与拼装。
+    vi.useFakeTimers();
+    db = await createTaskRunTestDb();
+    store = new TaskRunStore({ database: db.database });
+    engine = new SchedulerEngine({ broadcaster: new TickBroadcaster() });
+    app = createServiceApp({
+      logger: new AppLogger({ source: "scheduler-tasks-view-test" }),
+      handlers: [new SchedulerTasksViewHandler({ engine, store })],
+    });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    engine.stop();
+    await db.cleanup();
+    vi.useRealTimers();
+  });
+
+  async function fetchTasks(): Promise<SchedulerTasksViewResponse> {
+    const res = await app.inject({ method: "GET", url: "/scheduler/tasks" });
+    expect(res.statusCode).toBe(200);
+    return res.json() as SchedulerTasksViewResponse;
+  }
+
+  it("returns empty tasks when no owner is registered", async () => {
+    expect((await fetchTasks()).tasks).toEqual([]);
+  });
+
+  it("lists active tasks across all owners (cross-owner)", async () => {
+    registerOwner(engine, "agent", ["taskA"]);
+    registerOwner(engine, "napcat", ["taskB"]);
+
+    const { tasks } = await fetchTasks();
+    const byOwner = new Map(tasks.map(t => [`${t.ownerId}/${t.name}`, t]));
+    expect(byOwner.has("agent/taskA")).toBe(true);
+    expect(byOwner.has("napcat/taskB")).toBe(true);
+    expect(tasks).toHaveLength(2);
+  });
+
+  it("left-joins: an active task with no history gets empty recentRuns and isRunning=false", async () => {
+    registerOwner(engine, "agent", ["taskA"]);
+    const { tasks } = await fetchTasks();
+    const task = tasks.find(t => t.name === "taskA")!;
+    expect(task.recentRuns).toEqual([]);
+    expect(task.isRunning).toBe(false);
+    // schedule + nextRunAt 来自 engine（活任务侧）。
+    expect(task.schedule).toEqual({ kind: "interval", intervalMs: 60_000 });
+    expect(task.nextRunAt).not.toBeNull();
+  });
+
+  it("joins recentRuns and derives isRunning from a running row", async () => {
+    registerOwner(engine, "agent", ["taskA"]);
+    await store.upsertRun({
+      id: "r-done",
+      ownerId: "agent",
+      taskName: "taskA",
+      ownerGeneration: 1,
+      status: "success",
+      trigger: "scheduled",
+      scheduledAt: "2026-07-06T10:00:00.000Z",
+      startedAt: "2026-07-06T10:00:01.000Z",
+      finishedAt: "2026-07-06T10:00:05.000Z",
+      durationMs: 4000,
+      error: null,
+    });
+    await store.upsertRun({
+      id: "r-live",
+      ownerId: "agent",
+      taskName: "taskA",
+      ownerGeneration: 1,
+      status: "running",
+      trigger: "manual",
+      scheduledAt: null,
+      startedAt: "2026-07-06T11:00:00.000Z",
+      finishedAt: null,
+      durationMs: null,
+      error: null,
+    });
+
+    const { tasks } = await fetchTasks();
+    const task = tasks.find(t => t.name === "taskA")!;
+    expect(task.isRunning).toBe(true);
+    // startedAt desc：running（11:00）在前，success（10:00:01）在后。
+    expect(task.recentRuns.map(r => r.id)).toEqual(["r-live", "r-done"]);
+    expect(task.recentRuns[1]).toMatchObject({
+      status: "success",
+      trigger: "scheduled",
+      durationMs: 4000,
+      finishedAt: "2026-07-06T10:00:05.000Z",
+    });
+  });
+
+  it("does not leak orphan history whose task the owner no longer registers", async () => {
+    registerOwner(engine, "agent", ["taskA"]); // 只注册 taskA
+    await store.upsertRun({
+      id: "orphan",
+      ownerId: "agent",
+      taskName: "taskGone",
+      ownerGeneration: 1,
+      status: "success",
+      trigger: "scheduled",
+      scheduledAt: null,
+      startedAt: "2026-07-06T10:00:00.000Z",
+      finishedAt: "2026-07-06T10:00:01.000Z",
+      durationMs: 1000,
+      error: null,
+    });
+
+    const { tasks } = await fetchTasks();
+    expect(tasks.map(t => t.name)).toEqual(["taskA"]);
+  });
+});

--- a/apps/scheduler/test/task-run-store.test.ts
+++ b/apps/scheduler/test/task-run-store.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { SchedulerReportRunRequest } from "@kagami/scheduler-api/run";
-import { TaskRunStore } from "../src/infra/db/task-run-store.js";
+import { TaskRunStore, taskKeyString } from "../src/infra/db/task-run-store.js";
 import { createTaskRunTestDb, type TaskRunTestDb } from "./helpers/task-run-db.js";
 
 const RUN_ID = "run-1";
@@ -181,6 +181,109 @@ describe("TaskRunStore", () => {
       await seed("old", "taskA", iso(100));
       await store.pruneHistory({ retentionCount: 200, retentionDays: 90 });
       expect(await db.database.taskRun.findMany()).toHaveLength(0);
+    });
+  });
+
+  describe("getRecentRunsForTasks (全局视图 #493 P4)", () => {
+    async function seedRun(
+      id: string,
+      ownerId: string,
+      taskName: string,
+      startedAt: string,
+      status: SchedulerReportRunRequest["status"] = "success",
+    ): Promise<void> {
+      await store.upsertRun(
+        runningRecord({
+          id,
+          ownerId,
+          taskName,
+          status,
+          startedAt,
+          finishedAt: status === "running" ? null : startedAt,
+          durationMs: status === "running" ? null : 1,
+        }),
+      );
+    }
+
+    const iso = (n: number): string => `2026-07-06T${String(n).padStart(2, "0")}:00:00.000Z`;
+
+    it("returns empty map for empty keys without touching the db", async () => {
+      const result = await store.getRecentRunsForTasks([]);
+      expect(result.size).toBe(0);
+    });
+
+    it("caps each (owner, task) group at RECENT_RUNS_PER_TASK, startedAt desc", async () => {
+      // taskA 塞 12 条，只应回最近 10 条（startedAt desc）。
+      for (let h = 1; h <= 12; h++) {
+        await seedRun(`a${h}`, "agent", "taskA", iso(h));
+      }
+      const result = await store.getRecentRunsForTasks([{ ownerId: "agent", taskName: "taskA" }]);
+      const bucket = result.get(taskKeyString("agent", "taskA"));
+      expect(bucket).toBeDefined();
+      expect(bucket!.recentRuns).toHaveLength(10);
+      // 首条是最新（h=12），末条是第 10 新（h=3）；h=1/2 被截掉。
+      expect(bucket!.recentRuns[0]!.startedAt).toBe(iso(12));
+      expect(bucket!.recentRuns[9]!.startedAt).toBe(iso(3));
+    });
+
+    it("derives isRunning from a running row and includes it in recentRuns", async () => {
+      await seedRun("done", "agent", "taskA", iso(1), "success");
+      await seedRun("live", "agent", "taskA", iso(2), "running");
+      const result = await store.getRecentRunsForTasks([{ ownerId: "agent", taskName: "taskA" }]);
+      const bucket = result.get(taskKeyString("agent", "taskA"))!;
+      expect(bucket.isRunning).toBe(true);
+      expect(bucket.recentRuns.map(r => r.id)).toEqual(["live", "done"]);
+    });
+
+    it("ignores a stale older running row when the newest run is terminal (rank-1 derivation)", async () => {
+      // 孤儿：旧 running（终态上报丢失、从没转终态）+ 之后一次成功 run。最新一次是终态 → 任务其实
+      // 已空闲，isRunning 必须 false（只看 rank-1）；旧 running 只是陈旧孤儿，不能把任务判成在跑。
+      await seedRun("orphan", "agent", "taskA", iso(1), "running");
+      await seedRun("later", "agent", "taskA", iso(2), "success");
+      const result = await store.getRecentRunsForTasks([{ ownerId: "agent", taskName: "taskA" }]);
+      const bucket = result.get(taskKeyString("agent", "taskA"))!;
+      expect(bucket.isRunning).toBe(false);
+      // 孤儿仍在历史里（rank-2），只是不据它判在跑。
+      expect(bucket.recentRuns.map(r => r.id)).toEqual(["later", "orphan"]);
+    });
+
+    it("interrupted rows count as terminal (not running), still surface in history", async () => {
+      await seedRun("gone", "agent", "taskA", iso(1), "interrupted");
+      const result = await store.getRecentRunsForTasks([{ ownerId: "agent", taskName: "taskA" }]);
+      const bucket = result.get(taskKeyString("agent", "taskA"))!;
+      expect(bucket.isRunning).toBe(false);
+      expect(bucket.recentRuns[0]!.status).toBe("interrupted");
+    });
+
+    it("partitions per (owner, task): distinct owners with same task name stay separate", async () => {
+      await seedRun("x", "agent", "taskA", iso(1));
+      await seedRun("y", "napcat", "taskA", iso(1));
+      const result = await store.getRecentRunsForTasks([
+        { ownerId: "agent", taskName: "taskA" },
+        { ownerId: "napcat", taskName: "taskA" },
+      ]);
+      expect(result.get(taskKeyString("agent", "taskA"))!.recentRuns.map(r => r.id)).toEqual(["x"]);
+      expect(result.get(taskKeyString("napcat", "taskA"))!.recentRuns.map(r => r.id)).toEqual([
+        "y",
+      ]);
+    });
+
+    it("omits groups that are not in the requested keys (orphan history excluded)", async () => {
+      await seedRun("kept", "agent", "taskA", iso(1));
+      await seedRun("orphan", "agent", "taskB", iso(1)); // owner 已删该任务，不在 keys 里
+      const result = await store.getRecentRunsForTasks([{ ownerId: "agent", taskName: "taskA" }]);
+      expect(result.has(taskKeyString("agent", "taskA"))).toBe(true);
+      expect(result.has(taskKeyString("agent", "taskB"))).toBe(false);
+    });
+
+    it("leaves a requested key absent from the map when it has no history (left-join default)", async () => {
+      await seedRun("kept", "agent", "taskA", iso(1));
+      const result = await store.getRecentRunsForTasks([
+        { ownerId: "agent", taskName: "taskA" },
+        { ownerId: "agent", taskName: "taskNoHistory" },
+      ]);
+      // 无历史的活任务不入 map；调用方（handler）左连接时补 recentRuns=[] / isRunning=false。
+      expect(result.has(taskKeyString("agent", "taskNoHistory"))).toBe(false);
     });
   });
 });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
     "@kagami/metric-api": "workspace:*",
     "@kagami/oss-api": "workspace:*",
     "@kagami/rpc-client": "workspace:*",
+    "@kagami/scheduler-api": "workspace:*",
     "@radix-ui/react-select": "^2.2.6",
     "@tanstack/react-query": "^5.90.21",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/src/lib/rpc.ts
+++ b/apps/web/src/lib/rpc.ts
@@ -3,6 +3,8 @@ import { consoleApiContract } from "@kagami/console-api/contract";
 import { authApiContract } from "@kagami/llm-api/auth-contract";
 import { metricApiContract } from "@kagami/metric-api/contract";
 import { ossConsoleContract } from "@kagami/oss-api/contract";
+import { schedulerTasksViewContract } from "@kagami/scheduler-api/tasks-view";
+import { schedulerTriggerContract } from "@kagami/scheduler-api/trigger";
 import { createClient, type CreateClientOptions } from "@kagami/rpc-client/client";
 import { resolveApiBaseUrl } from "@/lib/api";
 
@@ -71,3 +73,9 @@ export const agentClient = createClient(agentApiContract, clientOptions);
 export const authClient = createClient(authApiContract, clientOptions);
 export const metricClient = createClient(metricApiContract, clientOptions);
 export const ossConsoleClient = createClient(ossConsoleContract, clientOptions);
+
+// 调度任务面（#493 P4）：前端第一次直连 scheduler，不再经 agent 中转。两个契约拆两条路由——全局
+// 查询（GET /scheduler/tasks）与手动触发（POST /scheduler/tasks/:o/:t/trigger）——经 gateway 的
+// /scheduler/tasks 前缀分流到 kagami-scheduler。
+export const schedulerTasksClient = createClient(schedulerTasksViewContract, clientOptions);
+export const schedulerTriggerClient = createClient(schedulerTriggerContract, clientOptions);

--- a/apps/web/src/pages/scheduler-tasks/SchedulerTasksPage.tsx
+++ b/apps/web/src/pages/scheduler-tasks/SchedulerTasksPage.tsx
@@ -1,165 +1,199 @@
-import type {
-  SchedulerTaskRun,
-  SchedulerTaskSchedule,
-  SchedulerTaskStatus,
-} from "@kagami/agent-api/scheduler";
-import { Badge } from "@/components/ui/badge";
+import type { SchedulerTaskSchedule } from "@kagami/scheduler-api/schedule";
+import type { SchedulerTaskView, SchedulerTaskViewRun } from "@kagami/scheduler-api/tasks-view";
+import type { SchedulerTriggerResponse } from "@kagami/scheduler-api/trigger";
+import { Badge, type BadgeProps } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { formatOptionalDateTime } from "@/lib/format";
-import { useSchedulerTasks, useTriggerSchedulerTask } from "./useSchedulerTasks";
+import {
+  useSchedulerTasks,
+  useTriggerSchedulerTask,
+  type TriggerVariables,
+} from "./useSchedulerTasks";
+
+/** 一次执行的状态（含 P2 的 interrupted 残留态）。 */
+type RunStatus = SchedulerTaskViewRun["status"];
 
 export function SchedulerTasksPage() {
   const query = useSchedulerTasks();
   const triggerMutation = useTriggerSchedulerTask();
 
-  if (query.isLoading && !query.data) {
-    return <PageShell>{<EmptyBlock label="正在加载调度任务…" />}</PageShell>;
-  }
+  const tasks = query.data?.tasks ?? [];
+  const isInitialLoading = query.isLoading && !query.data;
 
-  if (query.isError || !query.data) {
-    return (
-      <PageShell>
-        <div className="flex min-h-[120px] items-center justify-center rounded-none border border-dashed text-sm text-destructive">
-          调度任务查询失败，请检查后端 /scheduler/tasks 接口
-        </div>
-      </PageShell>
-    );
-  }
-
-  const tasks = query.data.tasks;
-
-  if (tasks.length === 0) {
-    return (
-      <PageShell>
-        <EmptyBlock label="当前没有注册的调度任务" />
-      </PageShell>
-    );
-  }
+  // 触发结果按 (ownerId, taskName) 定位，展示在对应行——无 toast 系统，就地反馈 outcome。
+  const activeTriggerKey = triggerMutation.variables ? taskRowKey(triggerMutation.variables) : null;
 
   return (
-    <PageShell>
-      <div className="h-full overflow-y-auto pr-1">
-        <div className="grid grid-cols-1 gap-3 md:grid-cols-2 2xl:grid-cols-3">
-          {tasks.map(task => (
-            <SchedulerTaskCard
-              key={task.name}
-              task={task}
-              isTriggering={triggerMutation.isPending && triggerMutation.variables === task.name}
-              onTrigger={() => triggerMutation.mutate(task.name)}
-            />
-          ))}
-        </div>
+    <div className="flex h-full min-h-0 w-full min-w-0 flex-col overflow-hidden p-3 md:p-6">
+      <div className="flex flex-wrap items-baseline gap-3">
+        <h1 className="font-serif text-2xl font-semibold tracking-tight">调度任务</h1>
+        <span className="ml-auto text-xs text-muted-foreground">共 {tasks.length} 个任务</span>
       </div>
-    </PageShell>
-  );
-}
 
-function PageShell({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="flex h-full min-h-0 w-full flex-col overflow-hidden p-3 md:p-6">
-      <h1 className="text-2xl font-semibold tracking-tight">调度任务</h1>
-      <div className="mt-4 min-h-0 flex-1 overflow-hidden">{children}</div>
+      {query.isError ? (
+        <p className="mt-3 text-sm text-destructive">
+          调度任务查询失败，请检查 kagami-scheduler 是否运行（GET /scheduler/tasks）。
+        </p>
+      ) : null}
+
+      <div className="mt-3 min-h-0 flex-1 overflow-auto rounded-none border">
+        <Table className="min-w-[880px]">
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-[112px]">归属</TableHead>
+              <TableHead className="w-[196px]">任务</TableHead>
+              <TableHead className="w-[168px]">周期</TableHead>
+              <TableHead className="w-[168px]">下次触发</TableHead>
+              <TableHead className="w-[88px]">状态</TableHead>
+              <TableHead>最近执行</TableHead>
+              <TableHead className="w-[120px] text-right">操作</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {isInitialLoading ? (
+              <TableRow>
+                <TableCell colSpan={7} className="h-24 text-center text-muted-foreground">
+                  正在加载调度任务…
+                </TableCell>
+              </TableRow>
+            ) : tasks.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={7} className="h-24 text-center text-muted-foreground">
+                  当前没有注册的调度任务
+                </TableCell>
+              </TableRow>
+            ) : (
+              tasks.map(task => {
+                const rowKey = taskRowKey(task);
+                const isTriggering = triggerMutation.isPending && activeTriggerKey === rowKey;
+                const triggerOutcome =
+                  triggerMutation.isSuccess && activeTriggerKey === rowKey
+                    ? triggerMutation.data
+                    : null;
+                const triggerFailed = triggerMutation.isError && activeTriggerKey === rowKey;
+                return (
+                  <TableRow key={rowKey} className="align-top">
+                    <TableCell className="font-mono text-xs text-muted-foreground">
+                      {task.ownerId}
+                    </TableCell>
+                    <TableCell className="font-mono text-sm break-all">{task.name}</TableCell>
+                    <TableCell className="font-mono text-xs text-muted-foreground tabular-nums">
+                      {formatSchedule(task.schedule)}
+                    </TableCell>
+                    <TableCell className="font-mono text-xs text-muted-foreground tabular-nums whitespace-nowrap">
+                      {formatOptionalDateTime(task.nextRunAt)}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={task.isRunning ? "scheduler" : "outline"}>
+                        {task.isRunning ? "运行中" : "空闲"}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <RecentRuns runs={task.recentRuns} />
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex flex-col items-end gap-1">
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          disabled={isTriggering}
+                          onClick={() =>
+                            triggerMutation.mutate({
+                              ownerId: task.ownerId,
+                              taskName: task.name,
+                            })
+                          }
+                        >
+                          {isTriggering ? "触发中…" : "立即触发"}
+                        </Button>
+                        <TriggerFeedback outcome={triggerOutcome} failed={triggerFailed} />
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                );
+              })
+            )}
+          </TableBody>
+        </Table>
+      </div>
     </div>
   );
 }
 
-function SchedulerTaskCard({
-  task,
-  isTriggering,
-  onTrigger,
+function RecentRuns({ runs }: { runs: SchedulerTaskViewRun[] }) {
+  if (runs.length === 0) {
+    return <span className="text-xs text-muted-foreground">尚未运行</span>;
+  }
+
+  const [latest, ...rest] = runs;
+  return (
+    <div className="space-y-1">
+      <RunLine run={latest} emphasize />
+      {rest.length > 0 ? (
+        <details className="text-xs text-muted-foreground">
+          <summary className="cursor-pointer select-none">更早 {rest.length} 次</summary>
+          <ul className="mt-1 space-y-1">
+            {rest.map(run => (
+              <li key={run.id}>
+                <RunLine run={run} />
+              </li>
+            ))}
+          </ul>
+        </details>
+      ) : null}
+    </div>
+  );
+}
+
+function RunLine({ run, emphasize = false }: { run: SchedulerTaskViewRun; emphasize?: boolean }) {
+  return (
+    <div className="flex flex-wrap items-center gap-2 text-xs">
+      <Badge variant={toRunBadgeVariant(run.status)}>{formatRunStatus(run.status)}</Badge>
+      <span className="font-mono text-muted-foreground tabular-nums">
+        {formatOptionalDateTime(run.startedAt)}
+        {run.durationMs !== null ? ` · ${run.durationMs} ms` : ""}
+      </span>
+      {emphasize && run.error ? (
+        <span className="w-full break-words whitespace-pre-wrap text-destructive">{run.error}</span>
+      ) : null}
+    </div>
+  );
+}
+
+/** 触发结果就地反馈：accepted / rejected(unknown_task|overlap) / owner_unreachable / 请求异常。 */
+function TriggerFeedback({
+  outcome,
+  failed,
 }: {
-  task: SchedulerTaskStatus;
-  isTriggering: boolean;
-  onTrigger: () => void;
+  outcome: SchedulerTriggerResponse | null;
+  failed: boolean;
 }) {
-  const latest = task.recentRuns.at(-1) ?? null;
-  return (
-    <Card>
-      <CardHeader className="pb-4">
-        <CardTitle className="font-mono text-sm">{task.name}</CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-3">
-        <div className="flex flex-wrap items-center gap-2 text-xs">
-          <Badge variant="outline">{formatSchedule(task.schedule)}</Badge>
-          <Badge variant={task.isRunning ? "story" : "outline"}>
-            {task.isRunning ? "运行中" : "空闲"}
-          </Badge>
-          <Badge variant="outline" className="font-mono tabular-nums">
-            下次：{formatOptionalDateTime(task.nextRunAt)}
-          </Badge>
-        </div>
-
-        {latest ? (
-          <div className="space-y-1 text-xs">
-            <div className="flex items-center gap-2">
-              <span className="text-muted-foreground">最近：</span>
-              <Badge
-                variant={
-                  latest.status === "error"
-                    ? "signal"
-                    : latest.status === "skipped_overlap"
-                      ? "scheduler"
-                      : "story"
-                }
-              >
-                {formatRunStatus(latest.status)}
-              </Badge>
-              <span className="text-muted-foreground">
-                {formatOptionalDateTime(latest.startedAt)}
-                {latest.durationMs !== null ? ` · ${latest.durationMs} ms` : ""}
-              </span>
-            </div>
-            {latest.errorMessage ? (
-              <p className="whitespace-pre-wrap break-words text-destructive">
-                {latest.errorMessage}
-              </p>
-            ) : null}
-            {latest.metadata ? (
-              <pre className="whitespace-pre-wrap break-all rounded bg-muted px-2 py-1 text-[11px]">
-                {formatMetadata(latest.metadata)}
-              </pre>
-            ) : null}
-          </div>
-        ) : (
-          <p className="text-xs text-muted-foreground">尚未运行</p>
-        )}
-
-        {task.recentRuns.length > 1 ? (
-          <details className="text-xs text-muted-foreground">
-            <summary className="cursor-pointer select-none">
-              最近 {task.recentRuns.length} 次
-            </summary>
-            <ul className="mt-1 space-y-1 font-mono tabular-nums">
-              {[...task.recentRuns]
-                .reverse()
-                .slice(1)
-                .map((run, index) => (
-                  <li key={`${run.startedAt}-${index}`}>
-                    {formatOptionalDateTime(run.startedAt)} · {formatRunStatus(run.status)}
-                    {run.durationMs !== null ? ` · ${run.durationMs} ms` : ""}
-                  </li>
-                ))}
-            </ul>
-          </details>
-        ) : null}
-
-        <div className="pt-1">
-          <Button size="sm" variant="outline" disabled={isTriggering} onClick={onTrigger}>
-            {isTriggering ? "触发中…" : "立即触发"}
-          </Button>
-        </div>
-      </CardContent>
-    </Card>
-  );
-}
-
-function EmptyBlock({ label }: { label: string }) {
-  return (
-    <div className="flex min-h-[120px] items-center justify-center rounded-none border border-dashed text-sm text-muted-foreground">
-      {label}
-    </div>
-  );
+  if (failed) {
+    return <span className="text-xs text-destructive">请求失败</span>;
+  }
+  if (!outcome) {
+    return null;
+  }
+  switch (outcome.outcome) {
+    case "accepted":
+      return <span className="text-xs text-story">已触发</span>;
+    case "rejected":
+      return (
+        <span className="text-xs text-cost">
+          {outcome.reason === "overlap" ? "运行中，已跳过" : "未知任务"}
+        </span>
+      );
+    case "owner_unreachable":
+      return <span className="text-xs text-destructive">调度未连</span>;
+  }
 }
 
 function formatSchedule(schedule: SchedulerTaskSchedule): string {
@@ -169,23 +203,41 @@ function formatSchedule(schedule: SchedulerTaskSchedule): string {
   return `间隔: ${schedule.intervalMs} ms`;
 }
 
-function formatRunStatus(status: SchedulerTaskRun["status"]): string {
+function formatRunStatus(status: RunStatus): string {
   switch (status) {
     case "running":
       return "运行中";
     case "success":
       return "成功";
-    case "error":
+    case "failure":
       return "失败";
-    case "skipped_overlap":
-      return "重入跳过";
+    case "interrupted":
+      return "被打断";
   }
 }
 
-function formatMetadata(metadata: Record<string, unknown>): string {
-  try {
-    return JSON.stringify(metadata);
-  } catch {
-    return "[unserializable metadata]";
+/**
+ * 状态色遵循 DESIGN.md 语义映射（颜色是配给不是涂抹）：
+ * - running → 黄（scheduler · 等待 / 进行中）
+ * - success → 绿（story · 持久化的成功结果）
+ * - failure → 红（signal · 错误）
+ * - interrupted → 玫红（cost · 风险 / 异常残留），与「明确失败」的红区分开、克制。
+ */
+function toRunBadgeVariant(status: RunStatus): BadgeProps["variant"] {
+  switch (status) {
+    case "running":
+      return "scheduler";
+    case "success":
+      return "story";
+    case "failure":
+      return "signal";
+    case "interrupted":
+      return "cost";
   }
+}
+
+function taskRowKey(task: TriggerVariables | SchedulerTaskView): string {
+  const taskName = "taskName" in task ? task.taskName : task.name;
+  // JSON 元组作复合键：owner/task 名里任何字符都被转义，两个不同任务绝不拼成同一 React key。
+  return JSON.stringify([task.ownerId, taskName]);
 }

--- a/apps/web/src/pages/scheduler-tasks/useSchedulerTasks.ts
+++ b/apps/web/src/pages/scheduler-tasks/useSchedulerTasks.ts
@@ -1,13 +1,15 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { SchedulerTriggerResponse } from "@kagami/scheduler-api/trigger";
 import { createSchemaQueryOptions } from "@/lib/query";
-import { agentClient } from "@/lib/rpc";
+import { schedulerTasksClient, schedulerTriggerClient } from "@/lib/rpc";
 
 const QUERY_KEY = ["scheduler", "tasks"] as const;
 
 export function useSchedulerTasks() {
   const queryOptions = createSchemaQueryOptions({
     queryKey: QUERY_KEY,
-    queryFn: () => agentClient.listSchedulerTasks({}),
+    // #493 P4：前端第一次直连 scheduler 的全局查询（经 gateway /api/scheduler/tasks），不再经 agent。
+    queryFn: () => schedulerTasksClient.listTasks({}),
   });
 
   return useQuery({
@@ -19,12 +21,19 @@ export function useSchedulerTasks() {
   });
 }
 
+/** 触发变量：定位到具体 owner 的具体任务（全局视图里任务不再唯一由 name 标识）。 */
+export type TriggerVariables = {
+  ownerId: string;
+  taskName: string;
+};
+
 export function useTriggerSchedulerTask() {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: async (name: string) => {
-      await agentClient.triggerSchedulerTask({ params: { name }, input: {} });
-    },
+  return useMutation<SchedulerTriggerResponse, Error, TriggerVariables>({
+    // #493 P4：触发经 scheduler 的统一入口（前端 → scheduler → 反向 callback 回 owner），返回
+    // accepted | rejected(unknown_task|overlap) | owner_unreachable 判别联合，交给页面按 outcome 提示。
+    mutationFn: ({ ownerId, taskName }) =>
+      schedulerTriggerClient.triggerTask({ params: { ownerId, taskName }, input: {} }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: QUERY_KEY });
     },

--- a/packages/scheduler-api/src/tasks-view.ts
+++ b/packages/scheduler-api/src/tasks-view.ts
@@ -1,0 +1,75 @@
+import { defineJsonRoute } from "@kagami/http/contract";
+import { z } from "zod";
+import { SchedulerRunStatusSchema, SchedulerRunTriggerSchema } from "./run.js";
+import { SchedulerTaskScheduleSchema } from "./schedule.js";
+
+/**
+ * 全局任务观测视图 wire（scheduler B P4，issue #493）。前端第一次真正切到 scheduler：不再经 agent
+ * 的 listSchedulerTasks 中转，而是直接查 scheduler 的这条全局端点（跨全部 owner）。
+ *
+ * 数据来源是「活任务（engine 内存）左连接执行历史（TaskRun 库）」：
+ * - 活任务侧（ownerId / name / schedule / nextRunAt）来自 engine 内存 owners map，跨全部 owner。
+ * - 历史侧（recentRuns / isRunning）来自 DB，每 (ownerId, taskName) 取最近 RECENT_RUNS_PER_TASK 条。
+ * - 以活任务为主做左连接：无历史的活任务 recentRuns 为空、isRunning=false（历史只增不减，孤儿历史
+ *   行——owner 已删该任务——不进视图）。
+ */
+
+/** 每任务回传的最近执行历史条数上限（startedAt desc）。 */
+export const RECENT_RUNS_PER_TASK = 10;
+
+/** 一条执行历史（P1 的 TaskRun 落库形状投影到 wire；时间字段走 ISO 字符串）。 */
+export const SchedulerTaskViewRunSchema = z
+  .object({
+    id: z.string().min(1),
+    status: SchedulerRunStatusSchema,
+    trigger: SchedulerRunTriggerSchema,
+    scheduledAt: z.string().datetime().nullable(),
+    startedAt: z.string().datetime(),
+    finishedAt: z.string().datetime().nullable(),
+    durationMs: z.number().int().nonnegative().nullable(),
+    error: z.string().nullable(),
+  })
+  .strict();
+
+export type SchedulerTaskViewRun = z.infer<typeof SchedulerTaskViewRunSchema>;
+
+/** 一个活任务的完整观测视图（tick 侧活状态 + DB 侧执行历史）。 */
+export const SchedulerTaskViewSchema = z
+  .object({
+    ownerId: z.string().min(1),
+    name: z.string().min(1),
+    schedule: SchedulerTaskScheduleSchema,
+    /** 下次触发时刻（driver 算）；未排期为 null。 */
+    nextRunAt: z.string().datetime().nullable(),
+    /** 派生：该 (ownerId, taskName) 存在 status=running 的 TaskRun 行。 */
+    isRunning: z.boolean(),
+    /** 最近 RECENT_RUNS_PER_TASK 条执行历史，startedAt desc。 */
+    recentRuns: z.array(SchedulerTaskViewRunSchema),
+  })
+  .strict();
+
+export type SchedulerTaskView = z.infer<typeof SchedulerTaskViewSchema>;
+
+export const SchedulerTasksViewResponseSchema = z
+  .object({
+    tasks: z.array(SchedulerTaskViewSchema),
+  })
+  .strict();
+
+export type SchedulerTasksViewResponse = z.infer<typeof SchedulerTasksViewResponseSchema>;
+
+/**
+ * 全局任务查询契约（前端 → scheduler，经 gateway `/api/scheduler/tasks`）。无 params、无请求体
+ * （registerJsonRoute 已把 GET/POST 空 body 归一化成 {}）。
+ *
+ * 与 trigger 的 `POST /scheduler/tasks/:ownerId/:taskName/trigger` 同前缀但不冲突：方法（GET vs POST）
+ * + 路径深度（/scheduler/tasks vs /scheduler/tasks/:o/:t/trigger）都不同，fastify 能区分。
+ */
+export const schedulerTasksViewContract = {
+  listTasks: defineJsonRoute({
+    method: "GET",
+    path: "/scheduler/tasks",
+    input: z.object({}).strict(),
+    output: SchedulerTasksViewResponseSchema,
+  }),
+} as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -502,6 +502,9 @@ importers:
       '@kagami/rpc-client':
         specifier: workspace:*
         version: link:../../packages/rpc-client
+      '@kagami/scheduler-api':
+        specifier: workspace:*
+        version: link:../../packages/scheduler-api
       '@radix-ui/react-select':
         specifier: ^2.2.6
         version: 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)


### PR DESCRIPTION
scheduler B 方向重构（#493）**P4**：**前端第一次真正切到 scheduler**（不再经 agent 门面）。加全局查询端点、gateway scheduler 上游、前端改直连。

## 改动
- **scheduler-api**：`tasks-view.ts` 契约 `GET /scheduler/tasks`——跨全部 owner 的活任务 `{ownerId, name, schedule, nextRunAt, isRunning}` 左连接每任务最近 10 条 run（`RECENT_RUNS_PER_TASK`）。
- **scheduler**：`engine.listActiveTasks()` 跨 owner；`TaskRunStore.getRecentRunsForTasks()` 一条 window function SQL（`(owner_id,task_name) IN ((?,?),...)` + `ROW_NUMBER() rank≤10`，无 N+1，孤儿历史天然排除）；`tasks-view` handler 以活任务为主左连接。
- **gateway**：`schedulerTarget` + `/scheduler/tasks` 前缀分流（段边界匹配，覆盖 GET 列表 + POST `.../trigger`，不吃 register/status/runs）。
- **前端**：列表查 scheduler、触发走 scheduler 判别联合入口（accepted/rejected/owner_unreachable 就地反馈）、卡片网格→表格、新增归属(ownerId)列、run 状态含 `interrupted`。

## /review 抓到并修复（后端正确性 + 前端设计 + Codex 三跑，含一处 reviewer 分歧裁定）
1. **isRunning 派生**（后端 agent 说 top-10 可接受、Codex 说 BLOCK 建议 EXISTS）——我裁定**两者都非最优**：真正在跑的 run 必是 rank-1（锁保证同时一个、started_at 最新），rank>1 的 running 是漏报终态的陈旧孤儿。旧「top-10 任一 running」会被落在 top-10 的孤儿误判 true；Codex 的 `EXISTS(running)` 更糟（孤儿永远判在跑）。→ 改成**「只看 rank-1 是否 running」**，加孤儿场景测试。
2. **复合键 U+0000 碰撞**（Codex）：`(ownerId,taskName)` 裸 NUL 分隔符 → 改 `JSON.stringify` 元组（store 桶键 + 前端 React row key 两处），消除碰撞 + 不在源码放字面 NUL。
3. DateTime raw 查询返回类型：实测确认（回 JS Date、毫秒精确 round-trip），REFUTED。

## 已知取舍（可后续微调，不阻塞）
- **interrupted 状态色用玫红(cost)**：落「风险信号」半边说得过去，但玫红在系统里强绑定「高 token 成本/钱」，可能被误读。设计 review 判为「可辩取舍非违规」。若你嫌误读，一行可改成 scheduler 黄。其余状态色（running→黄/success→绿/failure→红）+ 表格样式 + Badge 语义变体均合 DESIGN.md。

## 验证
六项全绿（build/typecheck/lint/format/knip/test，含 scheduler view 相关 +13 测试）。

分 PR：P1(#497)→P2(#501)→P3(#502)→**P4(本)**→P5 拆 agent 门面。Related: #493