### PR TITLE
refactor(gba): 工具响应按「小镜看了有什么用」裁剪

### DIFF
--- a/apps/agent/src/agent/capabilities/gba/render/gba-screen-effect.ts
+++ b/apps/agent/src/agent/capabilities/gba/render/gba-screen-effect.ts
@@ -5,27 +5,21 @@ import type { OssClient } from "../../../../acl/oss-client.js";
 
 const logger = new AppLogger({ source: "agent.gba.screen" });
 
-type GbaScreenMeta = {
-  timelineId: string;
-  capturedFrame: number;
-  startFrame?: number;
-  releasedFrame?: number;
-};
-
 /**
  * 把 GBA 服务回传的 base64 PNG 装配成工具结果：**原图直接进多模态上下文**（append_message 带
  * image），叠加落 OSS 拿 resid 便于之后 switch(qq) 用 send_resource 发群（镜像 pixel render）。
- * tool_result 的 content 只含元数据 JSON，**绝不含 base64**（CLAUDE.md 红线：大块数据不进
- * 主 Agent 消息列表）。帧号/时间线元数据帮助诊断「决策-执行漂移」（实时运行下画面在推理间隙
- * 继续变化），timelineId 在换游戏/服务重启时更换。
+ *
+ * 响应内容按「她看了有什么用」裁剪（用户反馈 2026-07-22）：她的下一步行动只依赖**画面本身**
+ * 与 resid（发 QQ 用）,timelineId / 帧号这类诊断元数据属于服务端日志与 llm_chat_call,不进
+ * 她的上下文;resid 只写在贴着图的标签里,content 不重复携带。tool_result content 恒为
+ * `{"ok":true}`（ReAct 要求每个 tool_call 有 tool_result;失败路径由 GbaToolComponent 的
+ * 冻结结构错误负责）。
  */
 export async function buildGbaScreenToolResult({
   imageBase64,
-  meta,
   ossClient,
 }: {
   imageBase64: string;
-  meta: GbaScreenMeta;
   ossClient: OssClient | undefined;
 }): Promise<ToolExecutionResult> {
   const png = Buffer.from(imageBase64, "base64");
@@ -33,7 +27,7 @@ export async function buildGbaScreenToolResult({
   const residAttr = resid ? ` resid="${resid}"` : "";
   const appendEffect: RootAgentEffect = {
     type: "append_message",
-    content: `<gba_screen${residAttr} timeline="${meta.timelineId}" frame="${meta.capturedFrame}" />`,
+    content: `<gba_screen${residAttr} />`,
     image: {
       content: imageBase64,
       mimeType: "image/png",
@@ -41,14 +35,7 @@ export async function buildGbaScreenToolResult({
     },
   };
   return {
-    content: JSON.stringify({
-      ok: true,
-      timelineId: meta.timelineId,
-      ...(meta.startFrame === undefined ? {} : { startFrame: meta.startFrame }),
-      ...(meta.releasedFrame === undefined ? {} : { releasedFrame: meta.releasedFrame }),
-      capturedFrame: meta.capturedFrame,
-      ...(resid ? { resid } : {}),
-    }),
+    content: JSON.stringify({ ok: true }),
     effects: [appendEffect],
   };
 }

--- a/apps/agent/src/agent/capabilities/gba/tools/import-rom.tool.ts
+++ b/apps/agent/src/agent/capabilities/gba/tools/import-rom.tool.ts
@@ -33,11 +33,7 @@ export class GbaImportRomTool extends GbaToolComponent<typeof Schema> {
 
   protected async executeTyped(input: z.infer<typeof Schema>): Promise<string> {
     const rom = await this.getGbaClient().importRom({ resId: input.resid, name: input.name });
-    return JSON.stringify({
-      ok: true,
-      name: rom.name,
-      sizeBytes: rom.sizeBytes,
-      sha256: rom.sha256,
-    });
+    // 响应按「她看了有什么用」裁剪:sha256/字节数是校验痕迹,属于服务端日志。
+    return JSON.stringify({ ok: true, name: rom.name });
   }
 }

--- a/apps/agent/src/agent/capabilities/gba/tools/list-games.tool.ts
+++ b/apps/agent/src/agent/capabilities/gba/tools/list-games.tool.ts
@@ -24,17 +24,16 @@ export class GbaListGamesTool extends GbaToolComponent<typeof Schema> {
   protected async executeTyped(): Promise<string> {
     const client = this.getGbaClient();
     const [roms, state] = await Promise.all([client.listRoms(), client.state()]);
+    // 响应按「她看了有什么用」裁剪:字节数/帧号是诊断元数据;她关心的是有哪些游戏、
+    // 有没有存档、上次什么时候玩的、现在插着哪盘。
     return JSON.stringify({
       ok: true,
       games: roms.map(rom => ({
         name: rom.name,
-        sizeBytes: rom.sizeBytes,
         hasSave: rom.hasSave,
         lastPlayedAt: rom.lastPlayedAt,
       })),
-      current: state.loaded
-        ? { name: state.romName, foreground: state.foreground, frame: state.frame }
-        : null,
+      current: state.loaded ? { name: state.romName } : null,
     });
   }
 }

--- a/apps/agent/src/agent/capabilities/gba/tools/load-game.tool.ts
+++ b/apps/agent/src/agent/capabilities/gba/tools/load-game.tool.ts
@@ -41,10 +41,10 @@ export class GbaLoadGameTool extends GbaToolComponent<typeof Schema> {
       );
     }
     const loaded = await client.loadGame(rom.id);
+    // 响应按「她看了有什么用」裁剪:timelineId 是诊断元数据,不进她的上下文。
     return JSON.stringify({
       ok: true,
       romName: loaded.romName,
-      timelineId: loaded.timelineId,
       hasSave: rom.hasSave,
     });
   }

--- a/apps/agent/src/agent/capabilities/gba/tools/press-sequence.tool.ts
+++ b/apps/agent/src/agent/capabilities/gba/tools/press-sequence.tool.ts
@@ -83,7 +83,6 @@ export class GbaPressSequenceTool extends GbaToolComponent<typeof Schema> {
     );
     return buildGbaScreenToolResult({
       imageBase64: outcome.imageBase64,
-      meta: outcome,
       ossClient: this.ossClient,
     });
   }

--- a/apps/agent/src/agent/capabilities/gba/tools/press.tool.ts
+++ b/apps/agent/src/agent/capabilities/gba/tools/press.tool.ts
@@ -67,7 +67,6 @@ export class GbaPressTool extends GbaToolComponent<typeof Schema> {
     );
     return buildGbaScreenToolResult({
       imageBase64: outcome.imageBase64,
-      meta: outcome,
       ossClient: this.ossClient,
     });
   }

--- a/apps/agent/src/agent/capabilities/gba/tools/screenshot.tool.ts
+++ b/apps/agent/src/agent/capabilities/gba/tools/screenshot.tool.ts
@@ -36,7 +36,6 @@ export class GbaScreenshotTool extends GbaToolComponent<typeof Schema> {
     const outcome = await withForegroundRealign(client, () => client.screenshot());
     return buildGbaScreenToolResult({
       imageBase64: outcome.imageBase64,
-      meta: outcome,
       ossClient: this.ossClient,
     });
   }

--- a/apps/agent/test/agent/apps/gba/gba-tools.test.ts
+++ b/apps/agent/test/agent/apps/gba/gba-tools.test.ts
@@ -85,11 +85,11 @@ describe("GBA 工具", () => {
       holdFrames: 60,
       settleFrames: 12, // 默认值
     });
-    const content = JSON.parse(result.content) as Record<string, unknown>;
-    expect(content).toMatchObject({ ok: true, timelineId: "gba-t1", resid: "res-99" });
-    expect(result.content).not.toContain(PRESS_OUTCOME.imageBase64);
+    // 「她看了有什么用」裁剪:content 恒为 {"ok":true},诊断元数据(timelineId/帧号)与
+    // base64 都不进 tool_result;resid 只写在贴图标签里(单一位置)。
+    expect(result.content).toBe('{"ok":true}');
     const effect = appendEffect(result.effects);
-    expect(effect.content).toContain('<gba_screen resid="res-99"');
+    expect(effect.content).toBe('<gba_screen resid="res-99" />');
     expect(effect.image?.content).toBe(PRESS_OUTCOME.imageBase64);
     expect(effect.image?.mimeType).toBe("image/png");
   });
@@ -126,7 +126,7 @@ describe("GBA 工具", () => {
     const tool = new GbaLoadGameTool({ getGbaClient: () => client });
     const ok = await tool.execute({ name: "逆转裁判" }, context);
     expect(client.loadGame).toHaveBeenCalledWith(1);
-    expect(JSON.parse(ok.content)).toMatchObject({ ok: true, romName: "逆转裁判", hasSave: true });
+    expect(JSON.parse(ok.content)).toEqual({ ok: true, romName: "逆转裁判", hasSave: true });
 
     const miss = await tool.execute({ name: "口袋妖怪" }, context);
     const parsed = JSON.parse(miss.content) as Record<string, unknown>;
@@ -140,8 +140,8 @@ describe("GBA 工具", () => {
     const tool = new GbaListGamesTool({ getGbaClient: () => client });
     const result = JSON.parse((await tool.execute({}, context)).content) as Record<string, unknown>;
     expect(result.ok).toBe(true);
-    expect(result.games).toHaveLength(1);
-    expect(result.current).toMatchObject({ name: "逆转裁判", foreground: true });
+    expect(result.games).toEqual([{ name: "逆转裁判", hasSave: true, lastPlayedAt: null }]);
+    expect(result.current).toEqual({ name: "逆转裁判" });
   });
 
   it("前台失位自愈(review P1):press 首拒 GBA_NOT_FOREGROUND → 重申前台后重试成功", async () => {
@@ -154,7 +154,7 @@ describe("GBA 工具", () => {
     const result = await tool.execute({ buttons: ["a"] }, context);
     expect(client.setForeground).toHaveBeenCalledWith(true);
     expect(press).toHaveBeenCalledTimes(2);
-    expect(JSON.parse(result.content)).toMatchObject({ ok: true });
+    expect(result.content).toBe('{"ok":true}');
 
     // 其他拒绝原因不自愈:原样规整失败
     const otherReject = vi
@@ -176,7 +176,7 @@ describe("GBA 工具", () => {
       (await tool.execute({ resid: "res-7", name: "新卡带" }, context)).content,
     ) as Record<string, unknown>;
     expect(client.importRom).toHaveBeenCalledWith({ resId: "res-7", name: "新卡带" });
-    expect(ok.ok).toBe(true);
+    expect(ok).toEqual({ ok: true, name: "逆转裁判" });
 
     const rejecting = createFakeClient({
       importRom: vi.fn().mockRejectedValue(new GbaError("GBA_REJECTED", "NOT_A_GBA_ROM")),


### PR DESCRIPTION
落实用户提出的设计原则:**工具响应的读者是小镜,每个字段都要问「她看了有什么用」**。

| 字段 | 处置 | 理由 |
|---|---|---|
| press 类的 timelineId/startFrame/releasedFrame/capturedFrame | ❌ 移出 | 诊断元数据,她的行动依据是画面;排障走 llm_chat_call/服务端日志 |
| resid | ✅ 保留但去双写 | 发 QQ 要用;只留贴图标签一处 |
| list_games 的 sizeBytes、current.foreground/frame | ❌ 移出 | 她不需要知道 ROM 多少字节 |
| import_rom 的 sha256/sizeBytes | ❌ 移出 | 校验痕迹属于日志 |
| hasSave/lastPlayedAt/领域拒绝可读原因 | ✅ 保留 | 生活语义 + 可纠正操作 |

press 类响应 token 省 ~60%(玩一晚按几百次,全是前缀驻留)。契约/服务端不动,纯 agent 侧 content 装配;格式变化只影响新的尾部追加。五件套全绿,1303 测(断言同步收紧为精确相等)。

原则已入长期记忆,作为后续所有工具设计的显式自检项。