### PR TITLE
refactor(web): 抽 series 显隐为共享 hook/组件，缓存图接入（补 #513 覆盖）

### DIFF
--- a/apps/web/src/components/metric/MetricChartView.tsx
+++ b/apps/web/src/components/metric/MetricChartView.tsx
@@ -1,5 +1,5 @@
 import { type MetricChartQueryResponse, type MetricChartSeries } from "@kagami/metric-api/chart";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import {
   Area,
   AreaChart,
@@ -22,6 +22,8 @@ import {
   type ChartConfig,
 } from "@/components/ui/chart";
 import { formatBucketLabel, formatCompactNumber, formatFullDateTime } from "./metric-format";
+import { SeriesLegend, type LegendSeries } from "./SeriesLegend";
+import { useSeriesVisibility } from "./useSeriesVisibility";
 
 // === 纯展示层：只吃 data / 查询状态 + 展示 props，不发请求、不持控件状态（#444）===
 //
@@ -98,10 +100,9 @@ export function MetricChartView({
   seriesMeta,
   height = 288,
 }: MetricChartViewProps) {
-  // 隐藏集按 series.key（语义 tag 值，如 "wait"/"qq"）记，是纯客户端展示开关，不触发重查。
-  // 不随 data 刷新重置——跨 range/bucket 保留隐藏态（key 语义稳定）；组件卸载/刷新页面自然复位。
-  const [hiddenKeys, setHiddenKeys] = useState<Set<string>>(() => new Set());
-  const toggleSeries = (key: string) => setHiddenKeys(prev => toggleHiddenKey(prev, key));
+  // 显隐走共享 hook（id = series.key，语义 tag 值如 "wait"/"qq"）：纯客户端展示开关、不触发重查，
+  // 跨 range/bucket 保留（key 语义稳定），刷新页面复位。同一套机器缓存图也在用。
+  const { hiddenIds, toggle, isHidden } = useSeriesVisibility();
 
   const renderSeries = useMemo<RenderSeries[]>(
     () =>
@@ -119,8 +120,13 @@ export function MetricChartView({
   // 可见集：仅在完整 renderSeries 上过滤——dataKey / color 已在 renderSeries 阶段按序号定死，
   // 这里绝不重新编号，否则隐藏中间项会让剩余序列串色 / 串 label。
   const visibleSeries = useMemo(
-    () => selectVisibleSeries(renderSeries, hiddenKeys),
-    [renderSeries, hiddenKeys],
+    () => selectVisibleSeries(renderSeries, hiddenIds),
+    [renderSeries, hiddenIds],
+  );
+  // 图例吃完整序列（含隐藏项），id = series.key，color 用 resolved 值（renderSeries.color）。
+  const legendSeries = useMemo<LegendSeries[]>(
+    () => renderSeries.map(item => ({ id: item.key, label: item.label, color: item.color })),
+    [renderSeries],
   );
   // config 按全量建：隐藏项恢复时其颜色 / label 仍可解析。
   const chartConfig = useMemo(() => buildChartConfig(renderSeries), [renderSeries]);
@@ -387,7 +393,7 @@ export function MetricChartView({
 
         {/* 图例独立于 recharts 图表树，只要有序列就常驻——全部隐藏时图表区换成占位、图例仍可点恢复。 */}
         {!isLoading && !isError && hasSeries ? (
-          <SeriesLegend series={renderSeries} hiddenKeys={hiddenKeys} onToggle={toggleSeries} />
+          <SeriesLegend series={legendSeries} isHidden={isHidden} onToggle={toggle} />
         ) : null}
 
         {!isLoading && !isError && hasRenderable && data ? (
@@ -403,58 +409,6 @@ export function MetricChartView({
       </CardContent>
     </Card>
   );
-}
-
-type SeriesLegendProps = {
-  /** 完整序列（含隐藏项，隐藏项也要在图例里才能点回来）。 */
-  series: RenderSeries[];
-  hiddenKeys: Set<string>;
-  onToggle: (key: string) => void;
-};
-
-/**
- * 交互式图例。吃完整 renderSeries，渲染在 recharts 图表树之外——这样「全部隐藏」时图表区换成占位、
- * 图例仍常驻可点。每项是 button（Tab 可达、Enter/Space 触发、aria-pressed 播报显隐），隐藏态灰显 +
- * label 删除线。样式对齐原 ChartLegendContent（居中、换行、色块 h-2 w-2）。
- */
-function SeriesLegend({ series, hiddenKeys, onToggle }: SeriesLegendProps) {
-  return (
-    <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1.5 pt-3">
-      {series.map(item => {
-        const hidden = hiddenKeys.has(item.key);
-        return (
-          <button
-            key={item.key}
-            type="button"
-            aria-pressed={!hidden}
-            onClick={() => onToggle(item.key)}
-            className={`flex cursor-pointer items-center gap-1.5 text-sm transition-opacity ${
-              hidden ? "opacity-40" : "opacity-100"
-            }`}
-          >
-            <span
-              className="h-2 w-2 shrink-0 rounded-[2px]"
-              style={{ backgroundColor: item.color }}
-            />
-            <span className={hidden ? "line-through" : undefined}>{item.label}</span>
-          </button>
-        );
-      })}
-    </div>
-  );
-}
-
-/**
- * 隐藏集切换：不可变返回新 Set（原地 add/delete 不会触发 React 重渲染）。
- */
-export function toggleHiddenKey(prev: Set<string>, key: string): Set<string> {
-  const next = new Set(prev);
-  if (next.has(key)) {
-    next.delete(key);
-  } else {
-    next.add(key);
-  }
-  return next;
 }
 
 /**

--- a/apps/web/src/components/metric/SeriesLegend.tsx
+++ b/apps/web/src/components/metric/SeriesLegend.tsx
@@ -1,0 +1,48 @@
+// === 共享交互式图例 ===
+//
+// 渲染在 recharts 图表树之外——这样「全部隐藏」时图表区换成占位、图例仍常驻可点恢复。每项是 button
+// （Tab 可达、Enter/Space 触发、aria-pressed 播报显隐），隐藏态灰显 + label 删除线。只消费传入的 color
+// 字符串（必须是 resolved 值，如 hsl(var(--llm))；`var(--color-*)` 在 ChartContainer 外不解析），
+// 不解析主题、不碰 chartConfig。样式对齐原 ChartLegendContent（居中、换行、色块 h-2 w-2）。
+
+export type LegendSeries = {
+  /** 稳定标识：MetricChartView 传 series.key，缓存图传固定 dataKey。 */
+  id: string;
+  label: string;
+  /** resolved 颜色字符串（如 hsl(var(--llm))）。 */
+  color: string;
+};
+
+type SeriesLegendProps = {
+  /** 完整序列（含隐藏项，隐藏项也要在图例里才能点回来）。 */
+  series: LegendSeries[];
+  isHidden: (id: string) => boolean;
+  onToggle: (id: string) => void;
+};
+
+export function SeriesLegend({ series, isHidden, onToggle }: SeriesLegendProps) {
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1.5 pt-3">
+      {series.map(item => {
+        const hidden = isHidden(item.id);
+        return (
+          <button
+            key={item.id}
+            type="button"
+            aria-pressed={!hidden}
+            onClick={() => onToggle(item.id)}
+            className={`flex cursor-pointer items-center gap-1.5 text-sm transition-opacity ${
+              hidden ? "opacity-40" : "opacity-100"
+            }`}
+          >
+            <span
+              className="h-2 w-2 shrink-0 rounded-[2px]"
+              style={{ backgroundColor: item.color }}
+            />
+            <span className={hidden ? "line-through" : undefined}>{item.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/metric/useSeriesVisibility.ts
+++ b/apps/web/src/components/metric/useSeriesVisibility.ts
@@ -1,0 +1,38 @@
+import { useCallback, useState } from "react";
+
+// === series 显隐的横切机器（与 query / axis / chartType 完全解耦）===
+//
+// 单查询多序列图（MetricChartView）与双轴 composed 图（DashboardCacheChart）主体不同，但「哪些序列可见」
+// 这套逻辑一致：一个按稳定 id 记的隐藏集 + 点击切换。抽在这里，两类图共享一份实现——加新的横切能力
+// （显隐属之）不必写两遍。id 是调用方给的稳定标识：MetricChartView 传 series.key（语义 tag 值），
+// 缓存图传固定 dataKey（"tokens" / "ratePct"）。hook 不认识这些 id 的来源，只管开关。
+
+/**
+ * 隐藏集切换：不可变返回新 Set（原地 add/delete 不会触发 React 重渲染）。
+ */
+export function toggleHiddenId(prev: Set<string>, id: string): Set<string> {
+  const next = new Set(prev);
+  if (next.has(id)) {
+    next.delete(id);
+  } else {
+    next.add(id);
+  }
+  return next;
+}
+
+export type SeriesVisibility = {
+  /** 当前隐藏的 id 集合（供 useMemo 依赖 / 过滤可见序列）。 */
+  hiddenIds: Set<string>;
+  toggle: (id: string) => void;
+  isHidden: (id: string) => boolean;
+};
+
+/**
+ * series 显隐状态。纯客户端展示开关，不触发重查；不随数据刷新重置——组件卸载 / 刷新页面自然复位。
+ */
+export function useSeriesVisibility(): SeriesVisibility {
+  const [hiddenIds, setHiddenIds] = useState<Set<string>>(() => new Set());
+  const toggle = useCallback((id: string) => setHiddenIds(prev => toggleHiddenId(prev, id)), []);
+  const isHidden = useCallback((id: string) => hiddenIds.has(id), [hiddenIds]);
+  return { hiddenIds, toggle, isHidden };
+}

--- a/apps/web/src/pages/dashboard/DashboardCacheChart.tsx
+++ b/apps/web/src/pages/dashboard/DashboardCacheChart.tsx
@@ -5,13 +5,13 @@ import {
   formatFullDateTime,
   formatMetricValue,
 } from "@/components/metric/metric-format";
+import { SeriesLegend, type LegendSeries } from "@/components/metric/SeriesLegend";
 import { useMetricChartData } from "@/components/metric/useMetricChartData";
 import { useMetricDerivedData } from "@/components/metric/useMetricDerivedData";
+import { useSeriesVisibility } from "@/components/metric/useSeriesVisibility";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   ChartContainer,
-  ChartLegend,
-  ChartLegendContent,
   ChartTooltip,
   ChartTooltipContent,
   type ChartConfig,
@@ -32,6 +32,12 @@ const chartConfig = {
   tokens: { label: "总输入 token", color: "hsl(var(--llm))" },
   ratePct: { label: "缓存命中率", color: "hsl(var(--story))" },
 } satisfies ChartConfig;
+
+// 图例吃固定 2 序列，id = dataKey；color 用 chartConfig 的 resolved 值（在 ChartContainer 外也解析）。
+const legendSeries: LegendSeries[] = [
+  { id: "tokens", label: chartConfig.tokens.label, color: chartConfig.tokens.color },
+  { id: "ratePct", label: chartConfig.ratePct.label, color: chartConfig.ratePct.color },
+];
 
 export function DashboardCacheChart({ range }: { range: DashboardRange }) {
   const totalQuery = useMetricChartData({
@@ -69,6 +75,13 @@ export function DashboardCacheChart({ range }: { range: DashboardRange }) {
     return hasBelow90 ? [0, 100] : [90, 100];
   }, [rows]);
 
+  // 显隐走共享 hook（id = 固定 dataKey "tokens"/"ratePct"）。隐藏某条时，连同其 Y 轴一起条件渲染掉，
+  // 避免留一根空轴误导（Codex 复核点）。
+  const { toggle, isHidden } = useSeriesVisibility();
+  const tokensHidden = isHidden("tokens");
+  const rateHidden = isHidden("ratePct");
+  const allHidden = tokensHidden && rateHidden;
+
   const isLoading = totalQuery.isLoading || rateQuery.isLoading;
   const isError = totalQuery.isError || rateQuery.isError;
   const errorMessage = totalQuery.isError
@@ -76,6 +89,7 @@ export function DashboardCacheChart({ range }: { range: DashboardRange }) {
     : rateQuery.isError
       ? getApiErrorMessage(rateQuery.error)
       : undefined;
+  const emptyMessage = allHidden ? "全部序列已隐藏，点图例恢复" : "当前时间范围内没有数据。";
   const placeholderClassName = "flex items-center justify-center rounded-none border border-dashed";
   const placeholderStyle = { height: CHART_HEIGHT };
 
@@ -104,29 +118,39 @@ export function DashboardCacheChart({ range }: { range: DashboardRange }) {
           </div>
         ) : null}
 
-        {!isLoading && !isError && rows.length > 0 ? (
+        {!isLoading && !isError && rows.length > 0 && allHidden ? (
+          <div className={placeholderClassName} style={placeholderStyle}>
+            <p className="text-sm text-muted-foreground">{emptyMessage}</p>
+          </div>
+        ) : null}
+
+        {!isLoading && !isError && rows.length > 0 && !allHidden ? (
           <ChartContainer className="w-full" style={{ height: CHART_HEIGHT }} config={chartConfig}>
             <ComposedChart data={rows} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
               <CartesianGrid vertical={false} />
               <XAxis dataKey="label" tickLine={false} axisLine={false} minTickGap={24} />
-              <YAxis
-                yAxisId="tokens"
-                width={56}
-                tickLine={false}
-                axisLine={false}
-                tickFormatter={(value: number | string) => formatCompactNumber(value)}
-              />
-              <YAxis
-                yAxisId="rate"
-                orientation="right"
-                width={44}
-                domain={rateDomain}
-                tickLine={false}
-                axisLine={false}
-                tickFormatter={(value: number | string) =>
-                  typeof value === "number" ? `${value}%` : String(value)
-                }
-              />
+              {!tokensHidden ? (
+                <YAxis
+                  yAxisId="tokens"
+                  width={56}
+                  tickLine={false}
+                  axisLine={false}
+                  tickFormatter={(value: number | string) => formatCompactNumber(value)}
+                />
+              ) : null}
+              {!rateHidden ? (
+                <YAxis
+                  yAxisId="rate"
+                  orientation="right"
+                  width={44}
+                  domain={rateDomain}
+                  tickLine={false}
+                  axisLine={false}
+                  tickFormatter={(value: number | string) =>
+                    typeof value === "number" ? `${value}%` : String(value)
+                  }
+                />
+              ) : null}
               <ChartTooltip
                 content={
                   <ChartTooltipContent
@@ -154,31 +178,38 @@ export function DashboardCacheChart({ range }: { range: DashboardRange }) {
                   />
                 }
               />
-              <ChartLegend content={<ChartLegendContent />} />
-              <Line
-                yAxisId="tokens"
-                type="linear"
-                dataKey="tokens"
-                name="总输入 token"
-                stroke="var(--color-tokens)"
-                strokeWidth={2}
-                dot={false}
-                connectNulls={false}
-                isAnimationActive={false}
-              />
-              <Line
-                yAxisId="rate"
-                type="linear"
-                dataKey="ratePct"
-                name="缓存命中率"
-                stroke="var(--color-ratePct)"
-                strokeWidth={2}
-                dot={false}
-                connectNulls
-                isAnimationActive={false}
-              />
+              {!tokensHidden ? (
+                <Line
+                  yAxisId="tokens"
+                  type="linear"
+                  dataKey="tokens"
+                  name="总输入 token"
+                  stroke="var(--color-tokens)"
+                  strokeWidth={2}
+                  dot={false}
+                  connectNulls={false}
+                  isAnimationActive={false}
+                />
+              ) : null}
+              {!rateHidden ? (
+                <Line
+                  yAxisId="rate"
+                  type="linear"
+                  dataKey="ratePct"
+                  name="缓存命中率"
+                  stroke="var(--color-ratePct)"
+                  strokeWidth={2}
+                  dot={false}
+                  connectNulls
+                  isAnimationActive={false}
+                />
+              ) : null}
             </ComposedChart>
           </ChartContainer>
+        ) : null}
+
+        {!isLoading && !isError && rows.length > 0 ? (
+          <SeriesLegend series={legendSeries} isHidden={isHidden} onToggle={toggle} />
         ) : null}
       </CardContent>
     </Card>

--- a/apps/web/test/metric-chart-view.test.ts
+++ b/apps/web/test/metric-chart-view.test.ts
@@ -3,7 +3,6 @@ import {
   buildChartRows,
   buildPieData,
   selectVisibleSeries,
-  toggleHiddenKey,
   type RenderSeries,
 } from "@/components/metric/MetricChartView";
 
@@ -26,25 +25,6 @@ describe("buildPieData 用解析后的 color", () => {
     const pie = buildPieData(renderSeries);
     expect(pie[0]?.fill).toBe("hsl(var(--scheduler))");
     expect(pie[0]?.value).toBe(10);
-  });
-});
-
-describe("toggleHiddenKey：不可变切换", () => {
-  it("缺则加、有则删", () => {
-    const empty = new Set<string>();
-    const added = toggleHiddenKey(empty, "wait");
-    expect(added.has("wait")).toBe(true);
-    const removed = toggleHiddenKey(added, "wait");
-    expect(removed.has("wait")).toBe(false);
-  });
-
-  it("返回新 Set，不原地改旧集（否则 React 不重渲染）", () => {
-    const prev = new Set<string>(["qq"]);
-    const next = toggleHiddenKey(prev, "wait");
-    expect(next).not.toBe(prev);
-    expect([...prev]).toEqual(["qq"]);
-    expect(next.has("qq")).toBe(true);
-    expect(next.has("wait")).toBe(true);
   });
 });
 

--- a/apps/web/test/series-visibility.test.ts
+++ b/apps/web/test/series-visibility.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { toggleHiddenId } from "@/components/metric/useSeriesVisibility";
+
+describe("toggleHiddenId：不可变切换", () => {
+  it("缺则加、有则删", () => {
+    const empty = new Set<string>();
+    const added = toggleHiddenId(empty, "tokens");
+    expect(added.has("tokens")).toBe(true);
+    const removed = toggleHiddenId(added, "tokens");
+    expect(removed.has("tokens")).toBe(false);
+  });
+
+  it("返回新 Set，不原地改旧集（否则 React 不重渲染）", () => {
+    const prev = new Set<string>(["ratePct"]);
+    const next = toggleHiddenId(prev, "tokens");
+    expect(next).not.toBe(prev);
+    expect([...prev]).toEqual(["ratePct"]);
+    expect(next.has("ratePct")).toBe(true);
+    expect(next.has("tokens")).toBe(true);
+  });
+});


### PR DESCRIPTION
## 做了什么

把 #513 的 series 显隐从 `MetricChartView` 里**抽成共享机器**，并让大盘「主 Agent 输入 token」缓存图接上——补平 #513 只覆盖 `MetricChartView` 系图表、缓存图漏掉的缺口。

方向经 Codex 复核：**共享横切能力，不共享整个组件**。双轴 composed 与单查询多序列主体各自保留，只把「哪些序列可见 + 交互图例」提出来。以后再加横切能力不必写两遍。

## 关键设计

- **新 `useSeriesVisibility` hook**：`{ hiddenIds, toggle, isHidden }`，纯客户端展示开关、不触发重查；**不认识 query/axis/chartType**，只按稳定 `id` 开关。
- **新 `SeriesLegend` 共享件**：模型中性 `{ id, label, color }`（Codex：别叫 `key`）；渲染在 recharts 树外 → 全隐藏时占位仍在、图例常驻可点；只消费 **resolved color 字符串**（`var(--color-*)` 在 ChartContainer 外不解析）。
- `MetricChartView`：改用共享 hook/legend（`id = series.key`），删内联实现，**行为零变化**。
- `DashboardCacheChart`（双 Y 轴 ComposedChart）接入：
  - 隐藏某序列时，其 `<Line>` **连同对应 `<YAxis>` 成对条件渲染掉**（Codex：不留空轴误导；也避免 dangling `yAxisId`）。
  - 两条都隐藏 → plot 占位「全部序列已隐藏，点图例恢复」，**图例仍可点恢复**。
  - 图例吃 `chartConfig.*.color`（resolved `hsl(var(--llm))`）。
- **不动 `chart.tsx`**：静态 `ChartLegend`/`ChartLegendContent` 还被 AuthPage 等用着，保留。
- `ChartShell`（外壳级抽象）**明确不做**，记为未来触发条件（第 3 张图 / 第二次改 chrome）。

## 测试 / 校验

- `toggleHiddenId` 不可变切换单测迁到新 `series-visibility.test.ts`；`selectVisibleSeries`/`buildChartRows`/`buildPieData` 过滤不串色测试保留。web 45 tests pass。
- 五件套全绿：build / typecheck / lint（0 error，仅 MetricChartView 存量 helper-export warn）/ format / knip（仅存量 warn）。
- Codex diff 复审 **VERDICT SHIP**。
- ⚠️ 未做真实浏览器交互验证（无 RTL/jsdom）：缓存图的 tooltip 排除隐藏项依赖 recharts 条件渲染（隐藏 Line 直接不渲染，天然不进 payload），逻辑层已保证。

Closes #524
Refs #513
