### PR TITLE
refactor(gateway): 统一 metric 路由为整段 /metric 前缀，放行摄取端点

### DIFF
--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -29,10 +29,11 @@ const CONSOLE_PATH_PREFIXES = [
 ];
 // 这些前缀路由到 kagami-llm 进程（OAuth 凭据中心）：认证管理端点已随 LLM 服务外移。
 const LLM_PATH_PREFIXES = ["/auth"];
-// metric 图表查询（POST /metric/query）、派生查询（POST /metric/derive，#475 P3）与 raw 原始点查询
-// （POST /metric/points，epic #521）走独立的 metric 进程（@kagami/metric）；摄取端点 /metric/record
-// 不经网关（agent 直连），故这里只逐个列查询端点而非整个 /metric 前缀（#444）。
-const METRIC_PATH_PREFIXES = ["/metric/query", "/metric/derive", "/metric/points"];
+// 整个 /metric 前缀路由到独立的 metric 进程（@kagami/metric）：查询（POST /metric/query）、
+// 派生（POST /metric/derive）、raw 原始点（POST /metric/points）与摄取（POST /metric/record）。
+// 内网单用户部署无安全边界考量，故不再逐个列查询端点、把写入端点排除在外（早期 #444 的做法），
+// 统一整段前缀放行——新增 /metric 子端点无需再同步维护此白名单。
+const METRIC_PATH_PREFIXES = ["/metric"];
 // 管理台对象浏览器只读面路由到 kagami-oss 进程。仅 /oss-object（列表 / 统计 / 预览字节）过网关；
 // 写操作前缀 /objects（put/delete）刻意不在此，浏览器经网关够不到 OSS 的任何写路由。
 const OSS_PATH_PREFIXES = ["/oss-object"];


### PR DESCRIPTION
## 背景

gateway 对 metric 一直是「选择性路由」：`METRIC_PATH_PREFIXES` 只逐个列查询端点（`/metric/query`、`/metric/derive`、`/metric/points`），把摄取端点 `/metric/record` 刻意排除在外（#444），理由是 agent 直连、走网关有安全边界考量。

内网单用户部署没有安全边界考量，这层特殊处理没有必要。

## 改动

`METRIC_PATH_PREFIXES` 收敛为 `["/metric"]`，整段前缀统一放行到 metric 进程。metric 进程暴露的四个端点（record / query / derive / points）全部落在此前缀下，从此都能经网关到达。

## 好处

- 去掉「新增经网关消费的 metric 端点必须同步加白名单」这份维护负担（#521 漏加、#532 补的那类问题不再发生）。
- agent 侧摄取仍直连 metric 进程，本次只是让网关也能到达 `record`，不影响既有链路。

## 自检

- KV 缓存：不涉及 agent 上下文/前缀，无影响。
- 提交前五件套（build / typecheck / lint / format / knip）全部通过。