### PR TITLE
fix(gba): review #557 修复——成功加载作废快照防 crash 复活，恢复失败丢弃核心真冷启动

### DIFF
--- a/apps/gba/src/application/gba.service.ts
+++ b/apps/gba/src/application/gba.service.ts
@@ -13,7 +13,7 @@ import { AppLogger } from "@kagami/kernel/logger/logger";
 import type { EmulatorCore, EmulatorCoreFactory } from "../emulator/emulator-core.js";
 import { encodeFramePng } from "../emulator/frame-png.js";
 import type { OssClient } from "../acl/oss-client.js";
-import type { GbaStore, RomRow } from "../persistence/gba-store.js";
+import type { GbaStore, ResumeStateRow, RomRow } from "../persistence/gba-store.js";
 
 type ScreenResult = z.infer<typeof GbaScreenResultSchema>;
 type LoadResult = z.infer<typeof GbaLoadResultSchema>;
@@ -127,9 +127,13 @@ export class GbaService {
     if (lastRomId === null) {
       return;
     }
+    // 先把快照读进内存：紧随其后的 loadGame 成功会作废持久化行（防 crash 复活，见
+    // doLoadGame），启动恢复用的是这份内存副本。
+    const resume = this.store.getResumeState();
     const result = await this.loadGame(lastRomId);
     if (!result.ok) {
-      // 快照留着不清：装 ROM 都没成（多半 OSS 瞬断），让下一次启动仍有机会无感恢复。
+      // 快照行留着不清：装 ROM 都没成（多半 OSS 瞬断），让下一次启动仍有机会无感恢复。
+      // 运行中任何一次成功加载都会作废它，不会陈旧复活。
       logger.warn("GBA 启动恢复上次 ROM 失败，跳过", {
         event: "gba.restore_last_rom_failed",
         romId: lastRomId,
@@ -137,16 +141,17 @@ export class GbaService {
       });
       return;
     }
-    this.resumeFromSnapshotIfAny(lastRomId);
+    if (resume) {
+      await this.restoreSnapshot(resume, lastRomId);
+    }
   }
 
-  /** 优雅关停快照的恢复（消费即删）：尝试过（无论成败）就作废，陈旧快照绝不隔代复活。 */
-  private resumeFromSnapshotIfAny(romId: number): void {
-    const resume = this.store.getResumeState();
-    if (!resume) {
-      return;
-    }
-    this.store.clearResumeState();
+  /**
+   * 优雅关停快照的恢复。持久化行已在本次 loadGame 成功时作废，这里只消费启动前读出的内存
+   * 副本。恢复失败（校验不通过 / WASM trap）时核心可能已被 unserialize **部分改写**，不能
+   * 当冷启动继续用——整个丢弃（不 flush 可能被污染的 SRAM）后全新重载（review #557 [P2]）。
+   */
+  private async restoreSnapshot(resume: ResumeStateRow, romId: number): Promise<void> {
     if (resume.romId !== romId || !this.core) {
       return;
     }
@@ -159,17 +164,18 @@ export class GbaService {
         this.core.runFrame(EMPTY_HELD);
       }
     } catch (error) {
-      logger.errorWithCause("GBA 快照恢复抛错，降级冷启动", error, {
+      logger.errorWithCause("GBA 快照恢复抛错，丢弃半恢复核心重载", error, {
         event: "gba.resume_restore_failed",
         romId,
       });
-      return;
+      restored = false;
     }
     if (!restored) {
-      logger.warn("GBA 快照恢复失败（核心校验不通过，多半核心版本变了），降级冷启动", {
+      logger.warn("GBA 快照恢复失败（核心校验不通过，多半核心版本变了），丢弃后重载为冷启动", {
         event: "gba.resume_restore_rejected",
         romId,
       });
+      await this.reloadDiscardingCore(romId);
       return;
     }
     // 帧计数接续停机瞬间（+1 = 上面刷新画面的那一帧）。
@@ -184,6 +190,31 @@ export class GbaService {
       frame: this.frame,
       foreground: resume.foreground,
     });
+  }
+
+  /**
+   * 恢复失败后的净化重载：丢弃现核心（**不 flush SRAM**——可能已被失败的 unserialize 污染，
+   * flush 会拿脏数据覆盖电池存档），再从 OSS + battery_save 全新加载出真正干净的冷启动实例。
+   * 重载也失败时保持未加载空手起，服务照常对外。
+   */
+  private async reloadDiscardingCore(romId: number): Promise<void> {
+    const poisoned = this.core;
+    this.core = null;
+    this.romId = null;
+    this.romName = null;
+    this.frame = 0;
+    this.lastSramHash = null;
+    if (poisoned) {
+      await poisoned.shutdown().catch(() => {});
+    }
+    const result = await this.loadGame(romId);
+    if (!result.ok) {
+      logger.warn("GBA 恢复失败后的重载也失败，保持未加载", {
+        event: "gba.resume_reload_failed",
+        romId,
+        reason: result.reason,
+      });
+    }
   }
 
   public state(): RunState {
@@ -319,6 +350,10 @@ export class GbaService {
 
     this.store.touchLastPlayed(romId);
     this.store.setLastRomId(romId);
+    // 任何一次成功加载都作废持久化快照（review #557 [P1]）：快照描述的是「上一次关停时的
+    // 现场」，一旦有新加载（含 OSS 瞬断恢复后的手动加载、换 ROM），它就过时了——留着会在
+    // 之后 crash 的下一次启动里复活、回滚新进度。init 的无感恢复用的是启动前读出的内存副本。
+    this.store.clearResumeState();
     if (this.foreground) {
       this.startLoop();
     }

--- a/apps/gba/test/gba-service.test.ts
+++ b/apps/gba/test/gba-service.test.ts
@@ -161,7 +161,7 @@ describe("GbaService", () => {
       await service2.shutdown();
     });
 
-    it("快照校验不通过（核心版本变了）：降级冷启动，快照已删", async () => {
+    it("快照校验不通过（核心版本变了）：丢弃半恢复核心、全新重载为真冷启动，快照已删", async () => {
       await uploadAndLoad();
       service.setForeground(true);
       await service.shutdown();
@@ -170,11 +170,42 @@ describe("GbaService", () => {
         core.failSetState = true;
       });
       await service2.init();
+      // 吃过失败 unserialize 的核心（cores[1]）不能继续用：整个丢弃，重载出干净实例（cores[2]）
+      expect(cores).toHaveLength(3);
+      expect(cores[1]!.shutdownCalled).toBe(true);
+      expect(cores[2]!.setStateCalls).toHaveLength(0);
       // 冷启动语义：只有 loadGame 的一帧、后台
       expect(service2.state().loaded).toBe(true);
       expect(service2.state().frame).toBe(1);
       expect(service2.state().foreground).toBe(false);
       expect(store.getResumeState()).toBeNull();
+      await service2.shutdown();
+    });
+
+    it("OSS 瞬断保留快照；之后任何成功加载作废快照，crash 后不复活回滚（review #557 [P1]）", async () => {
+      const romId = await uploadAndLoad();
+      service.setForeground(true);
+      await service.shutdown(); // 写快照
+
+      oss.failGet = true;
+      const service2 = buildService2();
+      await service2.init(); // 装 ROM 失败：快照保留，下次启动仍有机会无感恢复
+      expect(service2.state().loaded).toBe(false);
+      expect(store.getResumeState()).not.toBeNull();
+
+      // 运行中手动加载成功 → 快照作废（不恢复：手动加载 = 插卡带开机的冷启动语义）
+      oss.failGet = false;
+      const load = await service2.loadGame(romId);
+      expect(load.ok).toBe(true);
+      expect(cores[1]!.setStateCalls).toHaveLength(0);
+      expect(store.getResumeState()).toBeNull();
+
+      // 此后 crash（不调 shutdown）再启动：无快照可复活，冷启动 + 电池存档
+      const service3 = buildService2();
+      await service3.init();
+      expect(cores[2]!.setStateCalls).toHaveLength(0);
+      expect(service3.state().frame).toBe(1);
+      await service3.shutdown();
       await service2.shutdown();
     });
 


### PR DESCRIPTION
#557 合并后按标准流水线补做 codex review（此前跳步），抓到两个恢复语义漏洞，趁未部署修掉：

## [P1] 陈旧快照 crash 后复活回滚进度

**场景**：启动时 OSS 瞬断 → 快照按设计保留（给下次启动无感恢复）→ 运行中手动 `loadGame` 成功（不消费快照）→ 继续游玩 → crash → 下次启动发现快照仍匹配，恢复旧现场——进度回滚，且恢复后的周期 flush 会用旧 SRAM 覆盖更新过的电池存档。

**修复**：`doLoadGame` 成功尾部无条件作废持久化快照——快照描述的是「上一次关停时的现场」，任何新加载（手动加载、换 ROM）之后它就过时了。`init` 的无感恢复改为启动前先把快照读进内存、加载成功后消费内存副本，对正常路径语义零变化；「OSS 瞬断下次启动仍能无感恢复」的特性保留（loadGame 失败不清行）。

## [P2] 恢复失败不是真正的冷启动

**场景**：`retro_unserialize` 校验失败或恢复后首帧 WASM trap 时，核心可能已被**部分改写**，原实现只记日志就当冷启动继续服务；周期脏检查还可能把被污染的 SRAM flush 进 `battery_save`。

**修复**：恢复失败即丢弃整个核心（**不 flush SRAM**），从 OSS + `battery_save` 全新重载出干净实例；重载也失败则保持未加载空手起，服务照常对外（与既有「恢复失败不是启动失败」契约一致）。

## 测试

- 更新「校验不通过」用例：断言污染核心被 shutdown 丢弃、重载实例未吃 setState、状态为真冷启动。
- 新增 [P1] 全场景回归：瞬断保留 → 手动加载作废 → crash 后无复活。
- 全仓 1315 测试通过，五件套全绿。

codex 对其余重点（`_malloc/_free` 配对、ECONNREFUSED 重试幂等性、单行表约束）无阻塞发现。