### PR TITLE
feat(spire): 升级 sts-engine 至 0.5.0 并接入选牌屏

### DIFF
--- a/apps/agent/src/agent/capabilities/spire/render/spire-screen.ts
+++ b/apps/agent/src/agent/capabilities/spire/render/spire-screen.ts
@@ -165,6 +165,8 @@ export function renderSpireScreen(screen: SpireScreen): string {
     isRest: screen.screen === "rest",
     isEvent: screen.screen === "event",
     eventDescription: screen.event?.description ?? "",
+    isCardSelect: screen.screen === "card_select",
+    cardSelectTitle: screen.cardSelect?.title ?? "",
     isShop: screen.screen === "shop",
     isGameover: screen.screen === "gameover",
     isVictory: screen.screen === "victory",
@@ -234,6 +236,7 @@ const SPIRE_RARITY_LABELS: Record<string, string> = {
   rare: "稀有",
   boss: "首领",
   special: "特殊",
+  shop: "商店",
 };
 
 /** lookup 结果 → 文字（卡牌信息 + 术语定义）。框架文案在 .hbs，游戏数据插值。 */

--- a/apps/agent/static/context/spire-screen.hbs
+++ b/apps/agent/static/context/spire-screen.hbs
@@ -59,6 +59,13 @@
 [{{n}}] {{text}}
 {{/each}}
 用 invoke(tool="choose", option_index=编号) 做出选择。
+{{else if isCardSelect}}
+{{cardSelectTitle}}
+你：生命 {{hp}}/{{maxHp}}　牌组 {{deckCount}} 张。
+{{#each options}}
+[{{n}}] {{text}}
+{{/each}}
+用 invoke(tool="choose", option_index=编号) 选择。
 {{else if isShop}}
 商店。你有 {{gold}} 金币　生命 {{hp}}/{{maxHp}}　牌组 {{deckCount}} 张。
 在售（买完可继续逛，逛够了就离开）：

--- a/apps/agent/test/acl/spire-client.test.ts
+++ b/apps/agent/test/acl/spire-client.test.ts
@@ -18,6 +18,7 @@ function screenOf(version: number): SpireScreen {
     relics: [{ name: "燃烧之血", description: "每场战斗结束后，回复 6 点生命。" }],
     potions: [],
     event: null,
+    cardSelect: null,
     combat: null,
     options: ["0", "1"],
     log: [],

--- a/apps/spire/package.json
+++ b/apps/spire/package.json
@@ -15,7 +15,7 @@
     "@kagami/http": "workspace:*",
     "@kagami/kernel": "workspace:*",
     "@kagami/spire-api": "workspace:*",
-    "@kisinwen/sts-engine": "0.1.0",
+    "@kisinwen/sts-engine": "0.5.0",
     "fastify": "^5.6.2",
     "zod": "^3.24.4"
   },

--- a/apps/spire/src/application/state-view.ts
+++ b/apps/spire/src/application/state-view.ts
@@ -48,6 +48,7 @@ export function toScreenView(state: GameState, opts: { suppressLog?: boolean }):
       return [{ slot, name: def.name, description: def.description, targeted: def.targeted }];
     }),
     event: state.event ? { description: getEventDef(state.event.id).description } : null,
+    cardSelect: state.cardSelect ? { title: state.cardSelect.title } : null,
     combat: state.combat ? toCombatView(state) : null,
     options: currentOptions(state),
     log: opts.suppressLog ? [] : state.log,

--- a/packages/spire-api/src/contract.ts
+++ b/packages/spire-api/src/contract.ts
@@ -84,9 +84,28 @@ export const SpireEventViewSchema = z.object({
   description: z.string(),
 });
 
+/**
+ * 选牌子界面（图书馆选牌 / 复制器 / 和平烟斗去牌）。具体可选牌与「跳过」都进 options，
+ * 情境（加牌 / 复制 / 去牌）已由 title 的中文文案表达，故 view 只带 title 一项。
+ */
+export const SpireCardSelectViewSchema = z.object({
+  /** 情境标题（渲染用），如「从藏书中挑选一张带走」。 */
+  title: z.string(),
+});
+
 export const SpireScreenSchema = z.object({
   version: z.number().int(),
-  screen: z.enum(["map", "combat", "reward", "rest", "event", "shop", "gameover", "victory"]),
+  screen: z.enum([
+    "map",
+    "combat",
+    "reward",
+    "rest",
+    "event",
+    "shop",
+    "card_select",
+    "gameover",
+    "victory",
+  ]),
   act: z.number().int(),
   player: z.object({
     hp: z.number().int(),
@@ -97,6 +116,7 @@ export const SpireScreenSchema = z.object({
   relics: z.array(SpireRelicViewSchema),
   potions: z.array(SpirePotionViewSchema),
   event: SpireEventViewSchema.nullable(),
+  cardSelect: SpireCardSelectViewSchema.nullable(),
   combat: SpireCombatViewSchema.nullable(),
   options: z.array(z.string()),
   log: z.array(z.string()),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -460,8 +460,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/spire-api
       '@kisinwen/sts-engine':
-        specifier: 0.1.0
-        version: 0.1.0
+        specifier: 0.5.0
+        version: 0.5.0
       fastify:
         specifier: ^5.6.2
         version: 5.7.4
@@ -1448,8 +1448,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@kisinwen/sts-engine@0.1.0':
-    resolution: {integrity: sha512-uGlp/Qp7oCo9RvNBiS6PVIXeu5Yp4wZ9ZEl4D2kjUTCcoulj0Qf63FsW52odXzNcs09RsWrTcDGJmVlYLye6ag==}
+  '@kisinwen/sts-engine@0.5.0':
+    resolution: {integrity: sha512-7KT/7ETTbsUpFCzuVePpn/2dyhdKL5wcWBwcmAFM1CLogTiPCaA5Uo76SroiHFwTXaHrD0ByWJMlz/3753zCKA==}
     engines: {node: '>=20'}
 
   '@kurkle/color@0.3.4':
@@ -5063,7 +5063,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@kisinwen/sts-engine@0.1.0': {}
+  '@kisinwen/sts-engine@0.5.0': {}
 
   '@kurkle/color@0.3.4': {}
 


### PR DESCRIPTION
## 做了什么

把 `@kisinwen/sts-engine` 从 `0.1.0` 升到 `0.5.0`,并接入 0.5.0 新增的 **`card_select` 选牌屏**(图书馆选牌 / 复制器复制 / 和平烟斗去牌)。

引擎的 `GameAction` 未变——`card_select` 经既有的 `choose` 动作 + `currentOptions()` 驱动,所以机制层零改动;缺的只是契约的屏幕枚举与渲染时的情境标题。

## 改动

- **契约** (`packages/spire-api`):`screen` 枚举加 `card_select`;新增 `SpireCardSelectViewSchema`(仅 `title`);`SpireScreenSchema` 加 `cardSelect` 可空字段。
- **spire 服务** (`apps/spire`):`state-view` 映射 `state.cardSelect` → `{ title }`;升级依赖 pin。
- **agent 渲染** (`apps/agent`):`spire-screen.ts` + `.hbs` 模板渲染选牌屏(title + 选项列表,复用 `choose` 提示);补 `shop` 稀有度中文标签(0.5.0 `RelicRarity` 新增 `shop` 成员,新的商店遗物经 `lookup` 会命中)。

## 审查

- **Enum Completeness**:全仓只有 `renderSpireScreen` 对 `screen` 分支,已处理 `card_select`;其余消费者(state-view / handler / client / 8 个工具)均透传或无 per-screen 门控。
- **存档向后兼容**:0.5.0 `migrate.js` 对老档 `backfill(state, "cardSelect", null)`,contract `nullable()` 接受,不崩不损坏。
- **对抗审查**(Claude 独立子 Agent):无崩溃/静默损坏路径;发现并已修 2 个文案层瑕疵(shop 标签、契约死字段 `mode`/`canSkip` 已收敛为仅 `title`)。

## 验证

`pnpm build / typecheck / test(1436 passed) / lint / format / knip` 全绿(合并 master 后复跑)。

## 部署

需重载 **spire + agent** 两个服务(契约枚举变更两端都消费);部署前主仓库需 `pnpm install` 装 sts-engine 0.5.0。