### PR TITLE
feat(agent): 上下文压缩新增图片数触发条件（>550 张也触发摘要）

### DIFF
--- a/apps/agent/src/agent/runtime/context/context-compaction.ts
+++ b/apps/agent/src/agent/runtime/context/context-compaction.ts
@@ -9,11 +9,19 @@ export type ContextCompactionPlan = {
 
 export function createContextCompactionPlan(input: {
   messages: LlmMessage[];
-  totalTokens: number;
+  /** null = 本轮 usage 缺失（provider 未回报），此时仅按图片数触发。 */
+  totalTokens: number | null;
   totalTokenThreshold: number;
+  imageCountThreshold: number;
 }): ContextCompactionPlan | null {
-  const { messages, totalTokens, totalTokenThreshold } = input;
-  if (messages.length === 0 || totalTokens <= totalTokenThreshold) {
+  const { messages, totalTokens, totalTokenThreshold, imageCountThreshold } = input;
+  if (messages.length === 0) {
+    return null;
+  }
+
+  const exceedsTokenThreshold = totalTokens !== null && totalTokens > totalTokenThreshold;
+  const exceedsImageThreshold = countImageContentParts(messages) > imageCountThreshold;
+  if (!exceedsTokenThreshold && !exceedsImageThreshold) {
     return null;
   }
 
@@ -30,6 +38,21 @@ export function createContextCompactionPlan(input: {
     messagesToSummarize: messages.slice(0, cutIndex),
     messagesToKeep: messages.slice(cutIndex),
   };
+}
+
+function countImageContentParts(messages: LlmMessage[]): number {
+  let count = 0;
+  for (const message of messages) {
+    if (message.role !== "user" || typeof message.content === "string") {
+      continue;
+    }
+    for (const part of message.content) {
+      if (part.type === "image") {
+        count += 1;
+      }
+    }
+  }
+  return count;
 }
 
 function calculateCompactionKeepCount(input: { totalMessageCount: number }): number {

--- a/apps/agent/src/agent/runtime/root-agent/root-agent-runtime.ts
+++ b/apps/agent/src/agent/runtime/root-agent/root-agent-runtime.ts
@@ -79,6 +79,7 @@ type RootAgentRuntimeDeps = {
   agentTools?: ToolExecutor;
   contextSummarizer?: ContextSummarizerLike;
   contextCompactionTotalTokenThreshold?: number;
+  contextCompactionImageCountThreshold?: number;
   metricService?: MetricClient;
   llmRetryBackoffMs?: number;
   loopExtensions?: RootLoopExtension[];
@@ -92,6 +93,8 @@ const DEFAULT_IDLE_WAKE_MAX_WAIT_MS = 600_000;
 /** 摘要超轮失败后，阈值压缩的冷却时长：期间不再每轮重试，防成本放大。 */
 const SUMMARY_MAX_ROUNDS_COOLDOWN_MS = 600_000;
 const DEFAULT_CONTEXT_COMPACTION_TOTAL_TOKEN_THRESHOLD = 150_000;
+/** 图片是按张计费的重上下文成分，与 token 阈值并列的第二触发条件。 */
+const DEFAULT_CONTEXT_COMPACTION_IMAGE_COUNT_THRESHOLD = 550;
 const DEFAULT_DASHBOARD_CONTEXT_LIMIT = 40;
 const DEFAULT_DASHBOARD_PREVIEW_LENGTH = 160;
 const logger = new AppLogger({ source: "agent.root-agent-runtime" });
@@ -137,6 +140,7 @@ export class RootAgentHost implements RootAgentExtensionHost {
   private readonly runtimeKey: string;
   private readonly contextSummarizer?: ContextSummarizerLike;
   private readonly contextCompactionTotalTokenThreshold: number;
+  private readonly contextCompactionImageCountThreshold: number;
   private readonly llmRetryBackoffMs: number;
   private readonly metricService: MetricClient;
   private readonly now: () => Date;
@@ -163,6 +167,7 @@ export class RootAgentHost implements RootAgentExtensionHost {
     runtimeKey,
     contextSummarizer,
     contextCompactionTotalTokenThreshold,
+    contextCompactionImageCountThreshold,
     metricService,
     llmRetryBackoffMs,
     now,
@@ -181,6 +186,8 @@ export class RootAgentHost implements RootAgentExtensionHost {
     this.contextSummarizer = contextSummarizer;
     this.contextCompactionTotalTokenThreshold =
       contextCompactionTotalTokenThreshold ?? DEFAULT_CONTEXT_COMPACTION_TOTAL_TOKEN_THRESHOLD;
+    this.contextCompactionImageCountThreshold =
+      contextCompactionImageCountThreshold ?? DEFAULT_CONTEXT_COMPACTION_IMAGE_COUNT_THRESHOLD;
     this.metricService = metricService ?? NOOP_METRIC_CLIENT;
     this.llmRetryBackoffMs = llmRetryBackoffMs ?? DEFAULT_LLM_RETRY_BACKOFF_MS;
     this.now = now ?? (() => new Date());
@@ -407,23 +414,25 @@ export class RootAgentHost implements RootAgentExtensionHost {
       return false;
     }
 
+    // totalTokens 缺失时不整体跳过：token 阈值判不了，但图片数阈值仍可判（图片数
+    // 直接数消息列表即可，不依赖 provider 回报的 usage）。
     if (typeof totalTokens !== "number") {
       try {
-        logger.warn("Skipping context summary because totalTokens is missing", {
+        logger.warn("Context summary token trigger unavailable because totalTokens is missing", {
           event: "agent.root_agent_runtime.context_summary_skipped_missing_total_tokens",
         });
       } catch {
         // Ignore logger runtime setup gaps in tests and early boot.
       }
-      return false;
     }
 
     while (true) {
       const snapshot = await this.context.getSnapshot();
       const compactionPlan = createContextCompactionPlan({
         messages: snapshot.messages,
-        totalTokens,
+        totalTokens: typeof totalTokens === "number" ? totalTokens : null,
         totalTokenThreshold: this.contextCompactionTotalTokenThreshold,
+        imageCountThreshold: this.contextCompactionImageCountThreshold,
       });
       if (!compactionPlan) {
         return false;

--- a/apps/agent/src/app/agent-runtime.factory.ts
+++ b/apps/agent/src/app/agent-runtime.factory.ts
@@ -404,6 +404,7 @@ export async function buildAgentRuntime({
     tools: rootAgentTools,
     contextSummarizer: summaryTaskAgent,
     contextCompactionTotalTokenThreshold: config.server.agent.contextCompactionTotalTokenThreshold,
+    contextCompactionImageCountThreshold: config.server.agent.contextCompactionImageCountThreshold,
     metricService,
     llmRetryBackoffMs: config.server.agent.llmRetryBackoffMs,
     // 纯文本轮挂起的自唤醒兜底与 wait 工具共用同一个上限，语义一致：Agent 最多

--- a/apps/agent/test/agent/context-compaction.test.ts
+++ b/apps/agent/test/agent/context-compaction.test.ts
@@ -1,6 +1,20 @@
 import { describe, expect, it } from "vitest";
 import { createContextCompactionPlan } from "../../src/agent/runtime/context/context-compaction.js";
 import { createUserMessage } from "../../src/agent/runtime/context/context-message-factory.js";
+import type { LlmMessage } from "@kagami/llm-client";
+
+const IMAGE_COUNT_THRESHOLD = 550;
+
+function createImageUserMessage(imageCount: number): LlmMessage {
+  return {
+    role: "user",
+    content: Array.from({ length: imageCount }, (_, index) => ({
+      type: "image" as const,
+      content: `base64-${String(index)}`,
+      mimeType: "image/png",
+    })),
+  };
+}
 
 describe("createContextCompactionPlan", () => {
   it("returns null when total tokens do not exceed the threshold", () => {
@@ -9,6 +23,7 @@ describe("createContextCompactionPlan", () => {
         messages: [createUserMessage("alpha")],
         totalTokens: 100,
         totalTokenThreshold: 100,
+        imageCountThreshold: IMAGE_COUNT_THRESHOLD,
       }),
     ).toBeNull();
   });
@@ -19,11 +34,79 @@ describe("createContextCompactionPlan", () => {
         messages: [createUserMessage("alpha")],
         totalTokens: 101,
         totalTokenThreshold: 100,
+        imageCountThreshold: IMAGE_COUNT_THRESHOLD,
       }),
     ).toEqual({
       messagesToSummarize: [createUserMessage("alpha")],
       messagesToKeep: [],
     });
+  });
+
+  it("triggers on image count even when total tokens stay below the threshold", () => {
+    const messages = [createImageUserMessage(IMAGE_COUNT_THRESHOLD + 1)];
+
+    expect(
+      createContextCompactionPlan({
+        messages,
+        totalTokens: 100,
+        totalTokenThreshold: 100,
+        imageCountThreshold: IMAGE_COUNT_THRESHOLD,
+      }),
+    ).toEqual({
+      messagesToSummarize: messages,
+      messagesToKeep: [],
+    });
+  });
+
+  it("counts images across multiple user messages and ignores text-only content", () => {
+    const messages = [
+      createUserMessage("text-only"),
+      createImageUserMessage(300),
+      createImageUserMessage(250),
+    ];
+
+    expect(
+      createContextCompactionPlan({
+        messages,
+        totalTokens: 100,
+        totalTokenThreshold: 100,
+        imageCountThreshold: IMAGE_COUNT_THRESHOLD,
+      }),
+    ).toBeNull();
+
+    const overMessages = [...messages, createImageUserMessage(1)];
+    expect(
+      createContextCompactionPlan({
+        messages: overMessages,
+        totalTokens: 100,
+        totalTokenThreshold: 100,
+        imageCountThreshold: IMAGE_COUNT_THRESHOLD,
+      }),
+    ).not.toBeNull();
+  });
+
+  it("triggers on image count when total tokens are unavailable", () => {
+    const messages = [createImageUserMessage(IMAGE_COUNT_THRESHOLD + 1)];
+
+    expect(
+      createContextCompactionPlan({
+        messages,
+        totalTokens: null,
+        totalTokenThreshold: 100,
+        imageCountThreshold: IMAGE_COUNT_THRESHOLD,
+      }),
+    ).not.toBeNull();
+  });
+
+  it("returns null when total tokens are unavailable and image count is within the threshold", () => {
+    expect(
+      createContextCompactionPlan({
+        messages: [createUserMessage("alpha")],
+        totalTokens: null,
+        totalTokenThreshold: 100,
+        imageCountThreshold: IMAGE_COUNT_THRESHOLD,
+      }),
+    ).toBeNull();
   });
 
   it("includes the matching tool result when the cut lands on an assistant tool call", () => {
@@ -46,6 +129,7 @@ describe("createContextCompactionPlan", () => {
         messages,
         totalTokens: 100,
         totalTokenThreshold: 1,
+        imageCountThreshold: IMAGE_COUNT_THRESHOLD,
       }),
     ).toEqual({
       messagesToSummarize: messages,
@@ -87,6 +171,7 @@ describe("createContextCompactionPlan", () => {
         messages,
         totalTokens: 100,
         totalTokenThreshold: 1,
+        imageCountThreshold: IMAGE_COUNT_THRESHOLD,
       }),
     ).toEqual({
       messagesToSummarize: messages.slice(0, -1),

--- a/apps/napcat/test/napcat-gateway.test-helper.ts
+++ b/apps/napcat/test/napcat-gateway.test-helper.ts
@@ -116,6 +116,7 @@ export function createConfigManager(): ConfigManager {
       databaseUrl: "file::memory:",
       agent: {
         contextCompactionTotalTokenThreshold: 150_000,
+        contextCompactionImageCountThreshold: 550,
         llmRetryBackoffMs: 30_000,
         waitToolMaxWaitMs: 600_000,
         stateSampleIntervalMs: 2_000,

--- a/config.yaml
+++ b/config.yaml
@@ -32,6 +32,7 @@ server:
   databaseUrl: file:./data/sqlite/kagami.db # SQLite 库文件，相对仓库根；运行时与 Prisma CLI 解析为绝对路径
   agent:
     contextCompactionTotalTokenThreshold: 600000
+    contextCompactionImageCountThreshold: 550 # 上下文图片总数超过该值也触发摘要压缩（图片按张吃上下文，与 token 阈值并列的第二触发条件）
     llmRetryBackoffMs: 30000
     waitToolMaxWaitMs: 600000
     stateSampleIntervalMs: 2000 # 状态心跳采样间隔：每这么久采一次「小镜此刻处于哪个 App / wait / portal」，打 agent.state.sample metric

--- a/packages/kernel/src/config/config.loader.ts
+++ b/packages/kernel/src/config/config.loader.ts
@@ -7,6 +7,7 @@ import type { LlmUsageId } from "../contracts/llm.js";
 
 const DEFAULT_NAPCAT_STARTUP_CONTEXT_RECENT_MESSAGE_COUNT = 40;
 const DEFAULT_AGENT_CONTEXT_COMPACTION_TOTAL_TOKEN_THRESHOLD = 150_000;
+const DEFAULT_AGENT_CONTEXT_COMPACTION_IMAGE_COUNT_THRESHOLD = 550;
 const DEFAULT_AGENT_LLM_RETRY_BACKOFF_MS = 30_000;
 const DEFAULT_AGENT_WAIT_TOOL_MAX_WAIT_MS = 10 * 60 * 1000;
 const DEFAULT_AGENT_STATE_SAMPLE_INTERVAL_MS = 2_000;
@@ -260,6 +261,9 @@ const ConfigSchema = z.object({
           contextCompactionTotalTokenThreshold: PositiveIntSchema.default(
             DEFAULT_AGENT_CONTEXT_COMPACTION_TOTAL_TOKEN_THRESHOLD,
           ),
+          contextCompactionImageCountThreshold: PositiveIntSchema.default(
+            DEFAULT_AGENT_CONTEXT_COMPACTION_IMAGE_COUNT_THRESHOLD,
+          ),
           llmRetryBackoffMs: PositiveIntSchema.default(DEFAULT_AGENT_LLM_RETRY_BACKOFF_MS),
           waitToolMaxWaitMs: PositiveIntSchema.default(DEFAULT_AGENT_WAIT_TOOL_MAX_WAIT_MS),
           stateSampleIntervalMs: PositiveIntSchema.default(DEFAULT_AGENT_STATE_SAMPLE_INTERVAL_MS),
@@ -311,6 +315,7 @@ const ConfigSchema = z.object({
         })
         .transform(value => ({
           contextCompactionTotalTokenThreshold: value.contextCompactionTotalTokenThreshold,
+          contextCompactionImageCountThreshold: value.contextCompactionImageCountThreshold,
           llmRetryBackoffMs: value.llmRetryBackoffMs,
           waitToolMaxWaitMs: value.waitToolMaxWaitMs,
           stateSampleIntervalMs: value.stateSampleIntervalMs,


### PR DESCRIPTION
## 背景

主 Agent 上下文压缩此前只有 token 总量一个触发条件。图片按张吃上下文（且部分 provider 有单请求图片数上限），纯 token 阈值感知不到图片堆积。

## 改动

- `createContextCompactionPlan` 新增 `imageCountThreshold` 参数：统计消息列表中 user 消息的 image content part 总数，超过阈值即触发压缩，与 token 条件取**或**。
- 新配置 `server.agent.contextCompactionImageCountThreshold`（默认 550），kernel schema / config.yaml / factory / runtime 全链路透传，与 `contextCompactionTotalTokenThreshold` 同款范式。
- `compactContextIfNeeded` 在 `totalTokens` 缺失时不再整体跳过：降级为仅按图片数判定（图片数直接数消息列表，不依赖 provider 回报的 usage），warn 日志文案同步调整。

## KV 缓存自检

- 只是新增一个触发条件，压缩本身仍走既有 `replace_leading_messages` Effect 的计划性重建路径，未新增第二种破坏前缀的路径。
- 无进上下文的散文改动（配置注释与 log 不进 LLM 上下文）。

## 验证

- `pnpm build` / `typecheck` / `lint` / `format` / `knip` 全过（lint 3 条为存量前端 warning）。
- 全量测试 202 文件 / 1303 用例通过；`context-compaction.test.ts` 新增 4 个图片触发用例（含 totalTokens 缺失场景与跨消息累计）。