### PR TITLE
fix(auth): 额度大卡片韧性——抖动保留 last-known-good + 前端 keepPreviousData

### DIFF
--- a/apps/web/src/pages/auth/AuthPage.tsx
+++ b/apps/web/src/pages/auth/AuthPage.tsx
@@ -12,7 +12,7 @@ import { type ClaudeCodeUsageLimits } from "@kagami/llm-api/claude-code-auth";
 import { type CodexUsageLimits } from "@kagami/llm-api/codex-auth";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ExternalLink, KeyRound, LogOut, RefreshCcw, ShieldCheck, ShieldX } from "lucide-react";
-import { type ReactElement, useMemo, useState } from "react";
+import { type ReactElement, useEffect, useMemo, useState } from "react";
 import { Navigate, NavLink, useParams, useSearchParams } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import {
@@ -109,6 +109,8 @@ export function AuthPage() {
       queryKey: queryKeys.auth.usageLimits(providerConfig.key),
       queryFn: () =>
         authClient.getAuthUsageLimits({ params: { provider: providerConfig.key }, input: {} }),
+      // 一次采集/请求抖动不撤卡：保留上次成功数据，配合下方新鲜度提示（epic #521 卡片韧性）。
+      keepPrevious: true,
     }),
   });
   const usageTrendQuery = useQuery({
@@ -165,6 +167,13 @@ export function AuthPage() {
   const statusData = statusQuery.data ?? null;
   const primaryStatus = getPrimaryStatus(statusData);
   const warningMessage = getStatusWarningMessage(statusData);
+
+  // keepPreviousData 会在切 provider（新 query key）时先返回上一个 provider 的额度；按 provider 过滤，
+  // 避免 Codex 页短暂显示 Claude 的额度面板。切换途中无匹配数据即视为加载中。
+  const usageLimitsData =
+    usageLimitsQuery.data?.provider === providerConfig.key ? usageLimitsQuery.data : undefined;
+  const usageLimitsLoading =
+    usageLimitsQuery.isLoading || (usageLimitsQuery.isFetching && !usageLimitsData);
 
   if (shouldRedirect) {
     return <Navigate to="/auth/claude-code" replace />;
@@ -331,16 +340,22 @@ export function AuthPage() {
             </div>
           </div>
 
-          {usageLimitsQuery.isLoading ? (
+          {usageLimitsData ? (
+            <div className="mt-6 space-y-3">
+              <UsageFreshnessLine capturedAt={usageLimitsData.capturedAt} />
+              {usageLimitsQuery.isError ? (
+                <p className="rounded-none border border-scheduler bg-scheduler/10 px-3 py-2 text-xs text-muted-foreground">
+                  最近一次刷新失败，下面展示的是上一次成功的数据。
+                </p>
+              ) : null}
+              <UsageLimitsPanel data={usageLimitsData} />
+            </div>
+          ) : usageLimitsLoading ? (
             <p className="mt-6 text-sm text-muted-foreground">
               正在读取 {providerConfig.label} 额度...
             </p>
           ) : usageLimitsQuery.isError ? (
             <p className="mt-6 text-sm text-destructive">{usageLimitsQuery.error.message}</p>
-          ) : usageLimitsQuery.data ? (
-            <div className="mt-6">
-              <UsageLimitsPanel data={usageLimitsQuery.data} />
-            </div>
           ) : (
             <p className="mt-6 text-sm text-muted-foreground">暂无额度信息。</p>
           )}
@@ -396,6 +411,50 @@ function UsageLimitsPanel({ data }: { data: AuthUsageLimitsResponse }) {
   }
 
   return <CodexUsageLimitsPanel limits={data.limits} />;
+}
+
+// 采集周期是 10 分钟；超过 STALE 阈值（错过约 3 个周期）就提示「可能已过期」。
+const USAGE_STALE_THRESHOLD_MS = 30 * 60 * 1000;
+
+function UsageFreshnessLine({ capturedAt }: { capturedAt: string | null }) {
+  // staleness 依赖当前时间（render 期不能读 Date.now），放 effect 里算，并每分钟自刷。
+  const [isStale, setIsStale] = useState(false);
+  useEffect(() => {
+    if (!capturedAt) {
+      return;
+    }
+    const capturedMs = new Date(capturedAt).getTime();
+    if (Number.isNaN(capturedMs)) {
+      return;
+    }
+    const check = () => setIsStale(Date.now() - capturedMs > USAGE_STALE_THRESHOLD_MS);
+    check();
+    const timer = window.setInterval(check, 60_000);
+    return () => window.clearInterval(timer);
+  }, [capturedAt]);
+
+  if (!capturedAt) {
+    return null;
+  }
+
+  const captured = new Date(capturedAt);
+  if (Number.isNaN(captured.getTime())) {
+    return null;
+  }
+
+  const label = new Intl.DateTimeFormat("zh-CN", {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(captured);
+
+  return (
+    <p className={`text-xs ${isStale ? "font-medium text-foreground" : "text-muted-foreground"}`}>
+      更新于 {label}
+      {isStale ? " · 数据可能已过期" : ""}
+    </p>
+  );
 }
 
 function ClaudeUsageLimitsPanel({ limits }: { limits: ClaudeCodeUsageLimits }) {

--- a/packages/auth/src/application/auth-usage-cache.impl.service.ts
+++ b/packages/auth/src/application/auth-usage-cache.impl.service.ts
@@ -79,6 +79,9 @@ export class AuthUsageCacheManager {
   ) => Promise<CodexUsageLimitsResponse>;
   private claudeCodeUsageLimits = EMPTY_CLAUDE_CODE_USAGE_LIMITS;
   private codexUsageLimits = EMPTY_CODEX_USAGE_LIMITS;
+  // 上一次成功采集额度的时刻（供前端显示新鲜度）。仅在成功 fetch 时更新，登出清空时置 null。
+  private claudeCodeUsageCapturedAt: Date | null = null;
+  private codexUsageCapturedAt: Date | null = null;
   private isRefreshingClaudeCode = false;
   private isRefreshingCodex = false;
 
@@ -110,6 +113,14 @@ export class AuthUsageCacheManager {
     return this.codexUsageLimits;
   }
 
+  public getClaudeCodeUsageCapturedAt(): Date | null {
+    return this.claudeCodeUsageCapturedAt;
+  }
+
+  public getCodexUsageCapturedAt(): Date | null {
+    return this.codexUsageCapturedAt;
+  }
+
   public async refreshAll(): Promise<void> {
     await Promise.allSettled([this.refreshClaudeCodeUsageLimits(), this.refreshCodexUsageLimits()]);
   }
@@ -123,7 +134,9 @@ export class AuthUsageCacheManager {
     try {
       const status = await this.claudeCodeAuthService.getStatus();
       if (status.status !== "active") {
-        this.claudeCodeUsageLimits = EMPTY_CLAUDE_CODE_USAGE_LIMITS;
+        // 非 active 不再一律冲空：token 刷新窗口的 expired/refresh_failed 是瞬时态，清空会让卡片消失。
+        // 只有确无凭据（用户显式登出）才清；否则保留上次好值（卡片韧性，epic #521）。
+        await this.clearClaudeCodeUsageIfLoggedOut();
         return;
       }
 
@@ -131,7 +144,8 @@ export class AuthUsageCacheManager {
       try {
         auth = await this.claudeCodeAuthService.getAuthWithoutRefresh();
       } catch {
-        this.claudeCodeUsageLimits = EMPTY_CLAUDE_CODE_USAGE_LIMITS;
+        // 同上：瞬时读取失败保留上次好值，仅登出才清。
+        await this.clearClaudeCodeUsageIfLoggedOut();
         return;
       }
 
@@ -153,6 +167,7 @@ export class AuthUsageCacheManager {
         return;
       }
       this.claudeCodeUsageLimits = limits;
+      this.claudeCodeUsageCapturedAt = capturedAt;
       this.authUsageSnapshotSink.recordRefreshOutcome({ provider: "claude-code", success: true });
 
       // 旧 auth_usage_snapshot 双写失败不翻转 refresh_success（额度点已进 Metric）；仅记日志。#520 删。
@@ -186,7 +201,8 @@ export class AuthUsageCacheManager {
       try {
         auth = await this.codexAuthService.getAuthWithoutRefresh();
       } catch {
-        this.codexUsageLimits = EMPTY_CODEX_USAGE_LIMITS;
+        // 瞬时读取失败保留上次好值，仅登出（无凭据）才清（卡片韧性，epic #521）。
+        await this.clearCodexUsageIfLoggedOut();
         return;
       }
 
@@ -207,6 +223,7 @@ export class AuthUsageCacheManager {
         return;
       }
       this.codexUsageLimits = limits;
+      this.codexUsageCapturedAt = capturedAt;
       this.authUsageSnapshotSink.recordRefreshOutcome({ provider: "openai-codex", success: true });
 
       // 旧 auth_usage_snapshot 双写失败不翻转 refresh_success；仅记日志。#520 删。
@@ -226,6 +243,31 @@ export class AuthUsageCacheManager {
       });
     } finally {
       this.isRefreshingCodex = false;
+    }
+  }
+
+  // 显式清空（登出路径直调，立刻撤卡，不等下一轮后台刷新）。
+  public clearClaudeCodeUsage(): void {
+    this.claudeCodeUsageLimits = EMPTY_CLAUDE_CODE_USAGE_LIMITS;
+    this.claudeCodeUsageCapturedAt = null;
+  }
+
+  public clearCodexUsage(): void {
+    this.codexUsageLimits = EMPTY_CODEX_USAGE_LIMITS;
+    this.codexUsageCapturedAt = null;
+  }
+
+  // 登出判定 = hasCredentials 为假（凭据已删）。用它区分「用户登出」与「瞬时读取失败/expired」：
+  // 只有确无凭据才把额度缓存清空并撤 capturedAt，让卡片消失；有凭据的瞬时态一律保留上次好值。
+  private async clearClaudeCodeUsageIfLoggedOut(): Promise<void> {
+    if (!(await this.claudeCodeAuthService.hasCredentials())) {
+      this.clearClaudeCodeUsage();
+    }
+  }
+
+  private async clearCodexUsageIfLoggedOut(): Promise<void> {
+    if (!(await this.codexAuthService.hasCredentials())) {
+      this.clearCodexUsage();
     }
   }
 

--- a/packages/auth/src/http/auth.handler.ts
+++ b/packages/auth/src/http/auth.handler.ts
@@ -3,12 +3,14 @@ import { registerJsonRoute } from "@kagami/http/register";
 import { authApiContract } from "@kagami/llm-api/auth-contract";
 import { type AuthProvider } from "@kagami/llm-api/auth";
 import type { AuthUsageTrendQueryService } from "../application/auth-usage-trend-query.service.js";
+import type { AuthUsageCacheManager } from "../application/auth-usage-cache.impl.service.js";
 import { toInternalAuthProvider } from "../domain/auth-provider.js";
 import type { OAuthAuthService } from "../application/oauth-auth.service.js";
 
 type AuthHandlerDeps = {
   authServices: Record<AuthProvider, OAuthAuthService>;
   authUsageTrendQueryService: AuthUsageTrendQueryService;
+  authUsageCacheManager: AuthUsageCacheManager;
 };
 
 /**
@@ -19,10 +21,16 @@ type AuthHandlerDeps = {
 export class AuthHandler {
   private readonly authServices: Record<AuthProvider, OAuthAuthService>;
   private readonly authUsageTrendQueryService: AuthUsageTrendQueryService;
+  private readonly authUsageCacheManager: AuthUsageCacheManager;
 
-  public constructor({ authServices, authUsageTrendQueryService }: AuthHandlerDeps) {
+  public constructor({
+    authServices,
+    authUsageTrendQueryService,
+    authUsageCacheManager,
+  }: AuthHandlerDeps) {
     this.authServices = authServices;
     this.authUsageTrendQueryService = authUsageTrendQueryService;
+    this.authUsageCacheManager = authUsageCacheManager;
   }
 
   public register(app: FastifyInstance): void {
@@ -34,9 +42,16 @@ export class AuthHandler {
       this.authServices[params.provider].createLoginUrl(),
     );
 
-    registerJsonRoute(app, authApiContract.authLogout, ({ params }) =>
-      this.authServices[params.provider].logout(),
-    );
+    registerJsonRoute(app, authApiContract.authLogout, async ({ params }) => {
+      const result = await this.authServices[params.provider].logout();
+      // 登出即刻撤额度缓存，不等下一轮后台刷新（否则登出后前端 refetch 仍拿到旧卡，epic #521）。
+      if (params.provider === "codex") {
+        this.authUsageCacheManager.clearCodexUsage();
+      } else {
+        this.authUsageCacheManager.clearClaudeCodeUsage();
+      }
+      return result;
+    });
 
     registerJsonRoute(app, authApiContract.authRefresh, ({ params }) =>
       this.authServices[params.provider].refresh(),

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -102,6 +102,7 @@ export async function createAuthModule({
           primary: null,
           secondary: null,
         },
+        capturedAt: null,
       }) satisfies AuthUsageLimitsResponse,
   });
   codexCallbackServer.setAuthService(codexAuthService);
@@ -150,6 +151,7 @@ export async function createAuthModule({
           seven_day: null,
           extra_usage: null,
         },
+        capturedAt: null,
       }) satisfies AuthUsageLimitsResponse,
   });
   claudeCodeCallbackServer.setAuthService(claudeCodeAuthService);
@@ -180,12 +182,14 @@ export async function createAuthModule({
     return {
       provider: "codex",
       limits: await authUsageCacheManager.getCodexUsageLimits(),
+      capturedAt: authUsageCacheManager.getCodexUsageCapturedAt()?.toISOString() ?? null,
     };
   });
   claudeCodeAuthService.setUsageLimitsProvider(async () => {
     return {
       provider: "claude-code",
       limits: await authUsageCacheManager.getClaudeCodeUsageLimits(),
+      capturedAt: authUsageCacheManager.getClaudeCodeUsageCapturedAt()?.toISOString() ?? null,
     };
   });
   const authServices: AuthModule["authServices"] = {
@@ -200,6 +204,7 @@ export async function createAuthModule({
     authHandler: new AuthHandler({
       authServices,
       authUsageTrendQueryService,
+      authUsageCacheManager,
     }),
     callbackServers: [codexCallbackServer, claudeCodeCallbackServer],
   };

--- a/packages/auth/test/auth-usage-cache.impl.service.test.ts
+++ b/packages/auth/test/auth-usage-cache.impl.service.test.ts
@@ -145,7 +145,8 @@ describe("AuthUsageCacheManager", () => {
     );
   });
 
-  it("should clear the last successful Claude cache when auth becomes expired", async () => {
+  it("keeps the last successful Claude cache when auth becomes expired but creds remain (transient)", async () => {
+    // 卡片韧性（epic #521）：expired 是 token 刷新窗口的瞬时态，凭据还在 → 保留上次好值，不清空。
     const claudeCodeAuthService = createClaudeCodeAuthService({
       getStatus: vi
         .fn()
@@ -175,6 +176,8 @@ describe("AuthUsageCacheManager", () => {
             lastError: "expired",
           },
         }),
+      // 凭据仍在 = 瞬时态。
+      hasCredentials: vi.fn().mockResolvedValue(true),
     });
     const claudeFetch = vi.fn().mockResolvedValue({
       five_hour: {
@@ -198,17 +201,20 @@ describe("AuthUsageCacheManager", () => {
     await manager.refreshAll();
     expect(await manager.getClaudeCodeUsageLimits()).toEqual(
       expect.objectContaining({
-        five_hour: expect.objectContaining({
-          utilization: 19,
-        }),
+        five_hour: expect.objectContaining({ utilization: 19 }),
       }),
     );
 
     await manager.refreshAll();
-    expect(await manager.getClaudeCodeUsageLimits()).toEqual(EMPTY_CLAUDE_CODE_USAGE_LIMITS);
+    // 保留上次好值（不再冲成 EMPTY）。
+    expect(await manager.getClaudeCodeUsageLimits()).toEqual(
+      expect.objectContaining({
+        five_hour: expect.objectContaining({ utilization: 19 }),
+      }),
+    );
   });
 
-  it("should clear the Claude cache when credentials become unavailable", async () => {
+  it("clears the Claude cache on explicit logout (no credentials)", async () => {
     const claudeCodeAuthService = createClaudeCodeAuthService({
       getStatus: vi
         .fn()
@@ -231,6 +237,8 @@ describe("AuthUsageCacheManager", () => {
           isLoggedIn: false,
           session: null,
         }),
+      // 登出 = 凭据已删。
+      hasCredentials: vi.fn().mockResolvedValue(false),
     });
     const manager = new AuthUsageCacheManager({
       claudeCodeAuthService,
@@ -250,19 +258,14 @@ describe("AuthUsageCacheManager", () => {
     });
 
     await manager.refreshAll();
-    expect(await manager.getClaudeCodeUsageLimits()).toEqual(
-      expect.objectContaining({
-        five_hour: expect.objectContaining({
-          utilization: 19,
-        }),
-      }),
-    );
+    expect(manager.getClaudeCodeUsageCapturedAt()).not.toBeNull();
 
     await manager.refreshAll();
     expect(await manager.getClaudeCodeUsageLimits()).toEqual(EMPTY_CLAUDE_CODE_USAGE_LIMITS);
+    expect(manager.getClaudeCodeUsageCapturedAt()).toBeNull();
   });
 
-  it("should clear a cache when credentials become unavailable", async () => {
+  it("keeps the last successful Codex cache on a transient auth read failure (creds remain)", async () => {
     const getAuthWithoutRefresh = vi
       .fn()
       .mockResolvedValueOnce({
@@ -274,7 +277,7 @@ describe("AuthUsageCacheManager", () => {
         lastRefresh: "2026-03-25T00:00:00.000Z",
         expiresAt: Date.now() + 60_000,
       })
-      .mockRejectedValueOnce(new Error("missing auth"));
+      .mockRejectedValueOnce(new Error("transient read error"));
     const codexFetch = vi.fn().mockResolvedValue({
       primary: {
         usedPercent: 50,
@@ -290,6 +293,8 @@ describe("AuthUsageCacheManager", () => {
       }),
       codexAuthService: createCodexAuthService({
         getAuthWithoutRefresh,
+        // 凭据仍在 = 瞬时态。
+        hasCredentials: vi.fn().mockResolvedValue(true),
       }),
       codexBinaryPath: "codex",
       fetchClaudeUsageLimits: vi.fn(),
@@ -299,14 +304,84 @@ describe("AuthUsageCacheManager", () => {
     await manager.refreshAll();
     expect(await manager.getCodexUsageLimits()).toEqual(
       expect.objectContaining({
-        primary: expect.objectContaining({
-          usedPercent: 50,
-        }),
+        primary: expect.objectContaining({ usedPercent: 50 }),
       }),
     );
 
     await manager.refreshAll();
+    // 瞬时读取失败保留上次好值。
+    expect(await manager.getCodexUsageLimits()).toEqual(
+      expect.objectContaining({
+        primary: expect.objectContaining({ usedPercent: 50 }),
+      }),
+    );
+  });
+
+  it("clears the Codex cache on explicit logout (no credentials)", async () => {
+    const getAuthWithoutRefresh = vi
+      .fn()
+      .mockResolvedValueOnce({
+        accessToken: "codex-access-token",
+        refreshToken: "codex-refresh-token",
+        idToken: "codex-id-token",
+        accountId: "acct_123",
+        email: "codex@example.com",
+        lastRefresh: "2026-03-25T00:00:00.000Z",
+        expiresAt: Date.now() + 60_000,
+      })
+      .mockRejectedValueOnce(new Error("missing auth"));
+
+    const manager = new AuthUsageCacheManager({
+      claudeCodeAuthService: createClaudeCodeAuthService({
+        getAuthWithoutRefresh: vi.fn().mockRejectedValue(new Error("missing auth")),
+      }),
+      codexAuthService: createCodexAuthService({
+        getAuthWithoutRefresh,
+        hasCredentials: vi.fn().mockResolvedValue(false),
+      }),
+      codexBinaryPath: "codex",
+      fetchClaudeUsageLimits: vi.fn(),
+      fetchCodexUsageLimits: vi.fn().mockResolvedValue({
+        primary: {
+          usedPercent: 50,
+          windowDurationMins: 300,
+          resetsAt: 1_774_400_000_000,
+        },
+        secondary: null,
+      } satisfies CodexUsageLimitsResponse),
+    });
+
+    await manager.refreshAll();
+    expect(manager.getCodexUsageCapturedAt()).not.toBeNull();
+
+    await manager.refreshAll();
     expect(await manager.getCodexUsageLimits()).toEqual(EMPTY_CODEX_USAGE_LIMITS);
+    expect(manager.getCodexUsageCapturedAt()).toBeNull();
+  });
+
+  it("clearClaudeCodeUsage empties the cache immediately (logout endpoint path)", async () => {
+    // 登出路由直调 clearClaudeCodeUsage()，不等下一轮后台刷新即撤卡。
+    const manager = new AuthUsageCacheManager({
+      claudeCodeAuthService: createClaudeCodeAuthService(),
+      codexAuthService: createCodexAuthService({
+        getAuthWithoutRefresh: vi.fn().mockRejectedValue(new Error("missing auth")),
+      }),
+      codexBinaryPath: "codex",
+      fetchClaudeUsageLimits: vi.fn().mockResolvedValue({
+        five_hour: { utilization: 19, resets_at: "2026-03-25T12:00:00.000Z" },
+        seven_day: null,
+        extra_usage: null,
+      } satisfies ClaudeCodeUsageLimitsResponse),
+      fetchCodexUsageLimits: vi.fn(),
+    });
+
+    await manager.refreshAll();
+    expect(manager.getClaudeCodeUsageCapturedAt()).not.toBeNull();
+
+    manager.clearClaudeCodeUsage();
+
+    expect(await manager.getClaudeCodeUsageLimits()).toEqual(EMPTY_CLAUDE_CODE_USAGE_LIMITS);
+    expect(manager.getClaudeCodeUsageCapturedAt()).toBeNull();
   });
 
   it("should skip snapshot writes when account id is missing", async () => {

--- a/packages/llm-api/src/auth.ts
+++ b/packages/llm-api/src/auth.ts
@@ -120,17 +120,21 @@ export const ClaudeCodeUsageLimitsSchema = z
 
 export type ClaudeCodeUsageLimits = z.infer<typeof ClaudeCodeUsageLimitsSchema>;
 
+// capturedAt = 上一次成功采集额度的时刻（ISO），从未采集过则 null。前端据此显示「更新于 X / 可能过期」，
+// 并让「一次抖动不撤卡」有据可依（epic #521 卡片韧性）。
 export const AuthUsageLimitsResponseSchema = z.discriminatedUnion("provider", [
   z
     .object({
       provider: z.literal("codex"),
       limits: CodexUsageLimitsSchema,
+      capturedAt: z.string().datetime().nullable(),
     })
     .strict(),
   z
     .object({
       provider: z.literal("claude-code"),
       limits: ClaudeCodeUsageLimitsSchema,
+      capturedAt: z.string().datetime().nullable(),
     })
     .strict(),
 ]);


### PR DESCRIPTION
## 做了什么

修内置登录页两张额度大卡片「一次采集/请求抖动就整块消失」的问题（epic #521）。根因是缺「上次好值」兜底。不引入 Metric（卡片要准实时 + 保留 Extra Usage）。

**后端（AuthUsageCacheManager）**
- 非 active（expired/refresh_failed）与 getAuth 瞬时失败不再冲成 EMPTY；用 `hasCredentials` 判定「是否登出」——仅确无凭据（显式登出）才清空并撤 `capturedAt`，瞬时态保留上次好值。
- 记录 `capturedAt`（上次成功采集时刻），经 `getUsageLimits` 透出到 wire（`AuthUsageLimitsResponse` 加 `capturedAt: ISO | null`）。
- **登出即刻撤卡**：logout 路由直调 `clearXxxUsage()`，不等下一轮 10 分钟刷新（codex review 修复）。

**前端（AuthPage）**
- `usageLimitsQuery` 开 `keepPrevious`：一次请求失败不撤卡，顶部弱提示「展示上次数据」。
- 新增新鲜度行「更新于 X」，超 30 分钟标「数据可能已过期」，每分钟自刷。
- 按 `provider` 过滤 keepPreviousData，切 tab 不串 provider（codex review 修复）。

## Codex review

抓到 3 点：① 登出不即时清缓存 → 已改 logout 路由直调清空；② keepPreviousData 切 provider 串数据 → 已加 provider 过滤；③ 长期 expired 无限保留旧数据 → 这是「last-known-good」的预期行为，配 30 分钟过期文案，符合本 issue「防一次抖动」的目标，保留。

## 测试

- expired（有凭据）保留；显式登出（无凭据）清空 + capturedAt 置 null（claude + codex）
- 瞬时 auth 读取失败保留；`clearClaudeCodeUsage` 立即清空
- 五件套全绿；全量 1445 测试通过。

Closes #518
Refs #521