### PR TITLE
feat(agent): App 名单为每个 App 加简短功能描述进 system prompt

### DIFF
--- a/apps/agent/src/agent/apps/amap/amap.app.ts
+++ b/apps/agent/src/agent/apps/amap/amap.app.ts
@@ -77,6 +77,7 @@ function renderAmapHelp(configured: boolean): string {
 export class AmapApp implements App<AmapConfig> {
   public readonly id = AMAP_APP_ID;
   public readonly displayName = "高德地图";
+  public readonly description = "查地点与路线，搜周边、看天气、生成地图。";
   public readonly configSchema = AmapConfigSchema;
   public readonly tools: readonly [
     GeocodeTool,

--- a/apps/agent/src/agent/apps/atelier/atelier.app.ts
+++ b/apps/agent/src/agent/apps/atelier/atelier.app.ts
@@ -26,6 +26,7 @@ type AtelierAppDeps = {
 export class AtelierApp implements App {
   public readonly id = ATELIER_APP_ID;
   public readonly displayName = "画室";
+  public readonly description = "把文字描述异步生成一张 AI 图。";
   public readonly tools: readonly ToolComponent[];
 
   public constructor({ imageClient, ossClient, asyncTaskManager }: AtelierAppDeps) {

--- a/apps/agent/src/agent/apps/browser/browser.app.ts
+++ b/apps/agent/src/agent/apps/browser/browser.app.ts
@@ -38,6 +38,7 @@ type BrowserAppDeps = {
 export class BrowserApp implements App {
   public readonly id = BROWSER_APP_ID;
   public readonly displayName = "浏览器";
+  public readonly description = "完整操作网页，导航、点按、填表、截图。";
   public readonly tools: readonly [
     BrowserNavigateTool,
     BrowserObserveTool,

--- a/apps/agent/src/agent/apps/calc/calc.app.ts
+++ b/apps/agent/src/agent/apps/calc/calc.app.ts
@@ -30,6 +30,7 @@ type CalcConfig = z.infer<typeof CalcConfigSchema>;
 export class CalcApp implements App<CalcConfig> {
   public readonly id = CALC_APP_ID;
   public readonly displayName = "计算器";
+  public readonly description = "对两个数做一次加减乘除，可设小数精度。";
   public readonly configSchema = CalcConfigSchema;
   public readonly tools: readonly CalculateTool[];
 

--- a/apps/agent/src/agent/apps/clock/clock.app.ts
+++ b/apps/agent/src/agent/apps/clock/clock.app.ts
@@ -15,6 +15,7 @@ const CLOCK_APP_ID = "clock";
 export class ClockApp implements App {
   public readonly id = CLOCK_APP_ID;
   public readonly displayName = "时钟";
+  public readonly description = "查看当前北京时间，精确到秒。";
   public readonly tools: readonly ViewTimeTool[];
 
   public constructor() {

--- a/apps/agent/src/agent/apps/hn/hn.app.ts
+++ b/apps/agent/src/agent/apps/hn/hn.app.ts
@@ -57,6 +57,7 @@ type HnConfig = z.infer<typeof HnConfigSchema>;
 export class HnApp implements App<HnConfig> {
   public readonly id = HN_APP_ID;
   public readonly displayName = "Hacker News";
+  public readonly description = "浏览 Hacker News 榜单，搜帖、读讨论和用户主页。";
   public readonly configSchema = HnConfigSchema;
   public readonly tools: readonly (
     | GlanceHnTool

--- a/apps/agent/src/agent/apps/ithome/ithome.app.ts
+++ b/apps/agent/src/agent/apps/ithome/ithome.app.ts
@@ -26,6 +26,7 @@ type IthomeAppDeps = {
 export class IthomeApp implements App {
   public readonly id = ITHOME_APP_ID;
   public readonly displayName = "IT之家";
+  public readonly description = "浏览 IT 之家文章列表，打开读全文。";
   public readonly tools: readonly OpenIthomeArticleTool[];
 
   private readonly ithomeService: IthomeService;

--- a/apps/agent/src/agent/apps/pixel/pixel.app.ts
+++ b/apps/agent/src/agent/apps/pixel/pixel.app.ts
@@ -40,6 +40,7 @@ type PixelAppDeps = {
 export class PixelApp implements App {
   public readonly id = PIXEL_APP_ID;
   public readonly displayName = "像素画";
+  public readonly description = "在画布上逐格填色作画，导出为图。";
   public readonly tools: readonly [
     PixelNewCanvasTool,
     PixelSetPixelsTool,

--- a/apps/agent/src/agent/apps/qq/qq.app.ts
+++ b/apps/agent/src/agent/apps/qq/qq.app.ts
@@ -120,6 +120,7 @@ type QqAppDeps = {
 export class QqApp implements App, ForegroundInputSource {
   public readonly id = QQ_APP_ID;
   public readonly displayName = "QQ";
+  public readonly description = "收发 QQ 群聊与私聊消息，发图、传文件。";
   public readonly tools: readonly ToolComponent[];
 
   private readonly napcatGateway: NapcatClient;

--- a/apps/agent/src/agent/apps/spire/spire.app.ts
+++ b/apps/agent/src/agent/apps/spire/spire.app.ts
@@ -35,6 +35,7 @@ type SpireAppDeps = {
 export class SpireApp implements App {
   public readonly id = SPIRE_APP_ID;
   public readonly displayName = "尖塔";
+  public readonly description = "游玩爬塔卡牌游戏，出牌、做选择、查战况。";
   public readonly tools: readonly [
     SpireStartRunTool,
     SpirePlayCardTool,

--- a/apps/agent/src/agent/apps/terminal/terminal.app.ts
+++ b/apps/agent/src/agent/apps/terminal/terminal.app.ts
@@ -61,6 +61,7 @@ type TerminalAppDeps = {
 export class TerminalApp implements App<TerminalConfig> {
   public readonly id = TERMINAL_APP_ID;
   public readonly displayName = "终端";
+  public readonly description = "执行非交互 shell 命令，分页查看输出。";
   public readonly configSchema = TerminalConfigSchema;
   public readonly tools: readonly (BashTool | ReadBashOutputTool)[];
 

--- a/apps/agent/src/agent/apps/todo/todo.app.ts
+++ b/apps/agent/src/agent/apps/todo/todo.app.ts
@@ -29,6 +29,7 @@ type TodoAppDeps = {
 export class TodoApp implements App {
   public readonly id = TODO_APP_ID;
   public readonly displayName = "待办";
+  public readonly description = "管理自己的待办，记事、改状态、设到点和周期提醒。";
   public readonly tools: readonly [
     AddTodoTool,
     ListTodosTool,

--- a/apps/agent/src/agent/runtime/root-agent/system-prompt.ts
+++ b/apps/agent/src/agent/runtime/root-agent/system-prompt.ts
@@ -5,10 +5,10 @@ export function createAgentSystemPrompt({
   apps,
 }: {
   creatorName: string;
-  apps: ReadonlyArray<{ id: string; displayName: string }>;
+  apps: ReadonlyArray<{ id: string; displayName: string; description: string }>;
 }): string {
   // QQ 相关（botQQ / creatorQQ / 群聊场景与行为）已全部下沉到 QQ App 的 help，主 system prompt
-  // 只保留与平台无关的身份与手机 OS 说明。App 名单（id + 名称）每轮由主循环重新渲染进 prompt，
+  // 只保留与平台无关的身份与手机 OS 说明。App 名单（id + 名称 + 功能）每轮由主循环重新渲染进 prompt，
   // 让小镜天然知道自己有哪些 App。这依赖一条不变量：App 集合在进程内不可变（所有 register 集中
   // 在启动期），故相同入参每轮渲染字节恒定 → 稳定前缀不漂移 → KV 命中。名单只在增删 App 时变，
   // 而那必然伴随进程重启。（若将来引入会话中途热插拔 App，这条前缀稳定性会被打破，须重新设计。）

--- a/apps/agent/src/app/agent-runtime.factory.ts
+++ b/apps/agent/src/app/agent-runtime.factory.ts
@@ -264,7 +264,9 @@ export async function buildAgentRuntime({
   const agentSystemPromptFactory = async () => {
     return createAgentSystemPrompt({
       creatorName: config.server.bot.creator.name,
-      apps: appManager.getAllApps().map(app => ({ id: app.id, displayName: app.displayName })),
+      apps: appManager
+        .getAllApps()
+        .map(app => ({ id: app.id, displayName: app.displayName, description: app.description })),
     });
   };
   // root agent 每条进上下文的消息追加到 ledger（physical table `ledger`），只写不读，

--- a/apps/agent/static/prompts/main-engine-system.hbs
+++ b/apps/agent/static/prompts/main-engine-system.hbs
@@ -29,9 +29,9 @@
 你的世界像一台手机：有一个桌面（Portal），上面摆着若干 App。每个 App 是一种能力或一处去处——聊天、看资讯、用小工具，都是某个 App。
 
 {{#if hasApps}}
-你手机上现在装着这些 App（id：名称）：
+你手机上现在装着这些 App（id：名称——功能）：
 {{#each apps}}
-- {{id}}：{{displayName}}
+- {{id}}：{{displayName}}——{{description}}
 {{/each}}
 
 {{/if}}

--- a/apps/agent/test/agent/app-manager-startup.test.ts
+++ b/apps/agent/test/agent/app-manager-startup.test.ts
@@ -13,6 +13,7 @@ type CalcLikeConfig = z.infer<typeof CalcLikeConfigSchema>;
 class FakeConfiguredApp implements App<CalcLikeConfig> {
   public readonly id: string;
   public readonly displayName: string;
+  public readonly description = "测试用途";
   public readonly tools = [] as const;
   public readonly configSchema = CalcLikeConfigSchema;
 
@@ -39,6 +40,7 @@ class FakeConfiguredApp implements App<CalcLikeConfig> {
 class FakeUnconfiguredApp implements App {
   public readonly id: string;
   public readonly displayName: string;
+  public readonly description = "测试用途";
   public readonly tools = [] as const;
 
   public received: unknown = "not-called";
@@ -117,6 +119,7 @@ describe("AppManager.startupAll", () => {
     class LifecycleApp implements App {
       public readonly id: string;
       public readonly displayName: string;
+      public readonly description = "测试用途";
       public readonly tools = [] as const;
       public startupCalled = false;
       public constructor(

--- a/apps/agent/test/agent/foreground-input-session-routing.test.ts
+++ b/apps/agent/test/agent/foreground-input-session-routing.test.ts
@@ -20,6 +20,7 @@ function createForegroundApp(
   return {
     id,
     displayName: id,
+    description: id,
     tools: [],
     canInvoke: () => true,
     help: async () => "",
@@ -28,7 +29,14 @@ function createForegroundApp(
 }
 
 function createPlainApp(id: string): App {
-  return { id, displayName: id, tools: [], canInvoke: () => true, help: async () => "" };
+  return {
+    id,
+    displayName: id,
+    description: id,
+    tools: [],
+    canInvoke: () => true,
+    help: async () => "",
+  };
 }
 
 function createSession(apps: App[], metrics?: RecordMetricInput[]) {

--- a/apps/agent/test/agent/invoke.tool.test.ts
+++ b/apps/agent/test/agent/invoke.tool.test.ts
@@ -44,6 +44,7 @@ function createTestQqApp(tools: ToolComponent[]): App {
   return {
     id: TEST_QQ_APP_ID,
     displayName: "QQ",
+    description: "收发 QQ 群聊与私聊消息，发图、传文件。",
     tools,
     canInvoke: () => true,
     help: async () => "",

--- a/apps/agent/test/agent/root-agent-session.test.ts
+++ b/apps/agent/test/agent/root-agent-session.test.ts
@@ -7,7 +7,14 @@ import { initTestLoggerRuntime } from "../helpers/logger.js";
 initTestLoggerRuntime();
 
 function createTestApp(id: string, displayName: string): App {
-  return { id, displayName, tools: [], canInvoke: () => true, help: async () => "" };
+  return {
+    id,
+    displayName,
+    description: displayName,
+    tools: [],
+    canInvoke: () => true,
+    help: async () => "",
+  };
 }
 
 function createContext() {

--- a/apps/agent/test/agent/switch.tool.test.ts
+++ b/apps/agent/test/agent/switch.tool.test.ts
@@ -13,6 +13,7 @@ function createFakeApp(
   return {
     id,
     displayName: id,
+    description: id,
     tools: [],
     canInvoke: () => true,
     help: hooks.help ?? (async () => `you are in ${id}`),

--- a/apps/agent/test/agent/system-prompt.test.ts
+++ b/apps/agent/test/agent/system-prompt.test.ts
@@ -3,16 +3,16 @@ import { createAgentSystemPrompt } from "../../src/agent/runtime/root-agent/syst
 
 describe("createAgentSystemPrompt", () => {
   const apps = [
-    { id: "calc", displayName: "计算器" },
-    { id: "browser", displayName: "浏览器" },
-    { id: "qq", displayName: "QQ" },
+    { id: "calc", displayName: "计算器", description: "对两个数做一次加减乘除，可设小数精度。" },
+    { id: "browser", displayName: "浏览器", description: "完整操作网页，导航、点按、填表、截图。" },
+    { id: "qq", displayName: "QQ", description: "收发 QQ 群聊与私聊消息，发图、传文件。" },
   ];
 
-  it("embeds every registered app as `id：displayName` in the prompt", () => {
+  it("embeds every registered app as `id：displayName——description` in the prompt", () => {
     const prompt = createAgentSystemPrompt({ creatorName: "测试创造者", apps });
     expect(prompt).toContain("你手机上现在装着这些 App");
     for (const app of apps) {
-      expect(prompt).toContain(`- ${app.id}：${app.displayName}`);
+      expect(prompt).toContain(`- ${app.id}：${app.displayName}——${app.description}`);
     }
   });
 

--- a/packages/agent-runtime/src/app/app.ts
+++ b/packages/agent-runtime/src/app/app.ts
@@ -58,6 +58,13 @@ export interface App<TConfig = void> {
   readonly displayName: string;
 
   /**
+   * 给 Kagami 看的一句功能简介，平铺直叙介绍这个 App 能做什么。
+   * 每轮随 App 名单渲染进 system prompt，让她在桌面层就能判断该切进哪个 App。
+   * 静态常量、进程内不变，与 displayName 同为「稳定前缀」的一部分。
+   */
+  readonly description: string;
+
+  /**
    * 这个 App 贡献给 InvokeTool 的子工具集合。
    *
    * 固定数组，运行期不变。LLM 工具定义在 startup 时一次性确定，遵循 KV 缓存

--- a/packages/agent-runtime/test/app-state-persistence.test.ts
+++ b/packages/agent-runtime/test/app-state-persistence.test.ts
@@ -16,6 +16,7 @@ function makeApp(id: string, opts: Partial<App> = {}): App {
   return {
     id,
     displayName: id,
+    description: id,
     tools: [],
     canInvoke: () => true,
     help: async () => "",


### PR DESCRIPTION
## 做了什么

给主 Agent 的 system prompt 里那份「App 名单」的每一项补一句功能简介——从 `- calc：计算器` 变成 `- calc：计算器——对两个数做一次加减乘除，可设小数精度。`，让小镜在桌面（Portal）层就能判断该切进哪个 App，不必先 `switch` 进去再 `help` 才知道能力。

## 改动

- `App` 接口新增**必填** `readonly description: string`（`packages/agent-runtime/src/app/app.ts`），作为 `displayName` 的孪生字段；必填 → 新增 App 漏写就编译不过，防名单漂移。
- 12 个 App 各补 `description` 常量（calc / terminal / ithome / todo / clock / hn / amap / browser / spire / pixel / atelier / qq），文案平铺直叙介绍功能、无祈使语气，经 Codex 过了一版准确性。
- factory view-model 透传 `description`；`createAgentSystemPrompt` 参数类型同步；模板 `main-engine-system.hbs` 引导行 + 循环项渲染 `——{{description}}`。
- 更新 `system-prompt.test.ts` 断言新渲染形状；补齐各测试桩的 `description` 字段。

## KV 缓存

安全。`description` 是静态常量、App 集合进程内不可变，名单每轮渲染字节仍恒定；只在本次上线失效一次前缀，与改 `displayName` 同性质。

## 决策：描述住在 App 接口（方案 A）

co-locate 在各 App 文件、镜像 `displayName`。一句 App 身份元数据随 `displayName` 作为 view-model 喂给 `.hbs` 模板渲染，语气文案本体仍在模板里，与「进上下文散文走模板」规则对 `displayName` 一类结构标识的豁免一致，属有意为之。

## 验证

`pnpm build / typecheck / lint / format / knip` 五件套全绿；`pnpm test` 1422 测试全过。

Closes #515