### PR TITLE
refactor(gba): 契约源头清除无读者字段——timelineId/帧号/sha256 整体退场

### DIFF
--- a/apps/agent/src/acl/gba-client.ts
+++ b/apps/agent/src/acl/gba-client.ts
@@ -21,36 +21,15 @@ export type GbaRomView = z.infer<typeof GbaRomViewSchema>;
 /** 序列一步（holdFrames/gapFrames 已解析,client 层不吃 zod 默认值——工具层补齐后递交）。 */
 export type GbaPressStepInput = z.infer<typeof GbaPressStepSchema>;
 
-/** press/press_sequence 成功结果（截图 + 时间线元数据）。 */
-export type GbaPressOutcome = {
-  timelineId: string;
-  startFrame: number;
-  releasedFrame: number;
-  capturedFrame: number;
-  imageBase64: string;
-};
-
-export type GbaScreenshotOutcome = {
-  timelineId: string;
-  capturedFrame: number;
-  imageBase64: string;
-};
-
 export interface GbaClient {
   state(): Promise<GbaRunState>;
   setForeground(focused: boolean): Promise<{ foreground: boolean }>;
   listRoms(): Promise<GbaRomView[]>;
-  loadGame(romId: number): Promise<{ romId: number; romName: string; timelineId: string }>;
-  press(input: {
-    buttons: GbaButton[];
-    holdFrames: number;
-    settleFrames: number;
-  }): Promise<GbaPressOutcome>;
-  pressSequence(input: {
-    steps: GbaPressStepInput[];
-    settleFrames: number;
-  }): Promise<GbaPressOutcome>;
-  screenshot(): Promise<GbaScreenshotOutcome>;
+  loadGame(romId: number): Promise<{ romName: string }>;
+  /** press 类成功结果就是画面本身（base64 PNG）——契约不设诊断元数据。 */
+  press(input: { buttons: GbaButton[]; holdFrames: number; settleFrames: number }): Promise<string>;
+  pressSequence(input: { steps: GbaPressStepInput[]; settleFrames: number }): Promise<string>;
+  screenshot(): Promise<string>;
   importRom(input: { resId: string; name: string }): Promise<GbaRomView>;
 }
 
@@ -86,45 +65,43 @@ export class HttpGbaClient implements GbaClient {
     return roms;
   }
 
-  public async loadGame(
-    romId: number,
-  ): Promise<{ romId: number; romName: string; timelineId: string }> {
+  public async loadGame(romId: number): Promise<{ romName: string }> {
     const result = await this.api.loadGame({ romId });
     if (!result.ok) {
       throw new GbaError("GBA_REJECTED", result.reason);
     }
-    return { romId: result.romId, romName: result.romName, timelineId: result.timelineId };
+    return { romName: result.romName };
   }
 
   public async press(input: {
     buttons: GbaButton[];
     holdFrames: number;
     settleFrames: number;
-  }): Promise<GbaPressOutcome> {
+  }): Promise<string> {
     const result = await this.api.press(input);
     if (!result.ok) {
       throw new GbaError("GBA_REJECTED", result.reason);
     }
-    return result;
+    return result.imageBase64;
   }
 
   public async pressSequence(input: {
     steps: GbaPressStepInput[];
     settleFrames: number;
-  }): Promise<GbaPressOutcome> {
+  }): Promise<string> {
     const result = await this.api.pressSequence(input);
     if (!result.ok) {
       throw new GbaError("GBA_REJECTED", result.reason);
     }
-    return result;
+    return result.imageBase64;
   }
 
-  public async screenshot(): Promise<GbaScreenshotOutcome> {
+  public async screenshot(): Promise<string> {
     const result = await this.api.screenshot({});
     if (!result.ok) {
       throw new GbaError("GBA_REJECTED", result.reason);
     }
-    return result;
+    return result.imageBase64;
   }
 
   public async importRom(input: { resId: string; name: string }): Promise<GbaRomView> {

--- a/apps/agent/src/agent/capabilities/gba/tools/press-sequence.tool.ts
+++ b/apps/agent/src/agent/capabilities/gba/tools/press-sequence.tool.ts
@@ -71,7 +71,7 @@ export class GbaPressSequenceTool extends GbaToolComponent<typeof Schema> {
 
   protected async executeTyped(input: z.infer<typeof Schema>): Promise<ToolExecutionResult> {
     const client = this.getGbaClient();
-    const outcome = await withForegroundRealign(client, () =>
+    const imageBase64 = await withForegroundRealign(client, () =>
       client.pressSequence({
         steps: input.steps.map(step => ({
           buttons: step.buttons,
@@ -81,9 +81,6 @@ export class GbaPressSequenceTool extends GbaToolComponent<typeof Schema> {
         settleFrames: input.settle_frames,
       }),
     );
-    return buildGbaScreenToolResult({
-      imageBase64: outcome.imageBase64,
-      ossClient: this.ossClient,
-    });
+    return buildGbaScreenToolResult({ imageBase64, ossClient: this.ossClient });
   }
 }

--- a/apps/agent/src/agent/capabilities/gba/tools/press.tool.ts
+++ b/apps/agent/src/agent/capabilities/gba/tools/press.tool.ts
@@ -58,16 +58,13 @@ export class GbaPressTool extends GbaToolComponent<typeof Schema> {
 
   protected async executeTyped(input: z.infer<typeof Schema>): Promise<ToolExecutionResult> {
     const client = this.getGbaClient();
-    const outcome = await withForegroundRealign(client, () =>
+    const imageBase64 = await withForegroundRealign(client, () =>
       client.press({
         buttons: input.buttons,
         holdFrames: input.hold_frames,
         settleFrames: input.settle_frames,
       }),
     );
-    return buildGbaScreenToolResult({
-      imageBase64: outcome.imageBase64,
-      ossClient: this.ossClient,
-    });
+    return buildGbaScreenToolResult({ imageBase64, ossClient: this.ossClient });
   }
 }

--- a/apps/agent/src/agent/capabilities/gba/tools/screenshot.tool.ts
+++ b/apps/agent/src/agent/capabilities/gba/tools/screenshot.tool.ts
@@ -33,10 +33,7 @@ export class GbaScreenshotTool extends GbaToolComponent<typeof Schema> {
 
   protected async executeTyped(): Promise<ToolExecutionResult> {
     const client = this.getGbaClient();
-    const outcome = await withForegroundRealign(client, () => client.screenshot());
-    return buildGbaScreenToolResult({
-      imageBase64: outcome.imageBase64,
-      ossClient: this.ossClient,
-    });
+    const imageBase64 = await withForegroundRealign(client, () => client.screenshot());
+    return buildGbaScreenToolResult({ imageBase64, ossClient: this.ossClient });
   }
 }

--- a/apps/agent/test/agent/apps/gba/gba-tools.test.ts
+++ b/apps/agent/test/agent/apps/gba/gba-tools.test.ts
@@ -19,40 +19,27 @@ const ROM: GbaRomView = {
   id: 1,
   name: "逆转裁判",
   sizeBytes: 8705280,
-  sha256: "abc",
   createdAt: "2026-07-22T00:00:00.000Z",
   lastPlayedAt: null,
   hasSave: true,
 };
 
-const PRESS_OUTCOME = {
-  timelineId: "gba-t1",
-  startFrame: 100,
-  releasedFrame: 103,
-  capturedFrame: 116,
-  imageBase64: Buffer.from("png-bytes").toString("base64"),
-};
+const IMAGE_BASE64 = Buffer.from("png-bytes").toString("base64");
 
 function createFakeClient(overrides: Partial<GbaClient> = {}): GbaClient {
   return {
     state: vi.fn().mockResolvedValue({
       loaded: true,
-      romId: 1,
       romName: "逆转裁判",
       foreground: true,
       frame: 116,
-      timelineId: "gba-t1",
     }),
     setForeground: vi.fn().mockResolvedValue({ foreground: true }),
     listRoms: vi.fn().mockResolvedValue([ROM]),
-    loadGame: vi.fn().mockResolvedValue({ romId: 1, romName: "逆转裁判", timelineId: "gba-t1" }),
-    press: vi.fn().mockResolvedValue(PRESS_OUTCOME),
-    pressSequence: vi.fn().mockResolvedValue(PRESS_OUTCOME),
-    screenshot: vi.fn().mockResolvedValue({
-      timelineId: "gba-t1",
-      capturedFrame: 116,
-      imageBase64: PRESS_OUTCOME.imageBase64,
-    }),
+    loadGame: vi.fn().mockResolvedValue({ romName: "逆转裁判" }),
+    press: vi.fn().mockResolvedValue(IMAGE_BASE64),
+    pressSequence: vi.fn().mockResolvedValue(IMAGE_BASE64),
+    screenshot: vi.fn().mockResolvedValue(IMAGE_BASE64),
     importRom: vi.fn().mockResolvedValue(ROM),
     ...overrides,
   };
@@ -90,7 +77,7 @@ describe("GBA 工具", () => {
     expect(result.content).toBe('{"ok":true}');
     const effect = appendEffect(result.effects);
     expect(effect.content).toBe('<gba_screen resid="res-99" />');
-    expect(effect.image?.content).toBe(PRESS_OUTCOME.imageBase64);
+    expect(effect.image?.content).toBe(IMAGE_BASE64);
     expect(effect.image?.mimeType).toBe("image/png");
   });
 
@@ -148,7 +135,7 @@ describe("GBA 工具", () => {
     const press = vi
       .fn()
       .mockRejectedValueOnce(new GbaError("GBA_REJECTED", "GBA_NOT_FOREGROUND"))
-      .mockResolvedValue(PRESS_OUTCOME);
+      .mockResolvedValue(IMAGE_BASE64);
     const client = createFakeClient({ press });
     const tool = new GbaPressTool({ getGbaClient: () => client });
     const result = await tool.execute({ buttons: ["a"] }, context);

--- a/apps/gba/src/application/gba.service.ts
+++ b/apps/gba/src/application/gba.service.ts
@@ -1,13 +1,12 @@
-import { createHash, randomUUID } from "node:crypto";
+import { createHash } from "node:crypto";
 import { z } from "zod";
 import type {
   GbaButton,
   GbaDeleteResultSchema,
   GbaLoadResultSchema,
-  GbaPressResultSchema,
   GbaPressStepSchema,
   GbaRunStateSchema,
-  GbaScreenshotResultSchema,
+  GbaScreenResultSchema,
   GbaUploadResultSchema,
 } from "@kagami/gba-api/contract";
 import { AppLogger } from "@kagami/kernel/logger/logger";
@@ -16,8 +15,7 @@ import { encodeFramePng } from "../emulator/frame-png.js";
 import type { OssClient } from "../acl/oss-client.js";
 import type { GbaStore, RomRow } from "../persistence/gba-store.js";
 
-type PressResult = z.infer<typeof GbaPressResultSchema>;
-type ScreenshotResult = z.infer<typeof GbaScreenshotResultSchema>;
+type ScreenResult = z.infer<typeof GbaScreenResultSchema>;
 type LoadResult = z.infer<typeof GbaLoadResultSchema>;
 type UploadResult = z.infer<typeof GbaUploadResultSchema>;
 type DeleteResult = z.infer<typeof GbaDeleteResultSchema>;
@@ -58,10 +56,7 @@ const logger = new AppLogger({ source: "gba-service" });
 type PressPlan = {
   frames: ReadonlySet<GbaButton>[];
   cursor: number;
-  startFrame: number;
-  /** frames 中最后一个「按住」帧的下标 + 1（= 松键时刻,尾部 gap/settle 不计入）。 */
-  releaseOffset: number;
-  resolve: (result: PressResult) => void;
+  resolve: (result: ScreenResult) => void;
 };
 
 type GbaServiceDeps = {
@@ -96,7 +91,6 @@ export class GbaService {
   private core: EmulatorCore | null = null;
   private romId: number | null = null;
   private romName: string | null = null;
-  private timelineId: string | null = null;
   private frame = 0;
   private foreground = false;
   private plan: PressPlan | null = null;
@@ -142,11 +136,9 @@ export class GbaService {
   public state(): RunState {
     return {
       loaded: this.core !== null,
-      romId: this.romId,
       romName: this.romName,
       foreground: this.foreground,
       frame: this.frame,
-      timelineId: this.timelineId,
     };
   }
 
@@ -238,7 +230,6 @@ export class GbaService {
       this.core = null;
       this.romId = null;
       this.romName = null;
-      this.timelineId = null;
       this.frame = 0;
       await old.shutdown();
     }
@@ -265,7 +256,6 @@ export class GbaService {
     this.core = core;
     this.romId = romId;
     this.romName = rom.name;
-    this.timelineId = `gba-${this.now().toString(36)}-${randomUUID().slice(0, 8)}`;
     this.frame = 0;
     this.frameMs = 1000 / core.getFps();
     // 冷启动推进一帧：让 screenshot 立即有帧可看（后台加载也只多这一帧，无实时性影响）。
@@ -280,7 +270,7 @@ export class GbaService {
       this.startLoop();
     }
     logger.info("GBA 加载 ROM", { event: "gba.load_game", romId, romName: rom.name });
-    return { ok: true, romId, romName: rom.name, timelineId: this.timelineId };
+    return { ok: true, romName: rom.name };
   }
 
   /** press 工具的平铺形态：单 chord = 单步序列的语法糖，同一条执行路径。 */
@@ -288,14 +278,14 @@ export class GbaService {
     buttons: GbaButton[];
     holdFrames: number;
     settleFrames: number;
-  }): Promise<PressResult> {
+  }): Promise<ScreenResult> {
     return this.pressSequence({
       steps: [{ buttons: input.buttons, holdFrames: input.holdFrames, gapFrames: 1 }],
       settleFrames: input.settleFrames,
     });
   }
 
-  public pressSequence(input: { steps: PressStep[]; settleFrames: number }): Promise<PressResult> {
+  public pressSequence(input: { steps: PressStep[]; settleFrames: number }): Promise<ScreenResult> {
     this.touchActivity();
     if (!this.core) {
       return Promise.resolve({ ok: false, reason: "NO_GAME_LOADED" });
@@ -312,32 +302,21 @@ export class GbaService {
       return Promise.resolve({ ok: false, reason: built });
     }
 
-    return new Promise<PressResult>(resolve => {
-      this.plan = {
-        frames: built.frames,
-        cursor: 0,
-        startFrame: this.frame,
-        releaseOffset: built.releaseOffset,
-        resolve,
-      };
+    return new Promise<ScreenResult>(resolve => {
+      this.plan = { frames: built.frames, cursor: 0, resolve };
     });
   }
 
-  public screenshot(): ScreenshotResult {
+  public screenshot(): ScreenResult {
     this.touchActivity();
-    if (!this.core || this.timelineId === null) {
+    if (!this.core) {
       return { ok: false, reason: "NO_GAME_LOADED" };
     }
     const imageBase64 = this.captureFrameBase64();
     if (imageBase64 === null) {
       return { ok: false, reason: "NO_FRAME_AVAILABLE" };
     }
-    return {
-      ok: true,
-      timelineId: this.timelineId,
-      capturedFrame: this.frame,
-      imageBase64,
-    };
+    return { ok: true, imageBase64 };
   }
 
   // === ROM 库（控制台管理面）===
@@ -572,18 +551,11 @@ export class GbaService {
   private completePlan(plan: PressPlan): void {
     this.plan = null;
     const imageBase64 = this.captureFrameBase64();
-    if (imageBase64 === null || this.timelineId === null) {
+    if (imageBase64 === null) {
       plan.resolve({ ok: false, reason: "NO_FRAME_AVAILABLE" });
       return;
     }
-    plan.resolve({
-      ok: true,
-      timelineId: this.timelineId,
-      startFrame: plan.startFrame,
-      releasedFrame: plan.startFrame + plan.releaseOffset,
-      capturedFrame: this.frame,
-      imageBase64,
-    });
+    plan.resolve({ ok: true, imageBase64 });
   }
 
   /** 采当前帧并编码 base64 PNG；无帧可采时 null。screenshot 与 completePlan 共用。 */
@@ -656,12 +628,12 @@ export class GbaService {
 
 /**
  * 把 press 序列展开成逐帧按键计划。领域校验失败返回 reason 字符串（`{ ok:false }` 语义），
- * 通过则返回 frames（每帧一个 held 集合）+ releaseOffset（松键时刻，供时间线元数据）。
+ * 通过则返回 frames（每帧一个 held 集合）。
  */
 function buildPressPlan(
   steps: PressStep[],
   settleFrames: number,
-): { frames: ReadonlySet<GbaButton>[]; releaseOffset: number } | string {
+): { frames: ReadonlySet<GbaButton>[] } | string {
   if (steps.length > MAX_STEPS) {
     return `INVALID_PRESS: steps 数量 ${steps.length} 超上限 ${MAX_STEPS}`;
   }
@@ -669,8 +641,6 @@ function buildPressPlan(
     return `INVALID_PRESS: settleFrames ${settleFrames} 超上限 ${MAX_SETTLE_FRAMES}`;
   }
   const frames: ReadonlySet<GbaButton>[] = [];
-  // releasedFrame 语义 = 最后一个「按住」帧之后的时刻;尾部 gap 里键已松开,不计入。
-  let lastHoldEnd = 0;
   for (const [index, step] of steps.entries()) {
     const buttons = new Set(step.buttons);
     if (buttons.size !== step.buttons.length) {
@@ -695,19 +665,17 @@ function buildPressPlan(
     for (let i = 0; i < step.holdFrames; i++) {
       frames.push(chord);
     }
-    lastHoldEnd = frames.length;
     for (let i = 0; i < step.gapFrames; i++) {
       frames.push(EMPTY_HELD);
     }
   }
-  const releaseOffset = lastHoldEnd;
   for (let i = 0; i < settleFrames; i++) {
     frames.push(EMPTY_HELD);
   }
   if (frames.length > MAX_TOTAL_FRAMES) {
     return `INVALID_PRESS: 总帧数 ${frames.length} 超预算 ${MAX_TOTAL_FRAMES}（Σ每步(hold+gap)+settle ≤ ${MAX_TOTAL_FRAMES}）`;
   }
-  return { frames, releaseOffset };
+  return { frames };
 }
 
 /** better-sqlite3 的 UNIQUE 约束冲突（并发上传竞态的判定依据）。 */
@@ -721,7 +689,6 @@ export function toRomView(rom: RomRow): {
   id: number;
   name: string;
   sizeBytes: number;
-  sha256: string;
   createdAt: string;
   lastPlayedAt: string | null;
   hasSave: boolean;
@@ -730,7 +697,6 @@ export function toRomView(rom: RomRow): {
     id: rom.id,
     name: rom.name,
     sizeBytes: rom.sizeBytes,
-    sha256: rom.sha256,
     createdAt: new Date(rom.createdAt).toISOString(),
     lastPlayedAt: rom.lastPlayedAt === null ? null : new Date(rom.lastPlayedAt).toISOString(),
     hasSave: rom.hasSave,

--- a/apps/gba/test/gba-service.test.ts
+++ b/apps/gba/test/gba-service.test.ts
@@ -68,9 +68,8 @@ describe("GbaService", () => {
       const romId = await uploadAndLoad();
       const state = service.state();
       expect(state.loaded).toBe(true);
-      expect(state.romId).toBe(romId);
+      expect(state.romName).toBe("测试 ROM");
       expect(state.frame).toBe(1); // 冷启动推进的一帧
-      expect(state.timelineId).toMatch(/^gba-/);
       expect(state.foreground).toBe(false);
       expect(store.getLastRomId()).toBe(romId);
       // 后台加载：帧循环不跑
@@ -97,7 +96,7 @@ describe("GbaService", () => {
         },
       });
       await service2.init();
-      expect(service2.state().romId).toBe(romId);
+      expect(service2.state().loaded).toBe(true);
       expect(service2.state().foreground).toBe(false); // 冷启动处于后台
       const restored = cores[1]!;
       expect(restored.sram?.subarray(0, 8).toString()).toBe("SAVEDATA");
@@ -226,12 +225,11 @@ describe("GbaService", () => {
       const result = await promise;
       expect(result.ok).toBe(true);
       if (result.ok) {
-        expect(result.capturedFrame - result.startFrame).toBe(3 + 1 + 12); // hold+gap+settle
-        expect(result.releasedFrame - result.startFrame).toBe(3); // 松键时刻=最后一个按住帧之后,尾部 gap 不计
         expect(result.imageBase64.length).toBeGreaterThan(0);
       }
-      // 计划期内的前 3 帧按住 a，之后全空
+      // 计划:hold 3 帧按住 a,其后(gap/settle/计划外空转)全松开
       const during = core.frames.slice(baseline);
+      expect(during.filter(f => f.has("a"))).toHaveLength(3);
       expect(during[0]?.has("a")).toBe(true);
       expect(during[2]?.has("a")).toBe(true);
       expect(during[3]?.size).toBe(0);
@@ -254,10 +252,9 @@ describe("GbaService", () => {
       expect(after1s).toBeGreaterThanOrEqual(58);
       await vi.advanceTimersByTimeAsync(4200);
       const result = await promise;
-      expect(result.ok).toBe(true);
-      if (result.ok) {
-        expect(result.capturedFrame - result.startFrame).toBe(300);
-      }
+      expect(result.ok).toBe(true); // 计划(300 帧)已在实速下走完
+      expect(core.frames.length - baseline).toBeGreaterThanOrEqual(300);
+      expect(core.frames.length - baseline).toBeLessThanOrEqual(325); // 5.2s 实速上界
     });
 
     it("切后台中止在途 press：领域拒绝 + 按键清空 + 冻结", async () => {
@@ -322,7 +319,7 @@ describe("GbaService", () => {
       expect(result.ok).toBe(true);
       expect(store.getBatterySave(romA)?.subarray(0, 6).toString()).toBe("A-SAVE");
       expect(coreA.shutdownCalled).toBe(true);
-      expect(service.state().romId).toBe(uploadB.rom.id);
+      expect(service.state().romName).toBe("ROM B");
     });
   });
 
@@ -342,7 +339,7 @@ describe("GbaService", () => {
     });
 
     it("切 ROM 拉取失败:旧会话毫发无损继续跑", async () => {
-      const romA = await uploadAndLoad("旧游戏");
+      await uploadAndLoad("旧游戏");
       service.setForeground(true);
       const uploadB = await service.uploadRom({ name: "新游戏", bytes: fakeRomBytes(8) });
       expect(uploadB.ok).toBe(true);
@@ -352,7 +349,7 @@ describe("GbaService", () => {
       const result = await service.loadGame(uploadB.rom.id);
       expect(result).toEqual({ ok: false, reason: "ROM_FETCH_FAILED" });
       // 旧会话仍在:状态自洽、帧循环继续推进
-      expect(service.state().romId).toBe(romA);
+      expect(service.state().romName).toBe("旧游戏");
       expect(service.state().loaded).toBe(true);
       const before = service.state().frame;
       await vi.advanceTimersByTimeAsync(500);
@@ -378,7 +375,7 @@ describe("GbaService", () => {
       const result = await badService.loadGame(upload.rom.id);
       expect(result).toEqual({ ok: false, reason: "ROM_LOAD_FAILED" });
       expect(badService.state().loaded).toBe(false);
-      expect(badService.state().romId).toBeNull(); // 状态自洽的空态
+      expect(badService.state().romName).toBeNull(); // 状态自洽的空态
       expect(cores[origFactory]!.shutdownCalled).toBe(true); // 半成品核心已释放
       // init() 走同一路径:坏 ROM 不会让启动抛穿
       store.setLastRomId(upload.rom.id);

--- a/packages/gba-api/src/contract.ts
+++ b/packages/gba-api/src/contract.ts
@@ -44,58 +44,32 @@ export const GbaPressStepSchema = z.object({
 /** 最后一步松开后的结算等待帧数，默认 12（~200ms，避开「刚松键画面未提交」的过渡帧）。 */
 const SettleFramesSchema = z.number().int().min(0).default(12);
 
-/**
- * press 结果的时间线元数据：帧号帮助诊断「决策-执行漂移」（LLM 推理间隙游戏在实时继续跑），
- * 不做乐观锁。timelineId 在 loadGame / 服务重启时更换，防不同时间线的帧号被混为一谈。
- * releasedFrame = 最后一个「按住」帧之后的时刻（尾部 gap/settle 里键已松开，不计入）。
- */
-export const GbaFrameMetaSchema = z.object({
-  timelineId: z.string(),
-  startFrame: z.number().int(),
-  releasedFrame: z.number().int(),
-  capturedFrame: z.number().int(),
-});
-
 /** 各结果 schema 共用的失败分支：领域拒绝统一 `{ ok:false, reason }`。 */
 const GbaFailureSchema = z.object({ ok: z.literal(false), reason: z.string() });
 
 /**
+ * press / press_sequence / screenshot 的统一结果：成功分支**只有画面本身**。契约不设
+ * timelineId / 帧号这类诊断元数据——没有任何读者（小镜看图行动,用户不看,也无处落盘）,
+ * 「服务算了、传了、丢弃」是纯死重（设计原则见 issue #541 收尾反馈）。
  * 画面以 base64 PNG 走 JSON 回传（240×160 放大 2x，数十 KB、本机回环）：不值得为「上行 JSON +
  * 下行 binary」发明新契约原语；大块数据由 agent 侧工具拦下转多模态 effect，不进主 Agent 上下文。
  */
-export const GbaPressResultSchema = z.discriminatedUnion("ok", [
-  GbaFrameMetaSchema.extend({ ok: z.literal(true), imageBase64: z.string() }),
-  GbaFailureSchema,
-]);
-
-export const GbaScreenshotResultSchema = z.discriminatedUnion("ok", [
-  z.object({
-    ok: z.literal(true),
-    timelineId: z.string(),
-    capturedFrame: z.number().int(),
-    imageBase64: z.string(),
-  }),
+export const GbaScreenResultSchema = z.discriminatedUnion("ok", [
+  z.object({ ok: z.literal(true), imageBase64: z.string() }),
   GbaFailureSchema,
 ]);
 
 export const GbaLoadResultSchema = z.discriminatedUnion("ok", [
-  z.object({
-    ok: z.literal(true),
-    romId: z.number().int(),
-    romName: z.string(),
-    timelineId: z.string(),
-  }),
+  z.object({ ok: z.literal(true), romName: z.string() }),
   GbaFailureSchema,
 ]);
 
 export const GbaRunStateSchema = z.object({
   loaded: z.boolean(),
-  romId: z.number().int().nullable(),
   romName: z.string().nullable(),
   foreground: z.boolean(),
-  /** 自核心冷启动以来的帧计数；未加载时为 0。 */
+  /** 自核心冷启动以来的帧计数；未加载时为 0。控制台实况页显示,亦是「活着」的证据。 */
   frame: z.number().int(),
-  timelineId: z.string().nullable(),
 });
 
 /** ROM 库列表行（sqlite `rom` 表视图）。 */
@@ -103,7 +77,6 @@ export const GbaRomViewSchema = z.object({
   id: z.number().int(),
   name: z.string(),
   sizeBytes: z.number().int(),
-  sha256: z.string(),
   createdAt: z.string(),
   lastPlayedAt: z.string().nullable(),
   /** 是否已有电池存档（battery_save 行存在）。 */
@@ -161,7 +134,7 @@ export const gbaApiContract = {
       holdFrames: z.number().int().min(1).default(3),
       settleFrames: SettleFramesSchema,
     }),
-    output: GbaPressResultSchema,
+    output: GbaScreenResultSchema,
     timeoutMs: GBA_PRESS_TIMEOUT_MS,
   }),
   pressSequence: defineJsonRoute({
@@ -171,7 +144,7 @@ export const gbaApiContract = {
       steps: z.array(GbaPressStepSchema).min(1),
       settleFrames: SettleFramesSchema,
     }),
-    output: GbaPressResultSchema,
+    output: GbaScreenResultSchema,
     timeoutMs: GBA_PRESS_TIMEOUT_MS,
   }),
   screenshot: defineJsonRoute({
@@ -179,7 +152,7 @@ export const gbaApiContract = {
     path: "/gba/run/screenshot",
     input: z.object({}),
     // 前后台皆可（冻结帧也能看）；未加载 ROM 时领域拒绝。
-    output: GbaScreenshotResultSchema,
+    output: GbaScreenResultSchema,
     timeoutMs: GBA_QUERY_TIMEOUT_MS,
   }),
   listRoms: defineJsonRoute({


### PR DESCRIPTION
承接 #551 的后续:上一轮只在 agent 工具层裁剪,属于下游补救——死字段仍被服务端每次算出、传输、然后丢弃,全链路没有任何读者。本次在**契约源头**删干净。

| 层 | 改动 |
|---|---|
| 契约 | `GbaFrameMetaSchema` 删除;press 类统一 `{ok, imageBase64}`;loadGame → `{ok, romName}`;state 去 romId/timelineId;RomView 去 sha256 |
| 服务端 | timelineId 生成、松键位点追踪、帧号计算全删;返回随契约收窄 |
| agent client | press 类直接回 `imageBase64` 字符串 |
| **保留(有读者)** | `state.frame/foreground`(控制台实况页)、`listRoms` 的 sizeBytes/createdAt/lastPlayedAt(控制台 ROM 表格)、hasSave |

她的上下文不变(上轮已净),变的是:服务不再做无人收件的计算与传输,契约里每个字段现在都能说出读者是谁。

五件套全绿,1303 测(断言改为 FakeCore 帧记录自洽)。**本 PR 合并后暂不部署**(按用户指示)。