### PR TITLE
fix(web): 大盘状态占比图例改用原始 tag、去「未知」、wait 恒置顶

### DIFF
--- a/apps/web/src/components/metric/MetricChartView.tsx
+++ b/apps/web/src/components/metric/MetricChartView.tsx
@@ -60,6 +60,11 @@ type MetricChartViewProps = {
   chartType?: MetricChartType;
   /** 序列展示元数据解析器（显式配色/命名）。缺省时用 seriesColors 轮转 + 后端 label。 */
   seriesMeta?: SeriesMetaResolver;
+  /**
+   * 把指定 series key 移到堆叠渲染顺序末位（stacked-area 里 = 视觉最顶）。缺省不重排。
+   * 只影响堆叠面积图的 `<Area>` 渲染顺序；不改 dataKey/color/图例顺序。
+   */
+  pinSeriesToTop?: string;
   /** 图表区高度（px），默认 288（h-72）。 */
   height?: number;
 };
@@ -98,6 +103,7 @@ export function MetricChartView({
   data,
   chartType = "line",
   seriesMeta,
+  pinSeriesToTop,
   height = 288,
 }: MetricChartViewProps) {
   // 显隐走共享 hook（id = series.key，语义 tag 值如 "wait"/"qq"）：纯客户端展示开关、不触发重查，
@@ -283,7 +289,8 @@ export function MetricChartView({
                       />
                     }
                   />
-                  {visibleSeries.map(series => (
+                  {/* 渲染顺序末位 = 堆叠视觉最顶：pinSeriesToTop 指定的序列（如 wait）恒在顶。 */}
+                  {orderSeriesForStack(visibleSeries, pinSeriesToTop).map(series => (
                     <Area
                       key={series.key}
                       type="linear"
@@ -420,6 +427,22 @@ export function selectVisibleSeries(
   hiddenKeys: Set<string>,
 ): RenderSeries[] {
   return series.filter(item => !hiddenKeys.has(item.key));
+}
+
+/**
+ * 把 pinKey 对应的序列移到数组末位（stacked-area 里 = 堆叠视觉最顶），其余保持原相对顺序。
+ * 只改渲染顺序、不碰 dataKey/color（已在 renderSeries 阶段按原序号定死，随 dataKey 走色）——
+ * 守住「绝不重新编号」不变量。pinKey 缺省或不在序列里时按原序返回（顺序不变，不保证同一引用）。
+ */
+export function orderSeriesForStack<T extends { key: string }>(series: T[], pinKey?: string): T[] {
+  if (!pinKey) {
+    return series;
+  }
+  const pinned = series.filter(item => item.key === pinKey);
+  if (pinned.length === 0) {
+    return series;
+  }
+  return [...series.filter(item => item.key !== pinKey), ...pinned];
 }
 
 function buildChartConfig(series: RenderSeries[]): ChartConfig {

--- a/apps/web/src/components/metric/state-meta.ts
+++ b/apps/web/src/components/metric/state-meta.ts
@@ -1,48 +1,23 @@
 import type { SeriesMetaResolver } from "./MetricChartView";
 
 /**
- * 小镜「状态时间占比」图的状态 → 展示元数据（label + 颜色）显式映射。
+ * 小镜「状态时间占比」图里两个语义状态的展示 pin（label + 颜色）。
  *
- * 状态桶（互斥单轴，见后端 RootAgentSession.getCurrentStateTag）：
- * - 11 个 App（label 对齐后端 AppManager displayName）；
- * - `wait` = root loop 挂起（空闲等下一个生活输入）；
- * - `portal` = 桌面初始态（未进任何 App）。
+ * 只钉 DESIGN.md 要求显式配色的两个语义状态：
+ * - `wait` = root loop 挂起（空闲等下一个生活输入），语义黄（--scheduler = 等待/pending），
+ *   是最该被一眼扫到的空闲带（也恒堆在最顶，见 DashboardPage 的 pinSeriesToTop）；
+ * - `portal` = 桌面初始态（未进任何 App），中性弱色。
  *
- * 配色遵循 DESIGN.md「颜色是配给」：`wait` 用语义黄（--scheduler = 等待/pending，唯一带明确语义
- * 的状态、也是最该被一眼看到的空闲带）；`portal` 用中性弱色；11 个 App 无专属语义 token，落
- * 「文艺复兴 / 印象派颜料」去饱和扩展色（DESIGN.md 图表扩展序列色的同族，无语义、不上墙）。
- *
- * ⚠️ 这套 App 配色需 DESIGN.md 签核；`wait`=黄、`portal`=中性两条先钉死。
+ * 其余状态（各 App）不再维护名字/配色映射：图例回落到后端返回的原始 state tag（如 "qq"/"gba"），
+ * 颜色走 MetricChartView 的 seriesColors 轮转。新增 App 零维护，绝不再显示「未知」。
  */
-export const STATE_META: Record<string, { label: string; color: string }> = {
-  // 语义状态
+const STATE_META: Record<string, { label: string; color: string }> = {
   wait: { label: "等待", color: "hsl(var(--scheduler))" },
   portal: { label: "桌面", color: "hsl(var(--muted-foreground))" },
-  // 11 个 App（去饱和颜料色；label 对齐后端 displayName）
-  qq: { label: "QQ", color: "#A85B54" },
-  browser: { label: "浏览器", color: "#4E6A8A" },
-  ithome: { label: "IT之家", color: "#C9892E" },
-  hn: { label: "Hacker News", color: "#C2703D" },
-  amap: { label: "高德地图", color: "#5F8A6B" },
-  todo: { label: "待办", color: "#6B5D82" },
-  calc: { label: "计算器", color: "#7A8B5A" },
-  terminal: { label: "终端", color: "#4A5A5E" },
-  clock: { label: "时钟", color: "#8A6D57" },
-  spire: { label: "尖塔", color: "#7E5A8C" },
-  pixel: { label: "像素画", color: "#B0894E" },
 };
 
 /**
- * 漂移兜底：后端新增 App 而这里未同步时，用中性色 + 原始 state id 作 label，
- * 保证不缺色/不崩（只是暂时没有专属配色，等补进 STATE_META）。
+ * MetricChartView 的 seriesMeta 解析器：只对 wait/portal 显式给 label + 颜色；
+ * 其余状态返回 undefined → 回落到后端原始 tag 作 label + seriesColors 轮转色。
  */
-export const STATE_FALLBACK = { label: "未知", color: "hsl(var(--muted-foreground))" } as const;
-
-/** MetricChartView 的 seriesMeta 解析器：按状态 id 查 STATE_META，未命中回落到 STATE_FALLBACK。 */
-export const stateSeriesMeta: SeriesMetaResolver = seriesKey => {
-  const meta = STATE_META[seriesKey];
-  if (meta) {
-    return meta;
-  }
-  return { label: `${STATE_FALLBACK.label}（${seriesKey}）`, color: STATE_FALLBACK.color };
-};
+export const stateSeriesMeta: SeriesMetaResolver = seriesKey => STATE_META[seriesKey];

--- a/apps/web/src/pages/dashboard/DashboardPage.tsx
+++ b/apps/web/src/pages/dashboard/DashboardPage.tsx
@@ -148,6 +148,7 @@ export function DashboardPage() {
             aggregator="count"
             groupByTag={STATE_TAG}
             seriesMeta={stateSeriesMeta}
+            pinSeriesToTop="wait"
             chartType="stacked-area"
             range={range}
           />

--- a/apps/web/src/pages/dashboard/dashboard-charts.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-charts.tsx
@@ -75,6 +75,8 @@ type DashboardChartProps = {
   tagFilters?: MetricChartTagFilters;
   /** 序列展示元数据解析器（显式配色/命名，如状态占比图）。透传给 MetricChartView。 */
   seriesMeta?: SeriesMetaResolver;
+  /** 把指定 series key 钉在堆叠面积图的最顶（如状态占比图的 wait）。透传给 MetricChartView。 */
+  pinSeriesToTop?: string;
   /** 显示前的值缩放系数（如延迟 ms→秒 传 0.001）；缺省不缩放。存储值不变，只改展示。 */
   valueScale?: number;
   range: DashboardRange;
@@ -90,6 +92,7 @@ export function DashboardChart({
   groupByTag,
   tagFilters,
   seriesMeta,
+  pinSeriesToTop,
   valueScale,
   range,
 }: DashboardChartProps) {
@@ -107,6 +110,7 @@ export function DashboardChart({
       subtitle={subtitle}
       chartType={chartType}
       {...(seriesMeta ? { seriesMeta } : {})}
+      {...(pinSeriesToTop ? { pinSeriesToTop } : {})}
       isLoading={query.isLoading}
       isError={query.isError}
       errorMessage={query.isError ? getApiErrorMessage(query.error) : undefined}

--- a/apps/web/test/metric-chart-view.test.ts
+++ b/apps/web/test/metric-chart-view.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildChartRows,
   buildPieData,
+  orderSeriesForStack,
   selectVisibleSeries,
   type RenderSeries,
 } from "@/components/metric/MetricChartView";
@@ -52,6 +53,42 @@ describe("selectVisibleSeries：仅过滤、不重排不串色", () => {
 
   it("残留 stale key（不在序列里）→ 无害 no-op", () => {
     expect(selectVisibleSeries(all, new Set(["gone"]))).toEqual(all);
+  });
+});
+
+describe("orderSeriesForStack：pin 移末位 = 堆叠视觉最顶，不改 dataKey/color", () => {
+  const s0 = series("qq", "c0", [{ bucketStart: b0, value: 1 }], 0);
+  const s1 = series("wait", "c1", [{ bucketStart: b0, value: 2 }], 1);
+  const s2 = series("portal", "c2", [{ bucketStart: b0, value: 3 }], 2);
+  const all: RenderSeries[] = [s0, s1, s2];
+
+  it("pinKey 存在：移到末位，其余保持原相对顺序", () => {
+    const ordered = orderSeriesForStack(all, "wait");
+    expect(ordered.map(s => s.key)).toEqual(["qq", "portal", "wait"]);
+  });
+
+  it("重排不改 dataKey / color（随 dataKey 走色，绝不串色）", () => {
+    const ordered = orderSeriesForStack(all, "wait");
+    const waitEntry = ordered.at(-1);
+    expect(waitEntry?.key).toBe("wait");
+    // wait 原来是 series_1 / c1，移位后依旧。
+    expect(waitEntry?.dataKey).toBe("series_1");
+    expect(waitEntry?.color).toBe("c1");
+    // qq 仍是 series_0 / c0。
+    expect(ordered[0]?.dataKey).toBe("series_0");
+    expect(ordered[0]?.color).toBe("c0");
+  });
+
+  it("pinKey 缺省：原样返回（顺序不变）", () => {
+    expect(orderSeriesForStack(all).map(s => s.key)).toEqual(["qq", "wait", "portal"]);
+  });
+
+  it("pinKey 不在序列里：原样返回（顺序不变，无害 no-op）", () => {
+    expect(orderSeriesForStack(all, "gone").map(s => s.key)).toEqual(["qq", "wait", "portal"]);
+  });
+
+  it("pin 已在末位：仍是末位（幂等）", () => {
+    expect(orderSeriesForStack(all, "portal").map(s => s.key)).toEqual(["qq", "wait", "portal"]);
   });
 });
 

--- a/apps/web/test/state-meta.test.ts
+++ b/apps/web/test/state-meta.test.ts
@@ -1,55 +1,25 @@
 import { describe, expect, it } from "vitest";
-import { STATE_META, STATE_FALLBACK, stateSeriesMeta } from "@/components/metric/state-meta";
+import { stateSeriesMeta } from "@/components/metric/state-meta";
 
-// 后端已注册的 11 个 App id（对齐 apps/agent agent-runtime.factory 的注册表）+ 两个语义状态。
-// AppId 是 string 无可枚举源，这里钉住已知集合：删掉任一映射即回归，防止漂移丢色/丢 label。
-const KNOWN_APP_IDS = [
-  "calc",
-  "terminal",
-  "ithome",
-  "todo",
-  "clock",
-  "hn",
-  "amap",
-  "browser",
-  "spire",
-  "pixel",
-  "qq",
-] as const;
-
-describe("STATE_META", () => {
-  it("覆盖全部 11 个已知 App id + wait + portal", () => {
-    for (const id of KNOWN_APP_IDS) {
-      expect(STATE_META[id], `缺 App 状态映射: ${id}`).toBeDefined();
-    }
-    expect(STATE_META.wait).toBeDefined();
-    expect(STATE_META.portal).toBeDefined();
-  });
-
-  it("wait = 语义黄（--scheduler = 等待），符合 DESIGN.md", () => {
-    expect(STATE_META.wait?.color).toBe("hsl(var(--scheduler))");
-    expect(STATE_META.wait?.label).toBe("等待");
-  });
-
-  it("portal 用中性弱色", () => {
-    expect(STATE_META.portal?.color).toBe("hsl(var(--muted-foreground))");
-  });
-
-  it("每个状态颜色互不相同（同图多带不撞色）", () => {
-    const colors = Object.values(STATE_META).map(meta => meta.color);
-    expect(new Set(colors).size).toBe(colors.length);
-  });
-});
-
+// 「状态时间占比」图只显式钉两个语义状态（DESIGN.md），其余状态一律回落后端原始 tag + 轮转色。
 describe("stateSeriesMeta 解析器", () => {
-  it("命中 STATE_META 时返回其 label + color", () => {
-    expect(stateSeriesMeta("qq", 0)).toEqual(STATE_META.qq);
-    expect(stateSeriesMeta("wait", 5)).toEqual(STATE_META.wait);
+  it("wait = 语义黄 + 中文名「等待」（DESIGN.md 钉死）", () => {
+    expect(stateSeriesMeta("wait", 0)).toEqual({ label: "等待", color: "hsl(var(--scheduler))" });
   });
 
-  it("未命中（新增 App 漂移）时回落到 STATE_FALLBACK 色 + 带 id 的 label，不缺色不崩", () => {
-    const resolved = stateSeriesMeta("brand_new_app", 3);
-    expect(resolved?.color).toBe(STATE_FALLBACK.color);
-    expect(resolved?.label).toContain("brand_new_app");
+  it("portal = 中性弱色 + 中文名「桌面」", () => {
+    expect(stateSeriesMeta("portal", 1)).toEqual({
+      label: "桌面",
+      color: "hsl(var(--muted-foreground))",
+    });
+  });
+
+  it("其余状态（App / 新增漂移）返回 undefined → 回落后端原始 tag + 轮转色，绝不再出现「未知」", () => {
+    // 已知 App：不再维护名字/配色映射，图例直接用原始 tag。
+    expect(stateSeriesMeta("qq", 2)).toBeUndefined();
+    // gba 曾漏在旧表里显示成「未知（gba）」；现在回落成原始 tag "gba"。
+    expect(stateSeriesMeta("gba", 3)).toBeUndefined();
+    // 未来任意新增 App：零维护，同样回落，不会「未知」。
+    expect(stateSeriesMeta("brand_new_app", 4)).toBeUndefined();
   });
 });


### PR DESCRIPTION
## 做了什么

大盘「状态时间占比」堆叠面积图三处调整（回应创造者诉求）：

1. **图例按原始 tag** —— 拆掉 `state-meta` 里 13 条「状态 id → 中文名」映射，各 App 直接显示原始 `state` tag（`qq`/`gba`…）。后端分组查询本就返回原始 tag 作 label，前端停止覆盖即可。
2. **「未知」消失** —— 删掉 `STATE_FALLBACK`。没有名字查找就没有查不到；漏在旧表外的 `gba` 从「未知（gba）」变回 `gba`，新增 App 零维护。
3. **`wait` 恒置顶** —— 新增 `MetricChartView` 的 `pinSeriesToTop` prop + 纯函数 `orderSeriesForStack`，把指定序列移到堆叠渲染末位（Recharts 末位 = 视觉最顶），不碰 `dataKey`/`color`，守住「绝不重新编号」不变量。

`wait`/`portal` 两个语义状态保留中文名 + DESIGN.md 钉死的语义色（wait=黄、portal=中性）；其余 App 走 `seriesColors` 轮转。

## 边界

纯前端展示层，无 DB / 契约 / 后端采样改动。上线只需全量 `pnpm build` + 单服务重载 `gateway`（不动 agent 热状态）。

## 验证

- 五件套全绿：build / typecheck / lint(0 错) / format / knip
- web 测试 47 passed（重写 `state-meta` 用例 + 新增 `orderSeriesForStack` 5 例）
- codex 独立 review：NONE

Closes #569