### PR TITLE
feat(web): LLM 调用历史详情标示 thinking 块存在

### DIFF
--- a/apps/web/src/pages/llm-history/LlmChatCallDetailPanel.tsx
+++ b/apps/web/src/pages/llm-history/LlmChatCallDetailPanel.tsx
@@ -3,7 +3,11 @@ import {
   type LlmChatCallStatus,
   type LlmChatCallSummary,
 } from "@kagami/console-api/llm-chat-call";
-import { type LlmRequestMessage, type LlmRequestUserContentPart } from "@kagami/llm-api/llm-chat";
+import {
+  type LlmRequestMessage,
+  type LlmRequestUserContentPart,
+  type LlmThinkingBlockPayload,
+} from "@kagami/llm-api/llm-chat";
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { getApiErrorMessage } from "@/lib/api";
 import { formatDateTime } from "@/lib/format";
@@ -242,6 +246,11 @@ export function LlmChatCallDetailPanel({ id, summary }: LlmChatCallDetailPanelPr
                     toolCalls: parsed.response.message.toolCalls,
                   })}
                 >
+                  {parsed.response.message.thinkingBlocks?.length ? (
+                    <div className="mb-2 flex items-center gap-2">
+                      <ThinkingBadge blocks={parsed.response.message.thinkingBlocks} />
+                    </div>
+                  ) : null}
                   <MessageContent
                     content={parsed.response.message.content}
                     emptyHint={
@@ -403,6 +412,7 @@ function MessageCard({ message, index }: { message: LlmRequestMessage; index: nu
     <ContentCard title={title} preview={preview}>
       <div className="mb-2 flex items-center gap-2">
         <Badge variant="secondary">{message.role}</Badge>
+        <ThinkingBadge blocks={message.role === "assistant" ? message.thinkingBlocks : undefined} />
       </div>
       <MessageContent
         content={renderMessageContent(message.content)}
@@ -424,6 +434,18 @@ function MessageCard({ message, index }: { message: LlmRequestMessage; index: nu
       ) : null}
     </ContentCard>
   );
+}
+
+/**
+ * thinking 块的**存在性**标示（issue #577）：只读 `blocks.length`，绝不触碰块内的
+ * `thinking` / `data` 字段——思考正文因此在组件层面就无从进入 DOM，不是靠肉眼保证。
+ */
+function ThinkingBadge({ blocks }: { blocks?: LlmThinkingBlockPayload[] }) {
+  if (!blocks || blocks.length === 0) {
+    return null;
+  }
+
+  return <Badge variant="llm">思考 ×{blocks.length}</Badge>;
 }
 
 function MessageContent({ content, emptyHint }: { content: string; emptyHint?: string }) {

--- a/apps/web/test/llm-chat-call-detail-parser.test.ts
+++ b/apps/web/test/llm-chat-call-detail-parser.test.ts
@@ -1,0 +1,95 @@
+import { type LlmChatCallItem } from "@kagami/console-api/llm-chat-call";
+import { describe, expect, it } from "vitest";
+import { parseLlmChatCallDetail } from "@/pages/llm-history/llm-chat-call-detail-parser";
+
+// #573 起主 Agent 开了 adaptive thinking，request_payload 里 assistant 消息带 thinkingBlocks、
+// root 带 thinking 档位。契约 schema 是 .strict() 的：一旦哪天有人把这两个字段从
+// @kagami/llm-api/llm-chat 摘掉，前端就会当场退化成「结构化解析失败」红框、整个 LLM
+// 调用历史对主 Agent 全线失效（issue #577 就是这么炸的）。这两条测试钉住这个回归。
+
+function buildItem(requestPayload: Record<string, unknown>): LlmChatCallItem {
+  return {
+    id: 1,
+    requestId: "req-1",
+    seq: 1,
+    provider: "claude-code",
+    model: "claude-sonnet-4",
+    scene: "agent",
+    extension: null,
+    status: "success",
+    latencyMs: 1200,
+    createdAt: "2026-07-25T00:00:00.000Z",
+    requestPayload,
+    responsePayload: {
+      provider: "claude-code",
+      model: "claude-sonnet-4",
+      message: {
+        role: "assistant",
+        content: "回答",
+        toolCalls: [],
+        thinkingBlocks: [{ type: "thinking", thinking: "推理过程", signature: "sig-2" }],
+      },
+    },
+    nativeRequestPayload: null,
+    nativeResponsePayload: null,
+    error: null,
+    nativeError: null,
+  };
+}
+
+describe("parseLlmChatCallDetail", () => {
+  it("带 thinkingBlocks 与 root thinking 的 payload 解析无 schemaError", () => {
+    const parsed = parseLlmChatCallDetail(
+      buildItem({
+        system: "你是小镜",
+        model: "claude-sonnet-4",
+        messages: [
+          { role: "user", content: "在吗" },
+          {
+            role: "assistant",
+            content: "在的",
+            toolCalls: [],
+            thinkingBlocks: [{ type: "thinking", thinking: "推理过程", signature: "sig-1" }],
+          },
+        ],
+        tools: [],
+        toolChoice: "auto",
+        thinking: "low",
+      }),
+    );
+
+    expect(parsed.schemaErrors).toEqual([]);
+    expect(parsed.hasSchemaError).toBe(false);
+    expect(parsed.request?.thinking).toBe("low");
+    expect(parsed.response?.message.thinkingBlocks).toHaveLength(1);
+  });
+
+  it("thinking 与 redacted_thinking 混排时两个块都保留（徽章计数口径）", () => {
+    const parsed = parseLlmChatCallDetail(
+      buildItem({
+        model: "claude-sonnet-4",
+        messages: [
+          {
+            role: "assistant",
+            content: "",
+            toolCalls: [],
+            thinkingBlocks: [
+              { type: "thinking", thinking: "推理过程", signature: "sig-1" },
+              { type: "redacted_thinking", data: "encrypted-blob" },
+            ],
+          },
+        ],
+        tools: [],
+        toolChoice: "auto",
+      }),
+    );
+
+    expect(parsed.hasSchemaError).toBe(false);
+
+    const message = parsed.request?.messages[0];
+    expect(message?.role).toBe("assistant");
+    const blocks = message?.role === "assistant" ? message.thinkingBlocks : undefined;
+    expect(blocks).toHaveLength(2);
+    expect(blocks?.map(block => block.type)).toEqual(["thinking", "redacted_thinking"]);
+  });
+});


### PR DESCRIPTION
## 做了什么

LLM 调用历史详情面板对含 thinking 块的 assistant 消息显示一个 `思考 ×N` 徽章，**只标示存在、不渲染思考正文**。

- 输入区：`MessageCard` 的 role 徽章右侧
- 输出区：「Assistant 输出」卡片顶部
- `redacted_thinking` 一并计数，不作区分
- 徽章用 `Badge variant="llm"`（正蓝＝推理/LLM，DESIGN.md line 41）

## 关于那个「结构化解析失败」

报错文本是 `Unrecognized key(s) in object: 'thinkingBlocks'`，看着像契约缺字段，**实际不是**：`packages/llm-api/src/llm-chat.ts` 的 schema 早在 #573 就支持了 `thinkingBlocks`(:98/:145) 与 root `thinking`(:130)。`Unrecognized key(s)` 是 zod `.strict()` 报文，只有**不认识该字段的旧 schema** 才会产生 —— 真因是控制台前端还停在 #573 之前的构建（#573 只跑了 `app:deploy agent`，而 `app:deploy gateway` 不重建 web）。

所以本 PR **一行 schema 都没改**。报错会随本次前端重新构建上线而消失，与徽章代码无因果关系 —— issue 里的 AC 因此拆成了 A(代码)/B(渲染)/C(部署) 三组，避免把部署结果误当代码验收。

## 思考正文不进 DOM 的保证方式

不是靠肉眼，是结构约束：`ThinkingBadge` 组件体内**只读 `blocks.length`**，绝不触碰块内的 `thinking` / `data` 字段。已验证：

1. 文件内无 `.thinking` 正文字段读取
2. `ThinkingBadge` 对 `blocks` 的属性访问只有 `.length` ×2
3. 除 `detailQuery.data`（react-query）外无 `.data` 读取

**范围说明**：「原始 Payload」折叠区仍原样展示完整 JSON（含 thinking 正文）。那是它的职责 —— 它同样展示完整 system prompt 与全部消息，是排障兜底。此处诉求是**降噪**而非保密（自己 Agent 的思考、私有内网单用户控制台），在那里过滤反而有害。codex review 提了这点，判断为按设计保留。

## 测试

新增 `apps/web/test/llm-chat-call-detail-parser.test.ts` 2 例，钉住契约对 thinking 字段的支持。

**变异测试验证过它有牙**：临时从 `llm-api` 摘掉 assistant 的 `thinkingBlocks` 后重建，两例立即转红，且红在 `schemaErrors` 非空 —— 正是本 issue 报的失败模式。

徽章渲染本身不加组件测试：`apps/web` 无 React 测试基建（无 jsdom / testing-library），为两个条件渲染引入整套基建不成比例；且按上面的范围说明，一个全 DOM「无 thinking 文本」断言反而会被原始 Payload 面板判红。

## 实现期对 spec 的两处更正

1. **测试放 `test/` 不是 `src/`** —— `apps/web/vitest.config.ts:12` 的 include 只扫 `test/`，放 src 下不会被跑到。（issue 里那条「须实测确认」的 AC 当场兑现了。）
2. **AC A3 的 grep 断言有假阳性** —— `\.data\b` 会命中 react-query 的 `detailQuery.data`，已收紧为三条精确检查。

详见 issue #577 的评论。

## 验收

- 五件套 + `pnpm test` 全绿（合并 master 后重跑：1380 passed）
- 无文档需要更新：DESIGN.md 已记录 `llm` 变体存在，本次是应用它而非改设计系统

## 部署

含前端改动，`app:deploy gateway` **不重建 web** —— 须先全量 `pnpm build` 再 `pnpm app:deploy gateway`。选 gateway 单服务重载不打断 `kagami-agent` 热状态。

Closes #577
