### PR TITLE
feat(metric): 新增 raw 原始点查询 /metric/points（低频 gauge 不聚合）

### DIFF
--- a/apps/metric/src/app/metric-runtime.ts
+++ b/apps/metric/src/app/metric-runtime.ts
@@ -7,9 +7,11 @@ import { createServiceApp } from "@kagami/kernel/http/service-app";
 import { HealthHandler } from "@kagami/kernel/http/health.handler";
 import { MetricChartHandler } from "../metric/http/metric-chart.handler.js";
 import { MetricDeriveHandler } from "../metric/http/metric-derive.handler.js";
+import { MetricPointsHandler } from "../metric/http/metric-points.handler.js";
 import { MetricRecordHandler } from "../metric/http/metric-record.handler.js";
 import { DefaultMetricChartService } from "../metric/application/metric-chart.impl.service.js";
 import { DefaultMetricDeriveService } from "../metric/application/metric-derive.impl.service.js";
+import { DefaultMetricPointsService } from "../metric/application/metric-points.impl.service.js";
 import { DefaultMetricRecordService } from "../metric/application/metric-record.impl.service.js";
 import { openMetricDuckDb } from "../metric/infra/impl/duckdb-metric.impl.dao.js";
 
@@ -37,6 +39,7 @@ export async function buildMetricRuntime(): Promise<MetricRuntime> {
   const metricRecordService = new DefaultMetricRecordService({ metricDao });
   const metricChartService = new DefaultMetricChartService({ metricDao });
   const metricDeriveService = new DefaultMetricDeriveService({ metricDao });
+  const metricPointsService = new DefaultMetricPointsService({ metricDao });
 
   // 面向前端查询 + agent 摄取：traceId / 默认错误三分支由公共装配壳提供。
   const app = createServiceApp({
@@ -46,6 +49,7 @@ export async function buildMetricRuntime(): Promise<MetricRuntime> {
       new MetricRecordHandler({ metricRecordService }),
       new MetricChartHandler({ metricChartService }),
       new MetricDeriveHandler({ metricDeriveService }),
+      new MetricPointsHandler({ metricPointsService }),
     ],
   });
 

--- a/apps/metric/src/metric/application/metric-points.impl.service.ts
+++ b/apps/metric/src/metric/application/metric-points.impl.service.ts
@@ -1,0 +1,139 @@
+import {
+  METRIC_POINTS_MAX_POINTS,
+  METRIC_POINTS_RANGE_PRESET_MILLISECONDS,
+  type MetricPointsQueryRequest,
+  type MetricPointsQueryResponse,
+  type MetricPointsSeries,
+} from "@kagami/metric-api/points";
+import { BizError } from "@kagami/kernel/errors/biz-error";
+import type { MetricDao, MetricRawPointRow } from "../infra/metric.dao.js";
+import type { MetricPointsService } from "./metric-points.service.js";
+
+type DefaultMetricPointsServiceDeps = {
+  metricDao: MetricDao;
+};
+
+const UNGROUPED_SERIES_KEY = "__ungrouped__";
+const DEFAULT_SINGLE_SERIES_KEY = "__default__";
+
+/**
+ * raw 原始点查询：低频 gauge 不聚合、不分桶，把范围内每个原始点照画（对齐 <MetricChart> 的分组/命名
+ * 语义，但 points 是原始点而非桶）。行数 guard 走 LIMIT：DAO 按 occurred_at DESC 取 MAX+1 条，若命中
+ * MAX+1 则 truncated=true 且只保留最近 MAX 点（丢最旧点）；每条 series 输出前重排为 occurred_at 升序。
+ */
+export class DefaultMetricPointsService implements MetricPointsService {
+  private readonly metricDao: MetricDao;
+
+  public constructor({ metricDao }: DefaultMetricPointsServiceDeps) {
+    this.metricDao = metricDao;
+  }
+
+  public async query(request: MetricPointsQueryRequest): Promise<MetricPointsQueryResponse> {
+    const { startAt, endAt } = resolveTimeRange(request);
+
+    // 多取一条判 truncated：命中 MAX+1 说明范围内实际点数超上限。
+    const rows = await this.metricDao.queryRawPoints({
+      metricName: request.metricName,
+      tagFilters: request.tagFilters ?? null,
+      groupByTag: request.groupByTag ?? null,
+      startAt,
+      endAt,
+      limit: METRIC_POINTS_MAX_POINTS + 1,
+    });
+
+    const truncated = rows.length > METRIC_POINTS_MAX_POINTS;
+    // DESC 序，保留最近 MAX 条（丢最旧）。
+    const kept = truncated ? rows.slice(0, METRIC_POINTS_MAX_POINTS) : rows;
+
+    return {
+      startAt: startAt.toISOString(),
+      endAt: endAt.toISOString(),
+      truncated,
+      series: buildSeries({ request, rows: kept }),
+    };
+  }
+}
+
+function resolveTimeRange(request: MetricPointsQueryRequest): { startAt: Date; endAt: Date } {
+  if (request.rangePreset) {
+    const endAt = new Date();
+    const startAt = new Date(
+      endAt.getTime() - METRIC_POINTS_RANGE_PRESET_MILLISECONDS[request.rangePreset],
+    );
+    return { startAt, endAt };
+  }
+
+  if (!request.startAt || !request.endAt) {
+    throw new BizError({
+      message: "Metric raw 查询时间范围不合法",
+      meta: {
+        reason: "METRIC_POINTS_RANGE_INVALID",
+      },
+      statusCode: 400,
+    });
+  }
+
+  return {
+    startAt: new Date(request.startAt),
+    endAt: new Date(request.endAt),
+  };
+}
+
+function buildSeries(params: {
+  request: MetricPointsQueryRequest;
+  rows: MetricRawPointRow[];
+}): MetricPointsSeries[] {
+  const pointsBySeriesKey = new Map<string, { label: string; rows: MetricRawPointRow[] }>();
+
+  for (const row of params.rows) {
+    const { key, label } = resolveSeriesIdentity({
+      request: params.request,
+      seriesKey: row.seriesKey,
+    });
+
+    const existing = pointsBySeriesKey.get(key);
+    if (existing) {
+      existing.rows.push(row);
+    } else {
+      pointsBySeriesKey.set(key, { label, rows: [row] });
+    }
+  }
+
+  return [...pointsBySeriesKey.entries()].map(([key, { label, rows }]) => ({
+    key,
+    label,
+    // DAO 返回 DESC，前端画线要升序：按 occurredAt 升序（同刻不做二次 tiebreak，稀疏 gauge 无碰撞）。
+    points: rows
+      .slice()
+      .sort((left, right) => left.occurredAt.getTime() - right.occurredAt.getTime())
+      .map(row => ({
+        occurredAt: row.occurredAt.toISOString(),
+        value: row.value,
+      })),
+  }));
+}
+
+function resolveSeriesIdentity(params: {
+  request: MetricPointsQueryRequest;
+  seriesKey: string | null;
+}): { key: string; label: string } {
+  if (!params.request.groupByTag) {
+    return {
+      key: DEFAULT_SINGLE_SERIES_KEY,
+      label: params.request.metricName,
+    };
+  }
+
+  const normalizedKey = params.seriesKey?.trim();
+  if (!normalizedKey) {
+    return {
+      key: UNGROUPED_SERIES_KEY,
+      label: "未分组",
+    };
+  }
+
+  return {
+    key: normalizedKey,
+    label: normalizedKey,
+  };
+}

--- a/apps/metric/src/metric/application/metric-points.service.ts
+++ b/apps/metric/src/metric/application/metric-points.service.ts
@@ -1,0 +1,8 @@
+import type {
+  MetricPointsQueryRequest,
+  MetricPointsQueryResponse,
+} from "@kagami/metric-api/points";
+
+export interface MetricPointsService {
+  query(request: MetricPointsQueryRequest): Promise<MetricPointsQueryResponse>;
+}

--- a/apps/metric/src/metric/http/metric-points.handler.ts
+++ b/apps/metric/src/metric/http/metric-points.handler.ts
@@ -1,0 +1,23 @@
+import type { FastifyInstance } from "fastify";
+import { registerJsonRoute } from "@kagami/http/register";
+import { metricApiContract } from "@kagami/metric-api/contract";
+import type { MetricPointsService } from "../application/metric-points.service.js";
+
+type MetricPointsHandlerDeps = {
+  metricPointsService: MetricPointsService;
+};
+
+/** raw 原始点查询路由：低频 gauge 不聚合、不分桶，按 occurred_at 返回范围内每个原始点。 */
+export class MetricPointsHandler {
+  private readonly metricPointsService: MetricPointsService;
+
+  public constructor({ metricPointsService }: MetricPointsHandlerDeps) {
+    this.metricPointsService = metricPointsService;
+  }
+
+  public register(app: FastifyInstance): void {
+    registerJsonRoute(app, metricApiContract.points, ({ input }) =>
+      this.metricPointsService.query(input),
+    );
+  }
+}

--- a/apps/metric/src/metric/infra/impl/duckdb-metric.impl.dao.ts
+++ b/apps/metric/src/metric/infra/impl/duckdb-metric.impl.dao.ts
@@ -10,9 +10,11 @@ import type {
   MetricDao,
   MetricDeriveOperand,
   MetricDerivedSeriesRow,
+  MetricRawPointRow,
   MetricTagFilters,
   QueryDerivedSeriesInput,
   QueryMetricChartSeriesInput,
+  QueryMetricRawPointsInput,
 } from "../metric.dao.js";
 
 /**
@@ -204,11 +206,59 @@ export class DuckDbMetricDao implements MetricDao {
     }));
   }
 
+  public async queryRawPoints(input: QueryMetricRawPointsInput): Promise<MetricRawPointRow[]> {
+    const params = new VarcharParams();
+    const seriesKeyExpression = input.groupByTag
+      ? `NULLIF("tags" ->> ${params.add(input.groupByTag)}, '')`
+      : `NULL`;
+    const whereClause = buildWhereClause(
+      {
+        metricName: input.metricName,
+        startAt: input.startAt,
+        endAt: input.endAt,
+        tagFilters: input.tagFilters,
+      },
+      params,
+    );
+
+    // 无聚合、无分桶：直接取原始行。DESC + LIMIT 取「最近 N 条」——命中超上限时服务端据此判 truncated
+    // 并保留最近点、丢最旧点。epoch_ms 得 UTC 毫秒整数（occurred_at 是 naive UTC TIMESTAMP，与
+    // queryChartSeries 的 epoch() 语义一致，非 UTC 部署机也不错位）。limit 是受信整数，内联安全。
+    const limit = Math.max(0, Math.floor(input.limit));
+    const sql = `
+      SELECT
+        epoch_ms("occurred_at") AS "occurredAtMs",
+        ${seriesKeyExpression} AS "seriesKey",
+        "value" AS "value"
+      FROM "metric"
+      ${whereClause}
+      ORDER BY "occurred_at" DESC, "id" DESC
+      LIMIT ${limit}
+    `;
+
+    const prepared = await this.connection.prepare(sql);
+    params.bindAll(prepared);
+    const reader = await prepared.runAndReadAll();
+    const rows = reader.getRowObjects() as RawMetricRawPointRow[];
+
+    return rows.map(row => ({
+      occurredAt: new Date(Number(row.occurredAtMs)),
+      seriesKey: row.seriesKey === null ? null : String(row.seriesKey),
+      value: Number(row.value),
+    }));
+  }
+
   public close(): void {
     this.connection.closeSync();
     this.instance.closeSync();
   }
 }
+
+type RawMetricRawPointRow = {
+  occurredAtMs: number | bigint;
+  seriesKey: string | null;
+  value: number | bigint;
+};
 
 type RawMetricChartSeriesRow = {
   // DuckDB 返回 bucketStart（epoch 秒）与 count 为 bigint，value（sum/avg 等）为 number；映射处统一转。

--- a/apps/metric/src/metric/infra/metric.dao.ts
+++ b/apps/metric/src/metric/infra/metric.dao.ts
@@ -67,11 +67,30 @@ export type MetricDerivedSeriesRow = {
   value: number | null;
 };
 
+// raw 原始点查询：无聚合、无分桶，按 occurred_at 直接取范围内每个原始点。行数 LIMIT 兜底
+// （raw 点数由数据密度决定，不能用 range×bucket 预算）；DAO 按 occurred_at DESC 取最近 limit 条。
+export type QueryMetricRawPointsInput = {
+  metricName: string;
+  tagFilters: MetricTagFilters | null;
+  groupByTag: string | null;
+  startAt: Date;
+  endAt: Date;
+  limit: number;
+};
+
+export type MetricRawPointRow = {
+  occurredAt: Date;
+  seriesKey: string | null;
+  value: number;
+};
+
 export interface MetricDao {
   insert(input: InsertMetricInput): Promise<void>;
   queryChartSeries(input: QueryMetricChartSeriesInput): Promise<MetricChartSeriesRow[]>;
   /** 派生查询：一条 SQL 按桶对齐分子/分母算 ratio/diff，出单条派生线（#475 P3）。 */
   queryDerivedSeries(input: QueryDerivedSeriesInput): Promise<MetricDerivedSeriesRow[]>;
+  /** raw 原始点查询：按 occurred_at DESC 取最近 `limit` 条原始点（不聚合、不分桶）。 */
+  queryRawPoints(input: QueryMetricRawPointsInput): Promise<MetricRawPointRow[]>;
   /** 关停时释放 DuckDB 连接与实例。 */
   close(): void;
 }

--- a/apps/metric/test/metric/metric-chart.impl.service.test.ts
+++ b/apps/metric/test/metric/metric-chart.impl.service.test.ts
@@ -146,6 +146,7 @@ function createMetricDao(overrides?: Partial<MetricDao>): MetricDao {
     insert: vi.fn().mockResolvedValue(undefined),
     queryChartSeries: vi.fn().mockResolvedValue([]),
     queryDerivedSeries: vi.fn().mockResolvedValue([]),
+    queryRawPoints: vi.fn().mockResolvedValue([]),
     close: vi.fn(),
     ...overrides,
   };

--- a/apps/metric/test/metric/metric-derive.impl.service.test.ts
+++ b/apps/metric/test/metric/metric-derive.impl.service.test.ts
@@ -10,6 +10,7 @@ function createMetricDao(overrides?: Partial<MetricDao>): MetricDao {
     insert: vi.fn().mockResolvedValue(undefined),
     queryChartSeries: vi.fn().mockResolvedValue([]),
     queryDerivedSeries: vi.fn().mockResolvedValue([]),
+    queryRawPoints: vi.fn().mockResolvedValue([]),
     close: vi.fn(),
     ...overrides,
   };

--- a/apps/metric/test/metric/metric-points-schema.test.ts
+++ b/apps/metric/test/metric/metric-points-schema.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { MetricPointsQueryRequestSchema } from "@kagami/metric-api/points";
+
+// raw 端点的硬边界 guard 全落在这份 wire schema：无 aggregator/bucket（strict 拒绝），range 上限 7 天，
+// 点数不在 schema 层挡（走服务端行数 LIMIT + truncated）。
+
+describe("MetricPointsQueryRequestSchema guards", () => {
+  it("accepts a valid preset request", () => {
+    const result = MetricPointsQueryRequestSchema.safeParse({
+      metricName: "llm.oauth.quota.remaining_percent",
+      groupByTag: "window",
+      rangePreset: "7d",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a valid custom range request", () => {
+    const result = MetricPointsQueryRequestSchema.safeParse({
+      metricName: "llm.oauth.quota.remaining_percent",
+      startAt: "2026-07-01T00:00:00.000Z",
+      endAt: "2026-07-02T00:00:00.000Z",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an aggregator field (strict, raw has no aggregation)", () => {
+    const result = MetricPointsQueryRequestSchema.safeParse({
+      metricName: "llm.oauth.quota.remaining_percent",
+      aggregator: "last",
+      rangePreset: "1d",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a bucket field (strict, raw has no bucketing)", () => {
+    const result = MetricPointsQueryRequestSchema.safeParse({
+      metricName: "llm.oauth.quota.remaining_percent",
+      bucket: "30m",
+      rangePreset: "1d",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects when the range exceeds 7 days", () => {
+    const result = MetricPointsQueryRequestSchema.safeParse({
+      metricName: "llm.oauth.quota.remaining_percent",
+      startAt: "2026-07-01T00:00:00.000Z",
+      endAt: "2026-07-09T00:00:00.000Z",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects when no range is provided", () => {
+    const result = MetricPointsQueryRequestSchema.safeParse({
+      metricName: "llm.oauth.quota.remaining_percent",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects when preset and custom range are mixed", () => {
+    const result = MetricPointsQueryRequestSchema.safeParse({
+      metricName: "llm.oauth.quota.remaining_percent",
+      rangePreset: "1d",
+      startAt: "2026-07-01T00:00:00.000Z",
+      endAt: "2026-07-02T00:00:00.000Z",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects when startAt is after endAt", () => {
+    const result = MetricPointsQueryRequestSchema.safeParse({
+      metricName: "llm.oauth.quota.remaining_percent",
+      startAt: "2026-07-02T00:00:00.000Z",
+      endAt: "2026-07-01T00:00:00.000Z",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/metric/test/metric/metric-points.impl.service.test.ts
+++ b/apps/metric/test/metric/metric-points.impl.service.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  DuckDbMetricDao,
+  openMetricDuckDb,
+} from "../../src/metric/infra/impl/duckdb-metric.impl.dao.js";
+import { DefaultMetricPointsService } from "../../src/metric/application/metric-points.impl.service.js";
+
+// 端到端（内存 DuckDB + service）验证 raw 原始点查询：不聚合、不分桶、每个原始点照出，
+// groupByTag 分组、tagFilter、升序、truncated 边界。
+
+const METRIC = "llm.oauth.quota.remaining_percent";
+const iso = (s: string) => new Date(s);
+
+describe("DefaultMetricPointsService", () => {
+  let dao: DuckDbMetricDao;
+  let service: DefaultMetricPointsService;
+
+  beforeEach(async () => {
+    dao = await openMetricDuckDb(":memory:");
+    service = new DefaultMetricPointsService({ metricDao: dao });
+  });
+
+  afterEach(() => {
+    dao.close();
+  });
+
+  it("returns every raw point in ascending time order, no aggregation", async () => {
+    for (const [minute, value] of [
+      ["00", 98],
+      ["10", 96],
+      ["20", 95],
+    ] as const) {
+      await dao.insert({
+        metricName: METRIC,
+        value,
+        tags: { window: "five_hour" },
+        occurredAt: iso(`2026-07-06T10:${minute}:00.000Z`),
+      });
+    }
+
+    const response = await service.query({
+      metricName: METRIC,
+      startAt: "2026-07-06T09:00:00.000Z",
+      endAt: "2026-07-06T11:00:00.000Z",
+    });
+
+    expect(response.truncated).toBe(false);
+    expect(response.series).toHaveLength(1);
+    expect(response.series[0]?.points).toEqual([
+      { occurredAt: "2026-07-06T10:00:00.000Z", value: 98 },
+      { occurredAt: "2026-07-06T10:10:00.000Z", value: 96 },
+      { occurredAt: "2026-07-06T10:20:00.000Z", value: 95 },
+    ]);
+  });
+
+  it("splits into series by groupByTag", async () => {
+    await dao.insert({
+      metricName: METRIC,
+      value: 98,
+      tags: { window: "five_hour" },
+      occurredAt: iso("2026-07-06T10:00:00.000Z"),
+    });
+    await dao.insert({
+      metricName: METRIC,
+      value: 28,
+      tags: { window: "seven_day" },
+      occurredAt: iso("2026-07-06T10:00:00.000Z"),
+    });
+
+    const response = await service.query({
+      metricName: METRIC,
+      groupByTag: "window",
+      startAt: "2026-07-06T09:00:00.000Z",
+      endAt: "2026-07-06T11:00:00.000Z",
+    });
+
+    const byKey = Object.fromEntries(response.series.map(s => [s.key, s.points.map(p => p.value)]));
+    expect(byKey).toEqual({ five_hour: [98], seven_day: [28] });
+  });
+
+  it("applies tag filters (eq)", async () => {
+    await dao.insert({
+      metricName: METRIC,
+      value: 98,
+      tags: { provider: "claude-code", window: "five_hour" },
+      occurredAt: iso("2026-07-06T10:00:00.000Z"),
+    });
+    await dao.insert({
+      metricName: METRIC,
+      value: 50,
+      tags: { provider: "openai-codex", window: "five_hour" },
+      occurredAt: iso("2026-07-06T10:00:00.000Z"),
+    });
+
+    const response = await service.query({
+      metricName: METRIC,
+      tagFilters: { provider: { op: "eq", value: "claude-code" } },
+      groupByTag: "window",
+      startAt: "2026-07-06T09:00:00.000Z",
+      endAt: "2026-07-06T11:00:00.000Z",
+    });
+
+    expect(response.series).toHaveLength(1);
+    expect(response.series[0]?.points.map(p => p.value)).toEqual([98]);
+  });
+
+  it("does not aggregate points that land in the same coarse interval", async () => {
+    // 三个 10 分钟点若按 30m 桶聚合会塌成 1 个；raw 必须仍是 3 个。
+    for (const minute of ["00", "10", "20"] as const) {
+      await dao.insert({
+        metricName: METRIC,
+        value: 90,
+        tags: {},
+        occurredAt: iso(`2026-07-06T10:${minute}:00.000Z`),
+      });
+    }
+
+    const response = await service.query({
+      metricName: METRIC,
+      startAt: "2026-07-06T09:00:00.000Z",
+      endAt: "2026-07-06T11:00:00.000Z",
+    });
+
+    expect(response.series[0]?.points).toHaveLength(3);
+  });
+});

--- a/apps/metric/test/metric/metric.impl.dao.test.ts
+++ b/apps/metric/test/metric/metric.impl.dao.test.ts
@@ -616,4 +616,68 @@ describe("DuckDbMetricDao", () => {
       expect(rows).toEqual([{ bucketStart: iso("2026-07-06T10:00:00.000Z"), value: 5 }]);
     });
   });
+
+  describe("queryRawPoints", () => {
+    it("returns the most recent `limit` rows in DESC order (no aggregation)", async () => {
+      for (const [minute, value] of [
+        ["00", 10],
+        ["10", 20],
+        ["20", 30],
+        ["30", 40],
+        ["40", 50],
+      ] as const) {
+        await dao.insert({
+          metricName: METRIC,
+          value,
+          tags: {},
+          occurredAt: iso(`2026-07-06T10:${minute}:00.000Z`),
+        });
+      }
+
+      const rows = await dao.queryRawPoints({
+        metricName: METRIC,
+        tagFilters: null,
+        groupByTag: null,
+        startAt: iso("2026-07-06T09:00:00.000Z"),
+        endAt: iso("2026-07-06T11:00:00.000Z"),
+        limit: 3,
+      });
+
+      // LIMIT 取最近 3 条，DESC 序（service 层再升序 + 判 truncated）。
+      expect(rows.map(row => row.value)).toEqual([50, 40, 30]);
+      expect(rows.map(row => row.occurredAt.toISOString())).toEqual([
+        "2026-07-06T10:40:00.000Z",
+        "2026-07-06T10:30:00.000Z",
+        "2026-07-06T10:20:00.000Z",
+      ]);
+    });
+
+    it("extracts groupByTag into seriesKey and honors tag filters", async () => {
+      await dao.insert({
+        metricName: METRIC,
+        value: 98,
+        tags: { provider: "claude-code", window: "five_hour" },
+        occurredAt: iso("2026-07-06T10:00:00.000Z"),
+      });
+      await dao.insert({
+        metricName: METRIC,
+        value: 28,
+        tags: { provider: "openai-codex", window: "seven_day" },
+        occurredAt: iso("2026-07-06T10:01:00.000Z"),
+      });
+
+      const rows = await dao.queryRawPoints({
+        metricName: METRIC,
+        tagFilters: { provider: { op: "eq", value: "claude-code" } },
+        groupByTag: "window",
+        startAt: iso("2026-07-06T09:00:00.000Z"),
+        endAt: iso("2026-07-06T11:00:00.000Z"),
+        limit: 100,
+      });
+
+      expect(rows).toEqual([
+        { occurredAt: iso("2026-07-06T10:00:00.000Z"), seriesKey: "five_hour", value: 98 },
+      ]);
+    });
+  });
 });

--- a/packages/metric-api/src/contract.ts
+++ b/packages/metric-api/src/contract.ts
@@ -1,6 +1,7 @@
 import { defineJsonRoute } from "@kagami/http/contract";
 import { MetricChartQueryRequestSchema, MetricChartQueryResponseSchema } from "./chart.js";
 import { MetricDeriveRequestSchema } from "./derive.js";
+import { MetricPointsQueryRequestSchema, MetricPointsQueryResponseSchema } from "./points.js";
 import { RecordMetricRequestSchema, RecordMetricResponseSchema } from "./record.js";
 
 // === @kagami/metric-api：kagami-metric 服务的 HTTP 契约（issue #279 PR3 / #444） ===
@@ -31,5 +32,12 @@ export const metricApiContract = {
     path: "/metric/derive",
     input: MetricDeriveRequestSchema,
     output: MetricChartQueryResponseSchema,
+  }),
+  // raw 原始点查询：低频 gauge 不聚合、不分桶，按 occurred_at 返回范围内每个原始点，行数 LIMIT 兜底。
+  points: defineJsonRoute({
+    method: "POST",
+    path: "/metric/points",
+    input: MetricPointsQueryRequestSchema,
+    output: MetricPointsQueryResponseSchema,
   }),
 } as const;

--- a/packages/metric-api/src/points.ts
+++ b/packages/metric-api/src/points.ts
@@ -1,0 +1,138 @@
+import { z } from "zod";
+import { MetricChartTagFiltersSchema } from "./chart.js";
+
+// === Metric raw 原始点查询 wire schema ===
+//
+// query（#444）为高频事件 metric 而生：aggregator + bucket 必填，按桶聚合。但对**低频 gauge**
+// （如每 10 分钟一采的 OAuth 额度剩余百分比），桶聚合是错误工具——桶太细造一堆空桶且超点数上限，
+// 桶太粗把多个原始点塌成一个。raw 端点不聚合、不分桶，按 occurred_at 直接返回范围内每个原始点，
+// 按 groupByTag 分组。这是通用基建：任何低频 gauge（额度、余额、队列深度）都可复用。
+//
+// 与 query 的两点关键差异：
+// - 无 aggregator / 无 bucket（.strict() 会拒绝携带这两个字段）。
+// - 点数 guard 走**行数 LIMIT**（raw 点数由数据密度决定，不能像 query 那样用 range×bucket 预算），
+//   因此 range 上限可放宽到 7 天（query 是 2 天），行数由 LIMIT 兜底。
+
+/** raw 一次查询最多返回的原始点数（行数 LIMIT 兜底，超出则 truncated）。 */
+export const METRIC_POINTS_MAX_POINTS = 2000;
+/** raw 时间跨度上限（7 天）：低频 gauge 常查 7d，且行数已由 LIMIT 兜底，故比 query 的 2 天宽松。 */
+export const METRIC_POINTS_MAX_RANGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+export const MetricPointsRangePresetSchema = z.enum(["1h", "3h", "6h", "12h", "1d", "2d", "7d"]);
+
+export type MetricPointsRangePreset = z.infer<typeof MetricPointsRangePresetSchema>;
+
+export const METRIC_POINTS_RANGE_PRESET_MILLISECONDS: Record<MetricPointsRangePreset, number> = {
+  "1h": 60 * 60 * 1000,
+  "3h": 3 * 60 * 60 * 1000,
+  "6h": 6 * 60 * 60 * 1000,
+  "12h": 12 * 60 * 60 * 1000,
+  "1d": 24 * 60 * 60 * 1000,
+  "2d": 2 * 24 * 60 * 60 * 1000,
+  "7d": 7 * 24 * 60 * 60 * 1000,
+};
+
+export const MetricPointsQueryRequestSchema = z
+  .object({
+    metricName: z.string().trim().min(1),
+    // tagFilters 复用 query 的 eq/ne/in 判别联合（同一 key 一个过滤、跨 key 取 AND）。
+    tagFilters: MetricChartTagFiltersSchema.optional(),
+    groupByTag: z.string().trim().min(1).optional(),
+    rangePreset: MetricPointsRangePresetSchema.optional(),
+    startAt: z.string().datetime({ offset: true }).optional(),
+    endAt: z.string().datetime({ offset: true }).optional(),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    const hasPreset = value.rangePreset !== undefined;
+    const hasCustomStart = value.startAt !== undefined;
+    const hasCustomEnd = value.endAt !== undefined;
+
+    if (!hasPreset && !hasCustomStart && !hasCustomEnd) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["rangePreset"],
+        message: "rangePreset or startAt/endAt is required",
+      });
+      return;
+    }
+
+    if (hasPreset && (hasCustomStart || hasCustomEnd)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["rangePreset"],
+        message: "rangePreset and startAt/endAt cannot be used together",
+      });
+      return;
+    }
+
+    if (hasCustomStart !== hasCustomEnd) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: hasCustomStart ? ["endAt"] : ["startAt"],
+        message: "startAt and endAt must both be provided",
+      });
+      return;
+    }
+
+    let rangeMs: number;
+    if (value.rangePreset) {
+      rangeMs = METRIC_POINTS_RANGE_PRESET_MILLISECONDS[value.rangePreset];
+    } else if (value.startAt && value.endAt) {
+      const startAt = new Date(value.startAt).getTime();
+      const endAt = new Date(value.endAt).getTime();
+      if (startAt > endAt) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["startAt"],
+          message: "startAt must be less than or equal to endAt",
+        });
+        return;
+      }
+      rangeMs = endAt - startAt;
+    } else {
+      return;
+    }
+
+    // raw 只查 range 上限，不查点数（点数由数据密度决定，服务端行数 LIMIT 兜底 + truncated 标记）。
+    if (rangeMs > METRIC_POINTS_MAX_RANGE_MS) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["rangePreset"],
+        message: `时间跨度不能超过 ${METRIC_POINTS_MAX_RANGE_MS / (24 * 60 * 60 * 1000)} 天`,
+      });
+    }
+  });
+
+export type MetricPointsQueryRequest = z.infer<typeof MetricPointsQueryRequestSchema>;
+
+export const MetricPointsSeriesPointSchema = z
+  .object({
+    occurredAt: z.string().datetime(),
+    value: z.number(),
+  })
+  .strict();
+
+export type MetricPointsSeriesPoint = z.infer<typeof MetricPointsSeriesPointSchema>;
+
+export const MetricPointsSeriesSchema = z
+  .object({
+    key: z.string().min(1),
+    label: z.string().min(1),
+    points: z.array(MetricPointsSeriesPointSchema),
+  })
+  .strict();
+
+export type MetricPointsSeries = z.infer<typeof MetricPointsSeriesSchema>;
+
+export const MetricPointsQueryResponseSchema = z
+  .object({
+    startAt: z.string().datetime(),
+    endAt: z.string().datetime(),
+    // 命中行数超上限：只返回最近 METRIC_POINTS_MAX_POINTS 点，truncated=true 供前端提示。
+    truncated: z.boolean(),
+    series: z.array(MetricPointsSeriesSchema),
+  })
+  .strict();
+
+export type MetricPointsQueryResponse = z.infer<typeof MetricPointsQueryResponseSchema>;


### PR DESCRIPTION
## 做了什么

给 Metric 加 raw 原始点查询端点 `POST /metric/points`：低频 gauge（每 10 分钟一采）不聚合、不分桶，按 `occurred_at` 返回范围内每个原始点，按 `groupByTag` 分组。

- 契约 `packages/metric-api/src/points.ts`：无 `aggregator`/`bucket`（strict 拒绝），range 上限 7 天，行数 guard 走服务端 `LIMIT`。
- 服务端 `apps/metric`：`queryRawPoints`（`epoch_ms` + `DESC LIMIT`）+ service（升序/分组/`truncated`）+ handler + runtime 装配。
- 前端 client 走共享 `createClient(metricApiContract)` 自动获得 `points`，消费留给 #519。

## 为什么

`query` 端点按桶聚合，对低频 gauge 桶太细超上限、桶太粗吞点。raw 是 epic #521（OAuth 额度遥测迁 Metric）的前置基建，通用可复用。

## 测试

- schema guard（strict 拒 aggregator/bucket、range 上限、preset/custom 混用、start>end）
- DAO：DESC LIMIT 取最近 N、groupByTag 提取、tagFilter
- service：升序输出、分组、tagFilter、不聚合（3 个 10 分钟点仍是 3 点）
- 五件套全绿；全量 1436 测试通过；codex review 无正确性 bug。

Closes #516
Refs #521