### PR TITLE
refactor(agent): 删除工具返回中「已进入上下文」类自我解说 note

### DIFF
--- a/apps/agent/src/agent/apps/amap/tools/static-map.tool.ts
+++ b/apps/agent/src/agent/apps/amap/tools/static-map.tool.ts
@@ -154,9 +154,6 @@ export class StaticMapTool extends ZodToolComponent<typeof Schema> {
       content: JSON.stringify({
         ok: true,
         ...(resid ? { resid } : {}),
-        note: resid
-          ? "静态地图已进入你的上下文；已存档，可用 send_resource 转发或 read_resource 重看。"
-          : "静态地图已进入你的上下文（本次未落 OSS，无 resid）。",
       }),
       effects: [appendEffect],
     };

--- a/apps/agent/src/agent/capabilities/atelier/tools/generate.tool.ts
+++ b/apps/agent/src/agent/capabilities/atelier/tools/generate.tool.ts
@@ -77,9 +77,6 @@ export function createAtelierGenerateTool({
           ok: true,
           ...(resid ? { resid } : {}),
           ...(result.revisedPrompt ? { revised_prompt: result.revisedPrompt } : {}),
-          note: resid
-            ? "图生成好了，已进入你的视野，也存了档（resid 见上，可用 send_resource 发出去）。"
-            : "图生成好了，已进入你的视野（本次未落 OSS，无 resid）。",
         });
         return {
           content,

--- a/apps/agent/src/agent/capabilities/browser/tools/screenshot.tool.ts
+++ b/apps/agent/src/agent/capabilities/browser/tools/screenshot.tool.ts
@@ -65,9 +65,6 @@ export class BrowserScreenshotTool extends BrowserToolComponent<typeof Schema> {
         ok: true,
         url: shot.url,
         ...(resid ? { resid } : {}),
-        note: resid
-          ? "截图原图已进入你的上下文；已存档，可用 send_resource 转发或 read_resource 重看。"
-          : "截图原图已进入你的上下文（本次未落 OSS，无 resid）。",
       }),
       effects: [appendEffect],
     };

--- a/apps/agent/src/agent/capabilities/resource/tools/read-resource.tool.ts
+++ b/apps/agent/src/agent/capabilities/resource/tools/read-resource.tool.ts
@@ -90,7 +90,6 @@ export class ReadResourceTool extends ZodToolComponent<typeof ReadResourceArgume
         resid: resolved.resId,
         mime: resolved.mimeType,
         size: resolved.size,
-        note: "资源原图已作为下一条消息进入你的上下文。",
       }),
       effects: [appendEffect],
     };


### PR DESCRIPTION
## 背景

工具返回的 JSON 里塞了一批「原图已进入你的上下文；已存档，可用 send_resource 转发或 read_resource 重看」这类自我解说散文，每轮都进 LLM 上下文，对模型没有控制流价值——`resid` 本身就是转发/重看的句柄。

## 改动

删掉 4 处工具返回的 `note` 字段：

- `browser/screenshot`
- `amap/static-map`
- `atelier/generate`
- `resource/read-resource`（仅图片分支）

返回只保留 `ok`/`url`/`resid`/`mime`/`size` 等结构字段。

**保留**：`read_resource` 非图片分支的 note——它承载「未加载进上下文、原因是非图片」的控制流信息，删了模型会干等一张不来的图。

## 验证

build / typecheck / lint(0 error) / format / knip 全过；无测试断言这些 note 原文。