### PR TITLE
feat(web): Metric 图表支持按 series 显示/隐藏（点图例切换）

### DIFF
--- a/apps/web/src/components/metric/MetricChartView.tsx
+++ b/apps/web/src/components/metric/MetricChartView.tsx
@@ -1,5 +1,5 @@
 import { type MetricChartQueryResponse, type MetricChartSeries } from "@kagami/metric-api/chart";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import {
   Area,
   AreaChart,
@@ -17,8 +17,6 @@ import {
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   ChartContainer,
-  ChartLegend,
-  ChartLegendContent,
   ChartTooltip,
   ChartTooltipContent,
   type ChartConfig,
@@ -100,6 +98,11 @@ export function MetricChartView({
   seriesMeta,
   height = 288,
 }: MetricChartViewProps) {
+  // 隐藏集按 series.key（语义 tag 值，如 "wait"/"qq"）记，是纯客户端展示开关，不触发重查。
+  // 不随 data 刷新重置——跨 range/bucket 保留隐藏态（key 语义稳定）；组件卸载/刷新页面自然复位。
+  const [hiddenKeys, setHiddenKeys] = useState<Set<string>>(() => new Set());
+  const toggleSeries = (key: string) => setHiddenKeys(prev => toggleHiddenKey(prev, key));
+
   const renderSeries = useMemo<RenderSeries[]>(
     () =>
       data?.series.map((item, index) => {
@@ -113,9 +116,16 @@ export function MetricChartView({
       }) ?? [],
     [data?.series, seriesMeta],
   );
+  // 可见集：仅在完整 renderSeries 上过滤——dataKey / color 已在 renderSeries 阶段按序号定死，
+  // 这里绝不重新编号，否则隐藏中间项会让剩余序列串色 / 串 label。
+  const visibleSeries = useMemo(
+    () => selectVisibleSeries(renderSeries, hiddenKeys),
+    [renderSeries, hiddenKeys],
+  );
+  // config 按全量建：隐藏项恢复时其颜色 / label 仍可解析。
   const chartConfig = useMemo(() => buildChartConfig(renderSeries), [renderSeries]);
-  const rows = useMemo(() => buildChartRows(renderSeries), [renderSeries]);
-  const pieData = useMemo(() => buildPieData(renderSeries), [renderSeries]);
+  const rows = useMemo(() => buildChartRows(visibleSeries), [visibleSeries]);
+  const pieData = useMemo(() => buildPieData(visibleSeries), [visibleSeries]);
   // 饼图图例经 chartConfig[name].label 取字（config 按 slice name 键控，非 dataKey）；颜色仍走 Cell fill。
   const pieChartConfig = useMemo<ChartConfig>(
     () =>
@@ -125,8 +135,13 @@ export function MetricChartView({
     [pieData],
   );
   const pieTotal = pieData.reduce((sum, slice) => sum + slice.value, 0);
+  const hasSeries = (data?.series.length ?? 0) > 0;
+  const allHidden = hasSeries && visibleSeries.length === 0;
   // 饼图额外要求构成总量 > 0（全 0 会让 recharts 角度算成 NaN、画出空白饼图但 series 非空）。
-  const hasRenderable = chartType === "pie" ? pieTotal > 0 : (data?.series.length ?? 0) > 0;
+  // 其余画法只要还有可见序列即可渲染；hasRenderable 全部改吃 visibleSeries。
+  const hasRenderable = chartType === "pie" ? pieTotal > 0 : visibleSeries.length > 0;
+  // 全部隐藏 vs 真无数据分流：前者要引导「点图例恢复」，后者是范围内没数据。
+  const emptyMessage = allHidden ? "全部序列已隐藏，点图例恢复" : "当前时间范围内没有数据。";
   const placeholderClassName = "flex items-center justify-center rounded-none border border-dashed";
   const placeholderStyle = { height };
 
@@ -156,7 +171,7 @@ export function MetricChartView({
 
         {!isLoading && !isError && !hasRenderable ? (
           <div className={placeholderClassName} style={placeholderStyle}>
-            <p className="text-sm text-muted-foreground">当前时间范围内没有数据。</p>
+            <p className="text-sm text-muted-foreground">{emptyMessage}</p>
           </div>
         ) : null}
 
@@ -170,7 +185,6 @@ export function MetricChartView({
               {chartType === "pie" ? (
                 <PieChart>
                   <ChartTooltip content={<ChartTooltipContent nameKey="name" />} />
-                  <ChartLegend content={<ChartLegendContent nameKey="name" />} />
                   <Pie
                     data={pieData}
                     dataKey="value"
@@ -214,8 +228,7 @@ export function MetricChartView({
                       />
                     }
                   />
-                  <ChartLegend content={<ChartLegendContent />} />
-                  {renderSeries.map(series => (
+                  {visibleSeries.map(series => (
                     <Bar
                       key={series.key}
                       dataKey={series.dataKey}
@@ -264,8 +277,7 @@ export function MetricChartView({
                       />
                     }
                   />
-                  <ChartLegend content={<ChartLegendContent />} />
-                  {renderSeries.map(series => (
+                  {visibleSeries.map(series => (
                     <Area
                       key={series.key}
                       type="linear"
@@ -308,8 +320,7 @@ export function MetricChartView({
                       />
                     }
                   />
-                  <ChartLegend content={<ChartLegendContent />} />
-                  {renderSeries.map(series => (
+                  {visibleSeries.map(series => (
                     <Area
                       key={series.key}
                       // linear 而非 monotone：面积图常用来叠「子集 vs 全集」（如 wait ⊆ 所有工具）。
@@ -355,8 +366,7 @@ export function MetricChartView({
                       />
                     }
                   />
-                  <ChartLegend content={<ChartLegendContent />} />
-                  {renderSeries.map(series => (
+                  {visibleSeries.map(series => (
                     <Line
                       key={series.key}
                       type="linear"
@@ -372,20 +382,90 @@ export function MetricChartView({
                 </LineChart>
               )}
             </ChartContainer>
-
-            <div className="flex flex-wrap justify-between gap-3 text-xs text-muted-foreground">
-              <p>
-                时间范围：{formatFullDateTime(data.startAt)} - {formatFullDateTime(data.endAt)}
-              </p>
-              <p>
-                序列数：{data.series.length} · bucket：{data.bucket}
-              </p>
-            </div>
           </>
+        ) : null}
+
+        {/* 图例独立于 recharts 图表树，只要有序列就常驻——全部隐藏时图表区换成占位、图例仍可点恢复。 */}
+        {!isLoading && !isError && hasSeries ? (
+          <SeriesLegend series={renderSeries} hiddenKeys={hiddenKeys} onToggle={toggleSeries} />
+        ) : null}
+
+        {!isLoading && !isError && hasRenderable && data ? (
+          <div className="flex flex-wrap justify-between gap-3 text-xs text-muted-foreground">
+            <p>
+              时间范围：{formatFullDateTime(data.startAt)} - {formatFullDateTime(data.endAt)}
+            </p>
+            <p>
+              序列数：{data.series.length} · bucket：{data.bucket}
+            </p>
+          </div>
         ) : null}
       </CardContent>
     </Card>
   );
+}
+
+type SeriesLegendProps = {
+  /** 完整序列（含隐藏项，隐藏项也要在图例里才能点回来）。 */
+  series: RenderSeries[];
+  hiddenKeys: Set<string>;
+  onToggle: (key: string) => void;
+};
+
+/**
+ * 交互式图例。吃完整 renderSeries，渲染在 recharts 图表树之外——这样「全部隐藏」时图表区换成占位、
+ * 图例仍常驻可点。每项是 button（Tab 可达、Enter/Space 触发、aria-pressed 播报显隐），隐藏态灰显 +
+ * label 删除线。样式对齐原 ChartLegendContent（居中、换行、色块 h-2 w-2）。
+ */
+function SeriesLegend({ series, hiddenKeys, onToggle }: SeriesLegendProps) {
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1.5 pt-3">
+      {series.map(item => {
+        const hidden = hiddenKeys.has(item.key);
+        return (
+          <button
+            key={item.key}
+            type="button"
+            aria-pressed={!hidden}
+            onClick={() => onToggle(item.key)}
+            className={`flex cursor-pointer items-center gap-1.5 text-sm transition-opacity ${
+              hidden ? "opacity-40" : "opacity-100"
+            }`}
+          >
+            <span
+              className="h-2 w-2 shrink-0 rounded-[2px]"
+              style={{ backgroundColor: item.color }}
+            />
+            <span className={hidden ? "line-through" : undefined}>{item.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * 隐藏集切换：不可变返回新 Set（原地 add/delete 不会触发 React 重渲染）。
+ */
+export function toggleHiddenKey(prev: Set<string>, key: string): Set<string> {
+  const next = new Set(prev);
+  if (next.has(key)) {
+    next.delete(key);
+  } else {
+    next.add(key);
+  }
+  return next;
+}
+
+/**
+ * 按隐藏集过滤出可见序列。仅 filter、不重排不重编号：保留各序列原 dataKey / color / 顺序，
+ * 隐藏中间项也不会让剩余序列串色。喂给图表几何（rows / pieData / 各画法的 .map）。
+ */
+export function selectVisibleSeries(
+  series: RenderSeries[],
+  hiddenKeys: Set<string>,
+): RenderSeries[] {
+  return series.filter(item => !hiddenKeys.has(item.key));
 }
 
 function buildChartConfig(series: RenderSeries[]): ChartConfig {

--- a/apps/web/test/metric-chart-view.test.ts
+++ b/apps/web/test/metric-chart-view.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { buildPieData, type RenderSeries } from "@/components/metric/MetricChartView";
+import {
+  buildChartRows,
+  buildPieData,
+  selectVisibleSeries,
+  toggleHiddenKey,
+  type RenderSeries,
+} from "@/components/metric/MetricChartView";
 
 const b0 = "2026-07-07T00:00:00.000Z";
 
@@ -20,5 +26,93 @@ describe("buildPieData 用解析后的 color", () => {
     const pie = buildPieData(renderSeries);
     expect(pie[0]?.fill).toBe("hsl(var(--scheduler))");
     expect(pie[0]?.value).toBe(10);
+  });
+});
+
+describe("toggleHiddenKey：不可变切换", () => {
+  it("缺则加、有则删", () => {
+    const empty = new Set<string>();
+    const added = toggleHiddenKey(empty, "wait");
+    expect(added.has("wait")).toBe(true);
+    const removed = toggleHiddenKey(added, "wait");
+    expect(removed.has("wait")).toBe(false);
+  });
+
+  it("返回新 Set，不原地改旧集（否则 React 不重渲染）", () => {
+    const prev = new Set<string>(["qq"]);
+    const next = toggleHiddenKey(prev, "wait");
+    expect(next).not.toBe(prev);
+    expect([...prev]).toEqual(["qq"]);
+    expect(next.has("qq")).toBe(true);
+    expect(next.has("wait")).toBe(true);
+  });
+});
+
+describe("selectVisibleSeries：仅过滤、不重排不串色", () => {
+  const s0 = series("wait", "c0", [{ bucketStart: b0, value: 1 }], 0);
+  const s1 = series("app", "c1", [{ bucketStart: b0, value: 2 }], 1);
+  const s2 = series("portal", "c2", [{ bucketStart: b0, value: 3 }], 2);
+  const all: RenderSeries[] = [s0, s1, s2];
+
+  it("空隐藏集 → 全量原样", () => {
+    expect(selectVisibleSeries(all, new Set())).toEqual(all);
+  });
+
+  it("隐藏中间项：剩余序列 dataKey / color / 顺序不变", () => {
+    const visible = selectVisibleSeries(all, new Set(["app"]));
+    expect(visible.map(s => s.key)).toEqual(["wait", "portal"]);
+    // 关键：series_0 / series_2 与颜色纹丝不动，绝不因过滤重编号成 series_0 / series_1。
+    expect(visible.map(s => s.dataKey)).toEqual(["series_0", "series_2"]);
+    expect(visible.map(s => s.color)).toEqual(["c0", "c2"]);
+  });
+
+  it("全部隐藏 → 空数组", () => {
+    expect(selectVisibleSeries(all, new Set(["wait", "app", "portal"]))).toEqual([]);
+  });
+
+  it("残留 stale key（不在序列里）→ 无害 no-op", () => {
+    expect(selectVisibleSeries(all, new Set(["gone"]))).toEqual(all);
+  });
+});
+
+describe("几何按可见集重算：隐藏项被排除", () => {
+  const b1 = "2026-07-07T00:01:00.000Z";
+  const s0 = series(
+    "wait",
+    "c0",
+    [
+      { bucketStart: b0, value: 1 },
+      { bucketStart: b1, value: 4 },
+    ],
+    0,
+  );
+  const s1 = series(
+    "app",
+    "c1",
+    [
+      { bucketStart: b0, value: 2 },
+      { bucketStart: b1, value: 5 },
+    ],
+    1,
+  );
+
+  it("buildChartRows：隐藏序列的列从行里消失", () => {
+    const visible = selectVisibleSeries([s0, s1], new Set(["app"]));
+    const rows = buildChartRows(visible);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.series_0).toBe(1);
+    // 隐藏的 app（series_1）列不该出现在行数据里。
+    expect("series_1" in (rows[0] ?? {})).toBe(false);
+  });
+
+  it("buildPieData + total：隐藏切片消失、总量按可见项重算", () => {
+    const full = buildPieData([s0, s1]);
+    const fullTotal = full.reduce((sum, slice) => sum + slice.value, 0);
+    expect(fullTotal).toBe(1 + 4 + 2 + 5); // 12
+
+    const visible = buildPieData(selectVisibleSeries([s0, s1], new Set(["app"])));
+    expect(visible.map(slice => slice.name)).toEqual(["wait"]);
+    const visibleTotal = visible.reduce((sum, slice) => sum + slice.value, 0);
+    expect(visibleTotal).toBe(1 + 4); // 5，不再含 app
   });
 });


### PR DESCRIPTION
## 做了什么

前端 Metric 图表支持**点图例切换单条 series 显隐**——为即将上的多序列图表铺路。第一版从简：纯客户端展示开关，不碰查询/后端/契约。

做进共享展示层 `MetricChartView`，两个消费方（独立容器 `MetricChart` + 大盘 `dashboard-charts`）自动都有；6 种画法（line/area/stacked-area/bar/stacked/pie）全覆盖。

## 关键设计

- **状态**：`hiddenKeys: Set<string>`（按 `series.key` 记），纯内存、不触发重查；跨 range/bucket 保留，刷新页面复位。
- **几何按可见集重算**：`visibleSeries = filter(未隐藏)` 喂 rows/pieData/各画法 `.map`；`dataKey`/`color` 在**全量阶段定死、绝不重编号** → 隐藏中间项不串色；`chartConfig` 按全量建。stacked-area(expand)/pie 在可见序列间**自动重新归一化**（即预期语义）。
- **图例抽成独立 `SeriesLegend`**，渲染在 recharts 图表树**之外** → 「全部隐藏」时图表区换成占位、图例仍常驻可点恢复。图例项为 `button`（Tab 可达 + Enter/Space + `aria-pressed`），隐藏态灰显 + 删除线。
- **空态分流**：真无数据「当前时间范围内没有数据」vs 全部隐藏「全部序列已隐藏，点图例恢复」。
- 未动 `chart.tsx`（`ChartLegend/ChartLegendContent` 还被 AuthPage/DashboardCacheChart 用着），零 ripple。

## 测试 / 校验

- 新增 9 个纯函数单测（`toggleHiddenKey` 不可变切换、`selectVisibleSeries` 过滤不串色、`buildChartRows/buildPieData` 排除隐藏项 + total 重算）。web 测试 45 passed。
- 五件套全绿：build / typecheck / lint（0 error）/ format / knip（仅存量 warn）。
- Codex 设计评审 7/10 + diff 复审 VERDICT SHIP。
- ⚠️ 未做真实浏览器交互验证（无 RTL/jsdom；数据层逻辑已单测覆盖）。

Closes #513
