### PR TITLE
feat(auth): OAuth 额度打点接入 Metric + AuthUsageSnapshotSink 端口（双写）

### DIFF
--- a/apps/llm/src/app/llm-service-runtime.ts
+++ b/apps/llm/src/app/llm-service-runtime.ts
@@ -26,6 +26,7 @@ import { createImageClient, type ImageClient } from "@kagami/llm-client/image";
 import { HttpMetricClient } from "@kagami/metric-client/client";
 import { SchedulerClient } from "@kagami/scheduler-client/scheduler-client";
 import { recordLlmCallMetrics } from "./llm-metrics.js";
+import { MetricAuthUsageSnapshotSink } from "./metric-auth-usage-snapshot-sink.js";
 import { PrismaEmbeddingCacheDao } from "../infra/prisma-embedding-cache.dao.js";
 import { PrismaClaudeFileCacheDao } from "../infra/prisma-claude-file-cache.dao.js";
 import { InternalLlmHandler } from "../http/internal-llm.handler.js";
@@ -57,7 +58,18 @@ export async function buildLlmServiceRuntime(): Promise<LlmServiceRuntime> {
   // 与 agent / console 并发读写同一 SQLite 文件：开 WAL（库文件级持久设置）。
   await configureSqlite(database);
 
-  const authModule = await createAuthModule({ database, configManager });
+  // metric 打点走独立 metric 服务（@kagami/metric）的 HTTP 摄取端点；地址取自 services.metric。
+  // record 是 fire-and-forget（永不 reject），打点失败绝不影响 LLM 结果。提前到 auth 装配前建，
+  // 好把 OAuth 额度遥测 sink 注入 auth module（epic #521）。
+  const metricService = new HttpMetricClient({
+    baseUrl: `http://${config.services.metric.host}:${config.services.metric.port}`,
+  });
+
+  const authModule = await createAuthModule({
+    database,
+    configManager,
+    authUsageSnapshotSink: new MetricAuthUsageSnapshotSink({ metricClient: metricService }),
+  });
   const llmChatCallDao = new PrismaLlmChatCallDao({ database });
   const embeddingCacheDao = new PrismaEmbeddingCacheDao({ database });
   const claudeFileCacheDao = new PrismaClaudeFileCacheDao({ database });
@@ -92,12 +104,6 @@ export async function buildLlmServiceRuntime(): Promise<LlmServiceRuntime> {
       fileCacheDao: claudeFileCacheDao,
     }),
   };
-
-  // metric 打点走独立 metric 服务（@kagami/metric）的 HTTP 摄取端点；地址取自 services.metric。
-  // record 是 fire-and-forget（永不 reject），打点失败绝不影响 LLM 结果。
-  const metricService = new HttpMetricClient({
-    baseUrl: `http://${config.services.metric.host}:${config.services.metric.port}`,
-  });
 
   // 落库在服务内：llm-client 只发 observation，这里订阅后写 llm_chat_call（策略见 persistLlmChatCall，
   // 成功轮不落 native_request_payload 以控库体积）。返回 DAO 的 Promise，让 client 内部

--- a/apps/llm/src/app/metric-auth-usage-snapshot-sink.ts
+++ b/apps/llm/src/app/metric-auth-usage-snapshot-sink.ts
@@ -1,0 +1,49 @@
+import type {
+  AuthUsageRefreshOutcome,
+  AuthUsageSnapshotSink,
+  AuthUsageSnapshotSinkRecord,
+} from "@kagami/auth";
+import type { MetricClient } from "@kagami/metric-client/client";
+
+/** OAuth 额度剩余百分比 gauge（0-100），tags `{provider, window}`，图表用 raw / last。 */
+export const OAUTH_QUOTA_REMAINING_PERCENT_METRIC = "llm.oauth.quota.remaining_percent";
+/** OAuth 额度采集成败（1/0），tag `{provider}`，用于区分「没数据」与「采集挂了」。 */
+export const OAUTH_QUOTA_REFRESH_SUCCESS_METRIC = "llm.oauth.quota.refresh_success";
+
+type MetricAuthUsageSnapshotSinkDeps = {
+  metricClient: MetricClient;
+};
+
+/**
+ * 把 packages/auth 的额度遥测事件翻成 Metric 打点（epic #521）。auth 领域包只认窄端口
+ * AuthUsageSnapshotSink，这里是 apps/llm 侧的 Metric 适配实现。record 是 fire-and-forget
+ * （HttpMetricClient 咽下一切失败、永不 reject），端口方法为同步 void，故一律 `void`。
+ */
+export class MetricAuthUsageSnapshotSink implements AuthUsageSnapshotSink {
+  private readonly metricClient: MetricClient;
+
+  public constructor({ metricClient }: MetricAuthUsageSnapshotSinkDeps) {
+    this.metricClient = metricClient;
+  }
+
+  public record(input: AuthUsageSnapshotSinkRecord): void {
+    void this.metricClient
+      .record({
+        metricName: OAUTH_QUOTA_REMAINING_PERCENT_METRIC,
+        value: input.remainingPercent,
+        tags: { provider: input.provider, window: input.window },
+        occurredAt: input.capturedAt,
+      })
+      .catch(() => undefined);
+  }
+
+  public recordRefreshOutcome(input: AuthUsageRefreshOutcome): void {
+    void this.metricClient
+      .record({
+        metricName: OAUTH_QUOTA_REFRESH_SUCCESS_METRIC,
+        value: input.success ? 1 : 0,
+        tags: { provider: input.provider },
+      })
+      .catch(() => undefined);
+  }
+}

--- a/apps/llm/test/metric-auth-usage-snapshot-sink.test.ts
+++ b/apps/llm/test/metric-auth-usage-snapshot-sink.test.ts
@@ -1,0 +1,57 @@
+import type { MetricClient, RecordMetricInput } from "@kagami/metric-client/client";
+import { describe, expect, it } from "vitest";
+import {
+  MetricAuthUsageSnapshotSink,
+  OAUTH_QUOTA_REFRESH_SUCCESS_METRIC,
+  OAUTH_QUOTA_REMAINING_PERCENT_METRIC,
+} from "../src/app/metric-auth-usage-snapshot-sink.js";
+
+function capturing(): { client: MetricClient; calls: RecordMetricInput[] } {
+  const calls: RecordMetricInput[] = [];
+  const client: MetricClient = {
+    record: input => {
+      calls.push(input);
+      return Promise.resolve();
+    },
+  };
+  return { client, calls };
+}
+
+describe("MetricAuthUsageSnapshotSink", () => {
+  it("maps a window snapshot to the remaining_percent metric with provider/window tags", () => {
+    const { client, calls } = capturing();
+    const sink = new MetricAuthUsageSnapshotSink({ metricClient: client });
+    const capturedAt = new Date("2026-07-08T10:00:00.000Z");
+
+    sink.record({
+      provider: "claude-code",
+      window: "five_hour",
+      remainingPercent: 75,
+      capturedAt,
+    });
+
+    expect(calls).toEqual([
+      {
+        metricName: OAUTH_QUOTA_REMAINING_PERCENT_METRIC,
+        value: 75,
+        tags: { provider: "claude-code", window: "five_hour" },
+        occurredAt: capturedAt,
+      },
+    ]);
+  });
+
+  it("maps refresh outcome to the refresh_success metric (1 success / 0 failure)", () => {
+    const { client, calls } = capturing();
+    const sink = new MetricAuthUsageSnapshotSink({ metricClient: client });
+
+    sink.recordRefreshOutcome({ provider: "openai-codex", success: true });
+    sink.recordRefreshOutcome({ provider: "openai-codex", success: false });
+
+    expect(
+      calls.map(call => ({ name: call.metricName, value: call.value, tags: call.tags })),
+    ).toEqual([
+      { name: OAUTH_QUOTA_REFRESH_SUCCESS_METRIC, value: 1, tags: { provider: "openai-codex" } },
+      { name: OAUTH_QUOTA_REFRESH_SUCCESS_METRIC, value: 0, tags: { provider: "openai-codex" } },
+    ]);
+  });
+});

--- a/packages/auth/src/application/auth-usage-cache.impl.service.ts
+++ b/packages/auth/src/application/auth-usage-cache.impl.service.ts
@@ -21,6 +21,10 @@ import type { ClaudeCodeProviderAuth } from "../claude-code/types.js";
 import type { CodexProviderAuth } from "../codex/types.js";
 import { AppLogger } from "@kagami/kernel/logger/logger";
 import { serializeError } from "@kagami/kernel/logger/serializer";
+import {
+  NOOP_AUTH_USAGE_SNAPSHOT_SINK,
+  type AuthUsageSnapshotSink,
+} from "./auth-usage-snapshot-sink.js";
 import type { ClaudeCodeAuthService } from "./claude-code-auth.service.js";
 import type { CodexAuthService } from "./codex-auth.service.js";
 
@@ -46,6 +50,7 @@ type AuthUsageCacheManagerDeps = {
   codexAuthService: CodexAuthService;
   codexBinaryPath: string;
   authUsageSnapshotDao?: AuthUsageSnapshotDao;
+  authUsageSnapshotSink?: AuthUsageSnapshotSink;
   refreshIntervalMs?: number;
   fetchClaudeUsageLimits?: (auth: ClaudeCodeProviderAuth) => Promise<ClaudeCodeUsageLimitsResponse>;
   fetchCodexUsageLimits?: (
@@ -64,6 +69,7 @@ export class AuthUsageCacheManager {
   private readonly codexAuthService: CodexAuthService;
   private readonly codexBinaryPath: string;
   private readonly authUsageSnapshotDao: AuthUsageSnapshotDao | null;
+  private readonly authUsageSnapshotSink: AuthUsageSnapshotSink;
   public readonly refreshIntervalMs: number;
   private readonly fetchClaudeUsageLimits: (
     auth: ClaudeCodeProviderAuth,
@@ -81,6 +87,7 @@ export class AuthUsageCacheManager {
     codexAuthService,
     codexBinaryPath,
     authUsageSnapshotDao,
+    authUsageSnapshotSink,
     refreshIntervalMs,
     fetchClaudeUsageLimits,
     fetchCodexUsageLimits,
@@ -89,6 +96,7 @@ export class AuthUsageCacheManager {
     this.codexAuthService = codexAuthService;
     this.codexBinaryPath = codexBinaryPath;
     this.authUsageSnapshotDao = authUsageSnapshotDao ?? null;
+    this.authUsageSnapshotSink = authUsageSnapshotSink ?? NOOP_AUTH_USAGE_SNAPSHOT_SINK;
     this.refreshIntervalMs = refreshIntervalMs ?? DEFAULT_REFRESH_INTERVAL_MS;
     this.fetchClaudeUsageLimits = fetchClaudeUsageLimits ?? fetchClaudeCodeUsageLimitsFromApi;
     this.fetchCodexUsageLimits = fetchCodexUsageLimits ?? fetchCodexUsageLimitsViaAppServer;
@@ -128,13 +136,36 @@ export class AuthUsageCacheManager {
       }
 
       const capturedAt = new Date();
-      this.claudeCodeUsageLimits = await this.fetchClaudeUsageLimits(auth);
-      await this.recordClaudeCodeSnapshots({
-        auth,
-        limits: this.claudeCodeUsageLimits,
-        capturedAt,
-      });
+      // refresh_success 的语义是「采集（fetch）成败」，不含旧 DAO 双写：只有 fetch 抛错才算失败，
+      // 区分「采集挂了」与「没数据」（非 active / 未登录已早返回不发 outcome）。
+      let limits: ClaudeCodeUsageLimitsResponse;
+      try {
+        limits = await this.fetchClaudeUsageLimits(auth);
+      } catch (error) {
+        logger.warn("Failed to refresh Claude Code usage limits", {
+          event: "auth_usage_cache.claude_code_refresh_failed",
+          error: serializeError(error),
+        });
+        this.authUsageSnapshotSink.recordRefreshOutcome({
+          provider: "claude-code",
+          success: false,
+        });
+        return;
+      }
+      this.claudeCodeUsageLimits = limits;
+      this.authUsageSnapshotSink.recordRefreshOutcome({ provider: "claude-code", success: true });
+
+      // 旧 auth_usage_snapshot 双写失败不翻转 refresh_success（额度点已进 Metric）；仅记日志。#520 删。
+      try {
+        await this.recordClaudeCodeSnapshots({ auth, limits, capturedAt });
+      } catch (error) {
+        logger.warn("Failed to persist Claude Code usage snapshot", {
+          event: "auth_usage_cache.claude_code_snapshot_persist_failed",
+          error: serializeError(error),
+        });
+      }
     } catch (error) {
+      // 兜底非预期错误（如 getStatus 抛错）：fetch 未走到，不翻转 outcome。
       logger.warn("Failed to refresh Claude Code usage limits", {
         event: "auth_usage_cache.claude_code_refresh_failed",
         error: serializeError(error),
@@ -160,16 +191,35 @@ export class AuthUsageCacheManager {
       }
 
       const capturedAt = new Date();
-      this.codexUsageLimits = await this.fetchCodexUsageLimits({
-        auth,
-        binaryPath: this.codexBinaryPath,
-      });
-      await this.recordCodexSnapshots({
-        auth,
-        limits: this.codexUsageLimits,
-        capturedAt,
-      });
+      // 同 claude：refresh_success 只反映采集（fetch）成败。codex CLI 缺失会让 fetch 抛错 → success=0。
+      let limits: CodexUsageLimitsResponse;
+      try {
+        limits = await this.fetchCodexUsageLimits({ auth, binaryPath: this.codexBinaryPath });
+      } catch (error) {
+        logger.warn("Failed to refresh Codex usage limits", {
+          event: "auth_usage_cache.codex_refresh_failed",
+          error: serializeError(error),
+        });
+        this.authUsageSnapshotSink.recordRefreshOutcome({
+          provider: "openai-codex",
+          success: false,
+        });
+        return;
+      }
+      this.codexUsageLimits = limits;
+      this.authUsageSnapshotSink.recordRefreshOutcome({ provider: "openai-codex", success: true });
+
+      // 旧 auth_usage_snapshot 双写失败不翻转 refresh_success；仅记日志。#520 删。
+      try {
+        await this.recordCodexSnapshots({ auth, limits, capturedAt });
+      } catch (error) {
+        logger.warn("Failed to persist Codex usage snapshot", {
+          event: "auth_usage_cache.codex_snapshot_persist_failed",
+          error: serializeError(error),
+        });
+      }
     } catch (error) {
+      // 兜底非预期错误：fetch 未走到，不翻转 outcome。
       logger.warn("Failed to refresh Codex usage limits", {
         event: "auth_usage_cache.codex_refresh_failed",
         error: serializeError(error),
@@ -184,6 +234,23 @@ export class AuthUsageCacheManager {
     limits: ClaudeCodeUsageLimitsResponse;
     capturedAt: Date;
   }): Promise<void> {
+    // 先发 Metric（sink）：remaining_percent 不带 account 维度，故不受 accountId 缺失影响。
+    for (const [window, limit] of [
+      ["five_hour", input.limits.five_hour],
+      ["seven_day", input.limits.seven_day],
+    ] as const) {
+      if (!limit) {
+        continue;
+      }
+      this.authUsageSnapshotSink.record({
+        provider: "claude-code",
+        window,
+        remainingPercent: toRemainingPercent(limit.utilization),
+        capturedAt: input.capturedAt,
+      });
+    }
+
+    // 旧 auth_usage_snapshot 表双写（#517 阶段保留，供趋势图回滚；epic 收尾 #520 删）。
     if (!this.authUsageSnapshotDao) {
       return;
     }
@@ -225,6 +292,24 @@ export class AuthUsageCacheManager {
     limits: CodexUsageLimitsResponse;
     capturedAt: Date;
   }): Promise<void> {
+    // 先发 Metric（sink）：按 windowDurationMins 归一到 five_hour/seven_day，不带 account 维度。
+    for (const window of [input.limits.primary, input.limits.secondary]) {
+      if (!window) {
+        continue;
+      }
+      const windowKey = mapCodexWindowKey(window.windowDurationMins);
+      if (!windowKey) {
+        continue;
+      }
+      this.authUsageSnapshotSink.record({
+        provider: "openai-codex",
+        window: windowKey,
+        remainingPercent: toRemainingPercent(window.usedPercent),
+        capturedAt: input.capturedAt,
+      });
+    }
+
+    // 旧 auth_usage_snapshot 表双写（#517 阶段保留；#520 删）。
     if (!this.authUsageSnapshotDao) {
       return;
     }

--- a/packages/auth/src/application/auth-usage-snapshot-sink.ts
+++ b/packages/auth/src/application/auth-usage-snapshot-sink.ts
@@ -1,0 +1,36 @@
+// OAuth 额度遥测的下沉端口（epic #521）。packages/auth 是认证/额度领域包，Metric 是宿主应用的观测
+// 设施——领域包不该反向依赖 @kagami/metric-client。故这里只定义一个窄端口，由宿主（apps/llm）注入
+// Metric 实现；默认 noop，测试与未装配时零副作用。
+//
+// window / provider 取值故意在本文件自持（不引 @kagami/llm-api/auth-usage-trend）：那条趋势契约在
+// epic 收尾（#520）会被整条删除，sink 不该跟它耦合。
+
+export type AuthUsageMetricProvider = "claude-code" | "openai-codex";
+export type AuthUsageMetricWindow = "five_hour" | "seven_day";
+
+/** 一次成功采集里某个 (provider, window) 的额度剩余百分比快照。 */
+export type AuthUsageSnapshotSinkRecord = {
+  provider: AuthUsageMetricProvider;
+  window: AuthUsageMetricWindow;
+  /** 剩余百分比 0-100。 */
+  remainingPercent: number;
+  capturedAt: Date;
+};
+
+/** 一轮刷新对某 provider 的采集结果：success=false 用于区分「采集挂了」与「没数据」。 */
+export type AuthUsageRefreshOutcome = {
+  provider: AuthUsageMetricProvider;
+  success: boolean;
+};
+
+export interface AuthUsageSnapshotSink {
+  /** 上报某窗口的剩余额度。fire-and-forget，实现绝不 throw。 */
+  record(input: AuthUsageSnapshotSinkRecord): void;
+  /** 上报某 provider 本轮采集成功/失败。fire-and-forget，实现绝不 throw。 */
+  recordRefreshOutcome(input: AuthUsageRefreshOutcome): void;
+}
+
+export const NOOP_AUTH_USAGE_SNAPSHOT_SINK: AuthUsageSnapshotSink = {
+  record: () => undefined,
+  recordRefreshOutcome: () => undefined,
+};

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -5,6 +5,11 @@ import type { Database } from "@kagami/persistence/db/client";
 import { PrismaAuthUsageSnapshotDao } from "@kagami/persistence/dao/impl/auth-usage-snapshot.impl.dao";
 import { DefaultAuthUsageTrendQueryService } from "./application/auth-usage-trend-query.impl.service.js";
 import { AuthUsageCacheManager } from "./application/auth-usage-cache.impl.service.js";
+import type {
+  AuthUsageSnapshotSink,
+  AuthUsageSnapshotSinkRecord,
+  AuthUsageRefreshOutcome,
+} from "./application/auth-usage-snapshot-sink.js";
 import { OAuthAuthRefreshScheduler } from "./application/oauth-auth-refresh.scheduler.js";
 import {
   buildClaudeCodeAuthorizeUrl,
@@ -28,6 +33,8 @@ import { PrismaOAuthDao } from "./infra/prisma-oauth.dao.js";
 type AuthModuleDeps = {
   database: Database;
   configManager: ConfigManager;
+  // OAuth 额度遥测下沉端口（epic #521）。宿主（apps/llm）注入 Metric 实现；缺省 noop。
+  authUsageSnapshotSink?: AuthUsageSnapshotSink;
 };
 
 export type AuthModule = {
@@ -44,6 +51,7 @@ export type AuthModule = {
 export async function createAuthModule({
   database,
   configManager,
+  authUsageSnapshotSink,
 }: AuthModuleDeps): Promise<AuthModule> {
   const config = await configManager.config();
   const llmConfig = config.server.llm;
@@ -165,6 +173,7 @@ export async function createAuthModule({
     codexAuthService,
     codexBinaryPath: codexConfig.binaryPath,
     authUsageSnapshotDao,
+    authUsageSnapshotSink,
     refreshIntervalMs: llmConfig.authUsageRefreshIntervalMs,
   });
   codexAuthService.setUsageLimitsProvider(async () => {
@@ -199,3 +208,7 @@ export async function createAuthModule({
 // auth-scheduled-tasks（留在 agent 装配层，因它咬 agent 的 scheduler 领域类型）需要这两个
 // 类型来声明 buildAuthScheduledTasks 的入参，故从包顶层导出。
 export { AuthUsageCacheManager, OAuthAuthRefreshScheduler };
+
+// OAuth 额度遥测下沉端口：宿主（apps/llm）实现并注入 createAuthModule。本地转出（不用 re-export
+// from，仓库禁 export-from），类型在上方 import。
+export type { AuthUsageSnapshotSink, AuthUsageSnapshotSinkRecord, AuthUsageRefreshOutcome };

--- a/packages/auth/test/auth-usage-cache.impl.service.test.ts
+++ b/packages/auth/test/auth-usage-cache.impl.service.test.ts
@@ -15,6 +15,7 @@ import {
 } from "../src/application/auth-usage-cache.impl.service.js";
 import type { ClaudeCodeAuthService } from "../src/application/claude-code-auth.service.js";
 import type { CodexAuthService } from "../src/application/codex-auth.service.js";
+import type { AuthUsageSnapshotSink } from "../src/application/auth-usage-snapshot-sink.js";
 import { initTestLogger } from "./helpers/logger.js";
 
 const tempDirs: string[] = [];
@@ -590,6 +591,201 @@ process.stdin.on("data", chunk => {
       },
       secondary: null,
     });
+  });
+});
+
+describe("AuthUsageCacheManager sink emission (epic #521)", () => {
+  function createSink(): AuthUsageSnapshotSink {
+    return {
+      record: vi.fn(),
+      recordRefreshOutcome: vi.fn(),
+    };
+  }
+
+  it("emits remaining_percent per window for both providers and success outcomes", async () => {
+    const sink = createSink();
+    const manager = new AuthUsageCacheManager({
+      claudeCodeAuthService: createClaudeCodeAuthService(),
+      codexAuthService: createCodexAuthService(),
+      codexBinaryPath: "codex",
+      authUsageSnapshotSink: sink,
+      fetchClaudeUsageLimits: vi.fn().mockResolvedValue({
+        five_hour: { utilization: 25, resets_at: "2026-03-25T12:00:00.000Z" },
+        seven_day: { utilization: 40, resets_at: "2026-03-31T12:00:00.000Z" },
+        extra_usage: null,
+      } satisfies ClaudeCodeUsageLimitsResponse),
+      fetchCodexUsageLimits: vi.fn().mockResolvedValue({
+        primary: { usedPercent: 44, windowDurationMins: 300, resetsAt: 1_774_400_000_000 },
+        secondary: { usedPercent: 72, windowDurationMins: 10_080, resetsAt: 1_774_400_000_000 },
+      } satisfies CodexUsageLimitsResponse),
+    });
+
+    await manager.refreshAll();
+
+    expect(sink.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "claude-code",
+        window: "five_hour",
+        remainingPercent: 75,
+      }),
+    );
+    expect(sink.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "claude-code",
+        window: "seven_day",
+        remainingPercent: 60,
+      }),
+    );
+    expect(sink.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai-codex",
+        window: "five_hour",
+        remainingPercent: 56,
+      }),
+    );
+    expect(sink.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai-codex",
+        window: "seven_day",
+        remainingPercent: 28,
+      }),
+    );
+    expect(sink.recordRefreshOutcome).toHaveBeenCalledWith({
+      provider: "claude-code",
+      success: true,
+    });
+    expect(sink.recordRefreshOutcome).toHaveBeenCalledWith({
+      provider: "openai-codex",
+      success: true,
+    });
+  });
+
+  it("reports success=false when a fetch throws, and emits no remaining_percent for it", async () => {
+    const sink = createSink();
+    const manager = new AuthUsageCacheManager({
+      claudeCodeAuthService: createClaudeCodeAuthService(),
+      codexAuthService: createCodexAuthService({
+        getAuthWithoutRefresh: vi.fn().mockRejectedValue(new Error("missing auth")),
+      }),
+      codexBinaryPath: "codex",
+      authUsageSnapshotSink: sink,
+      fetchClaudeUsageLimits: vi.fn().mockRejectedValue(new Error("upstream down")),
+      fetchCodexUsageLimits: vi.fn(),
+    });
+
+    await manager.refreshAll();
+
+    expect(sink.recordRefreshOutcome).toHaveBeenCalledWith({
+      provider: "claude-code",
+      success: false,
+    });
+    expect(sink.record).not.toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "claude-code" }),
+    );
+  });
+
+  it("emits remaining_percent even when accountId is missing (metric has no account dimension)", async () => {
+    const sink = createSink();
+    const manager = new AuthUsageCacheManager({
+      claudeCodeAuthService: createClaudeCodeAuthService({
+        getAuthWithoutRefresh: vi.fn().mockResolvedValue({
+          accessToken: "claude-access-token",
+          refreshToken: "claude-refresh-token",
+          accountId: undefined,
+          email: "claude@example.com",
+          lastRefresh: "2026-03-25T00:00:00.000Z",
+          expiresAt: Date.now() + 60_000,
+        }),
+      }),
+      codexAuthService: createCodexAuthService({
+        getAuthWithoutRefresh: vi.fn().mockRejectedValue(new Error("missing auth")),
+      }),
+      codexBinaryPath: "codex",
+      authUsageSnapshotSink: sink,
+      fetchClaudeUsageLimits: vi.fn().mockResolvedValue({
+        five_hour: { utilization: 10, resets_at: "2026-03-25T12:00:00.000Z" },
+        seven_day: null,
+        extra_usage: null,
+      } satisfies ClaudeCodeUsageLimitsResponse),
+      fetchCodexUsageLimits: vi.fn(),
+    });
+
+    await manager.refreshAll();
+
+    expect(sink.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "claude-code",
+        window: "five_hour",
+        remainingPercent: 90,
+      }),
+    );
+  });
+
+  it("keeps refresh_success=true when only the legacy DAO write fails (fetch succeeded)", async () => {
+    const sink = createSink();
+    const manager = new AuthUsageCacheManager({
+      claudeCodeAuthService: createClaudeCodeAuthService(),
+      codexAuthService: createCodexAuthService({
+        getAuthWithoutRefresh: vi.fn().mockRejectedValue(new Error("missing auth")),
+      }),
+      codexBinaryPath: "codex",
+      authUsageSnapshotSink: sink,
+      // 旧表写失败：不该被误报成「采集失败」，metric 额度点已成功进 Metric。
+      authUsageSnapshotDao: createAuthUsageSnapshotDao({
+        insertBatch: vi.fn().mockRejectedValue(new Error("db down")),
+      }),
+      fetchClaudeUsageLimits: vi.fn().mockResolvedValue({
+        five_hour: { utilization: 25, resets_at: "2026-03-25T12:00:00.000Z" },
+        seven_day: null,
+        extra_usage: null,
+      } satisfies ClaudeCodeUsageLimitsResponse),
+      fetchCodexUsageLimits: vi.fn(),
+    });
+
+    await manager.refreshAll();
+
+    expect(sink.recordRefreshOutcome).toHaveBeenCalledWith({
+      provider: "claude-code",
+      success: true,
+    });
+    expect(sink.recordRefreshOutcome).not.toHaveBeenCalledWith({
+      provider: "claude-code",
+      success: false,
+    });
+    expect(sink.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "claude-code",
+        window: "five_hour",
+        remainingPercent: 75,
+      }),
+    );
+  });
+
+  it("does not emit a refresh outcome when the provider is not logged in", async () => {
+    const sink = createSink();
+    const manager = new AuthUsageCacheManager({
+      claudeCodeAuthService: createClaudeCodeAuthService({
+        getStatus: vi.fn().mockResolvedValue({
+          provider: "claude-code",
+          status: "logged_out",
+          isLoggedIn: false,
+          session: null,
+        }),
+      }),
+      codexAuthService: createCodexAuthService({
+        getAuthWithoutRefresh: vi.fn().mockRejectedValue(new Error("missing auth")),
+      }),
+      codexBinaryPath: "codex",
+      authUsageSnapshotSink: sink,
+      fetchClaudeUsageLimits: vi.fn(),
+      fetchCodexUsageLimits: vi.fn(),
+    });
+
+    await manager.refreshAll();
+
+    expect(sink.recordRefreshOutcome).not.toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "claude-code" }),
+    );
   });
 });
 


### PR DESCRIPTION
## 做了什么

把 Claude Code / Codex 的 OAuth 额度遥测打进通用 Metric（epic #521 第 2 步，双写不删旧）。

**架构**：`packages/auth` 不直接依赖 `@kagami/metric-client`（领域包不反向依赖观测设施），定义窄端口 `AuthUsageSnapshotSink`（默认 noop），`apps/llm` 注入 `MetricAuthUsageSnapshotSink`。

**打点**（fire-and-forget，10 分钟一轮，两 provider 两窗口）：
- `llm.oauth.quota.remaining_percent`（value=剩余% 0-100，tags `{provider, window}`）
- `llm.oauth.quota.refresh_success`（1/0，tag `{provider}`）——区分「没数据」与「采集挂了」

**语义**：`refresh_success` 只反映**采集（fetch）成败**——fetch 抛错（含 codex CLI 缺失）→ 0；未登录/非 active 早返回不发 outcome；旧 DAO 双写失败**不翻转** refresh_success（额度点已进 Metric，仅记日志）。`remaining_percent` 不带 account 维度，故 accountId 缺失也照发。旧 `auth_usage_snapshot` 表继续双写，#520 再删。

## Codex review

初版被 codex 抓到一个 P2：旧 DAO 双写失败会误报 `refresh_success=0`。已修——把 fetch 失败与 persist 失败分离，persist 失败只记日志、不翻转 outcome，并加回归测试。

## 测试

- 每窗口 remaining_percent + 两 provider success outcome
- fetch 失败 → success=0 且不发 remaining_percent
- accountId 缺失仍发 remaining_percent
- 未登录不发 outcome
- **DAO 写失败仍保持 success=true**（P2 回归）
- MetricAuthUsageSnapshotSink 事件→metric 映射
- 五件套全绿；全量 1429 测试通过。

Closes #517
Refs #521