### PR TITLE
fix(napcat): 提高 image/send bodyLimit，修大图发送 413

### DIFF
--- a/apps/napcat/src/app/napcat-runtime.ts
+++ b/apps/napcat/src/app/napcat-runtime.ts
@@ -29,6 +29,14 @@ const OUTBOX_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 const OUTBOX_PRUNE_INTERVAL_MS = 60 * 60 * 1000;
 
 /**
+ * Fastify 默认 bodyLimit 1 MB 远不够：send_resource 发图经 `/napcat/image/send` 以 `base64://` 内联
+ * 整图字节（自包含、不依赖 napcat 访问 OSS），一张图上限是 agent 侧 resource.maxBytes（4 MiB），base64
+ * 膨胀 ~4/3 后约 5.5 MiB，加 JSON 信封仍需 6 MiB 以上。取 16 MiB 留足头（也覆盖 resource cap 未来上调）。
+ * 不设的话 pixel/browser 小图能发、生图等大图一律 413（issue #508 上线后发现）。
+ */
+const NAPCAT_BODY_LIMIT_BYTES = 16 * 1024 * 1024;
+
+/**
  * outbox append 的重试：outbox 是入站事件的 durability 边界，append 失败 = 事件丢（replay 也救不回，
  * 因为根本没落库）。SQLite WAL 多写进程下偶发 SQLITE_BUSY（busy_timeout 内没抢到锁），这里再补几次
  * 重试兜底，彻底失败才让异常冒泡（调用方升级为 error 日志，不静默）。
@@ -145,6 +153,7 @@ export async function buildNapcatRuntime(): Promise<NapcatRuntime> {
       new NapcatHandler({ gateway }),
       new NapcatEventsHandler({ broadcaster, outboxDao }),
     ],
+    fastifyOptions: { bodyLimit: NAPCAT_BODY_LIMIT_BYTES },
   });
 
   // outbox prune：每小时删掉超保留窗口的旧行（保留窗口 > 任何现实停机时长即可安全回放）。


### PR DESCRIPTION
## 症状

生图（atelier #508）出的图**发不到 QQ**；pixel 像素画、browser 截图能发。

## 根因

`send_resource` 发图经 kagami-napcat 的 `POST /napcat/image/send`，以 `base64://<整图字节>` 内联在 JSON body（自包含、不依赖 napcat 访问 OSS）。但 **napcat 的 Fastify 没设 bodyLimit → 用默认 1 MB**。一张 2.5 MiB 的生图 base64 后 ~3.3 MiB，直接 413 `Request body is too large`（线上 napcat error 日志实锤）。pixel/browser 小图 base64 没超 1 MB 故能发——这是 #508 上线后暴露的**既有 latent bug**（任何 >~750 KB 的图都发不出，只是之前没有能稳定产大图的来源）。

llm-service / oss 早就因「Fastify 默认 1 MB 远不够」显式调大了 bodyLimit，napcat 当初漏了。

## 修复

给 napcat 的 `createServiceApp` 传 `fastifyOptions.bodyLimit = 16 MiB`：覆盖 agent 侧图上限 `resource.maxBytes`(4 MiB) base64 化后的 ~5.5 MiB + JSON 信封 + 未来上调余量。一行装配 + 一个具名常量。

## 验证

- 根因经线上 napcat error 日志确认（`/napcat/image/send error=Request body is too large`）+ OSS 库确认涉事图 res-2245 = 2.46 MiB image/png（在 4 MiB resolve cap 之下，故非 resolve 拦截、就是 napcat body 拦截）。
- 五件套全绿；napcat 138 测试 + 全量 1414 通过。

合并后部署 `app:deploy napcat`。