### PR TITLE
chore(config): 测试占位键名 tavily 改中性 demoProvider

### DIFF
--- a/packages/config/test/source.test.ts
+++ b/packages/config/test/source.test.ts
@@ -61,7 +61,7 @@ describe("assertSecretShape", () => {
   it("accepts a plain-object secret (any paths allowed — no whitelist)", () => {
     expect(() =>
       assertSecretShape(
-        { services: { agent: { port: 9999 } }, server: { tavily: { apiKey: "x" } } },
+        { services: { agent: { port: 9999 } }, server: { demoProvider: { apiKey: "x" } } },
         "config.secret.yaml",
       ),
     ).not.toThrow();
@@ -95,8 +95,8 @@ describe("resolveSecretConfigPath", () => {
 describe("loadMergedRawConfig", () => {
   it("merges config.yaml with config.secret.yaml (secret wins)", async () => {
     const configPath = await writeFiles({
-      "config.yaml": "server:\n  tavily:\n    apiKey: base\n  keep: base-only\n",
-      "config.secret.yaml": "server:\n  tavily:\n    apiKey: secret\n",
+      "config.yaml": "server:\n  demoProvider:\n    apiKey: base\n  keep: base-only\n",
+      "config.secret.yaml": "server:\n  demoProvider:\n    apiKey: secret\n",
     });
 
     const { raw } = await loadMergedRawConfig({
@@ -104,7 +104,7 @@ describe("loadMergedRawConfig", () => {
       secret: { required: true },
     });
 
-    expect(raw).toEqual({ server: { tavily: { apiKey: "secret" }, keep: "base-only" } });
+    expect(raw).toEqual({ server: { demoProvider: { apiKey: "secret" }, keep: "base-only" } });
   });
 
   it("throws CONFIG_SECRET_NOT_FOUND when the secret file is missing and required", async () => {


### PR DESCRIPTION
把 `packages/config/test/source.test.ts` 里的 `server.tavily` 示例键改成中性的 `demoProvider`。

该键只是 config 深合并 / 密钥优先覆盖测试的**任意示例**（换成任何名字测试语义都不变），与已下线的 tavily 无任何关联。改名后全仓 `rg -i tavily` 0 命中，避免以后 grep 误以为还有 tavily 残留。

纯测试改动，`pnpm --filter @kagami/config test` 14/14 通过。