### PR TITLE
fix(gateway): 网关放行 /metric/points 到 metric 进程

### DIFF
--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -29,10 +29,10 @@ const CONSOLE_PATH_PREFIXES = [
 ];
 // 这些前缀路由到 kagami-llm 进程（OAuth 凭据中心）：认证管理端点已随 LLM 服务外移。
 const LLM_PATH_PREFIXES = ["/auth"];
-// metric 图表查询（POST /metric/query）与派生查询（POST /metric/derive，#475 P3）走独立的 metric
-// 进程（@kagami/metric）；摄取端点 /metric/record 不经网关（agent 直连），故这里只逐个列查询/派生
-// 端点而非整个 /metric 前缀（#444）。
-const METRIC_PATH_PREFIXES = ["/metric/query", "/metric/derive"];
+// metric 图表查询（POST /metric/query）、派生查询（POST /metric/derive，#475 P3）与 raw 原始点查询
+// （POST /metric/points，epic #521）走独立的 metric 进程（@kagami/metric）；摄取端点 /metric/record
+// 不经网关（agent 直连），故这里只逐个列查询端点而非整个 /metric 前缀（#444）。
+const METRIC_PATH_PREFIXES = ["/metric/query", "/metric/derive", "/metric/points"];
 // 管理台对象浏览器只读面路由到 kagami-oss 进程。仅 /oss-object（列表 / 统计 / 预览字节）过网关；
 // 写操作前缀 /objects（put/delete）刻意不在此，浏览器经网关够不到 OSS 的任何写路由。
 const OSS_PATH_PREFIXES = ["/oss-object"];


### PR DESCRIPTION
## Bug

epic #521 给 metric 加了 raw 原始点查询 `POST /metric/points`（#516），额度页趋势图（#519）经 `metricClient.points` 消费它。但网关 `METRIC_PATH_PREFIXES` 白名单是逐个列端点（`/metric/query`、`/metric/derive`），**漏了 `/metric/points`** → 前端经网关 `/api/metric/points` 不匹配 metric 规则、fall through 到默认 agent → **404**。

（直连 metric 服务 20010 是 200；只有经网关 20004 才 404，因此上线后才暴露。）

## 修复

`METRIC_PATH_PREFIXES` 加入 `/metric/points`。

## 验证

修复+重载 gateway 后，`POST http://localhost:20004/api/metric/points` 正常返回（不再 404）。gateway 单服务重载，不动 agent 热状态。

Refs #521