### PR TITLE
feat(llm): agent usage 主力模型切到 claude-opus-5

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -119,6 +119,7 @@ server:
       claudeCode:
         baseUrl: https://api.anthropic.com
         models:
+          - claude-opus-5
           - claude-opus-4-8
           - claude-opus-4-6
           - claude-sonnet-5
@@ -140,7 +141,7 @@ server:
       agent:
         attempts:
           - provider: claude-code
-            model: claude-opus-4-6
+            model: claude-opus-5
             times: 3
         # adaptive thinking effort（#573）。usage=agent 覆盖主 Agent 与镜像 fork task agent
         # （它们字节级复用主 Agent 前缀，必须同 lineage）。删掉此行即整体关回 disabled。

--- a/packages/llm-client/src/providers/claude-code-request.ts
+++ b/packages/llm-client/src/providers/claude-code-request.ts
@@ -10,7 +10,7 @@ const CLAUDE_CODE_SDK_PROMPT = "You are a Claude agent, built on Anthropic's Cla
 const CLAUDE_CODE_BILLING_HEADER =
   "x-anthropic-billing-header: cc_version=2.1.76.b57; cc_entrypoint=sdk-cli; cch=00000;";
 const DEFAULT_MAX_TOKENS = 4096;
-const CLAUDE_4_MAX_TOKENS = 32000;
+const LARGE_OUTPUT_MAX_TOKENS = 32000;
 
 /**
  * LlmChatRequest → Anthropic Messages 请求体（含 system 前缀块 / thinking / 工具映射）。
@@ -239,15 +239,26 @@ function toClaudeToolChoice(
 }
 
 function resolveClaudeMaxTokens(model: string): number {
-  if (isClaude4Model(model)) {
-    return CLAUDE_4_MAX_TOKENS;
+  if (isLargeOutputModel(model)) {
+    return LARGE_OUTPUT_MAX_TOKENS;
   }
 
   return DEFAULT_MAX_TOKENS;
 }
 
-function isClaude4Model(model: string): boolean {
-  return model.startsWith("claude-sonnet-4-") || model.startsWith("claude-opus-4-");
+/**
+ * 支持大输出上限的机型（opus / sonnet 的 4 系与 5 系）。
+ *
+ * 注意 max_tokens 是「thinking + 正文」的合计硬顶：开着 adaptive thinking 时漏判会让思考
+ * 吃掉配额、正文中途截断。新增机型必须同步这里，否则静默回落 4096。
+ */
+function isLargeOutputModel(model: string): boolean {
+  return (
+    model.startsWith("claude-sonnet-4-") ||
+    model.startsWith("claude-opus-4-") ||
+    model.startsWith("claude-sonnet-5") ||
+    model.startsWith("claude-opus-5")
+  );
 }
 
 function requireRequestModel(request: { model?: string }): string {

--- a/packages/llm-client/test/claude-code-max-tokens.test.ts
+++ b/packages/llm-client/test/claude-code-max-tokens.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { toClaudeCodeRequestBody } from "../src/providers/claude-code-request.js";
+import type { LlmChatRequest } from "../src/types.js";
+
+// max_tokens 是「thinking + 正文」的合计硬顶：机型漏判会静默回落 4096，
+// 开着 adaptive thinking 时思考吃掉配额、正文中途截断。换主力机型时钉死这条。
+
+function createChatRequest(model: string): LlmChatRequest {
+  return {
+    system: "你是一个测试助手。",
+    messages: [{ role: "user", content: "ping" }],
+    tools: [],
+    toolChoice: "auto",
+    model,
+  };
+}
+
+describe("claude-code max_tokens", () => {
+  it.each([
+    "claude-opus-5",
+    "claude-sonnet-5",
+    "claude-opus-4-8",
+    "claude-opus-4-6",
+    "claude-sonnet-4-6",
+  ])("should give %s the large output budget", model => {
+    expect(toClaudeCodeRequestBody(createChatRequest(model)).max_tokens).toBe(32000);
+  });
+
+  it("should fall back to the conservative budget for other models", () => {
+    expect(toClaudeCodeRequestBody(createChatRequest("claude-haiku-4-5")).max_tokens).toBe(4096);
+  });
+});


### PR DESCRIPTION
## 做了什么

把主 Agent（`usages.agent`）的模型从 `claude-opus-4-6` 换成 `claude-opus-5`。

1. `config.yaml`
   - `usages.agent.attempts[0].model` → `claude-opus-5`
   - `providers.claudeCode.models` 补上 `claude-opus-5`（`LlmClient` 按该白名单校验模型，不加会直接 BizError）
2. `packages/llm-client/src/providers/claude-code-request.ts`
   - 原 `isClaude4Model` 只认 `claude-sonnet-4-` / `claude-opus-4-` 前缀，`claude-opus-5` 不匹配会静默回落 `DEFAULT_MAX_TOKENS = 4096`（现在是 32000）。
   - `max_tokens` 是「thinking + 正文」的合计硬顶，主 Agent 开着 adaptive thinking（effort=low），4096 会让思考吃掉配额、正文中途截断。
   - 改名 `isLargeOutputModel`，覆盖 opus/sonnet 的 4 系与 5 系，预算仍取 32000（没顺手抬到 Opus 5 支持的 128K，超出本次范围）。
3. 新增 `packages/llm-client/test/claude-code-max-tokens.test.ts`：纯逻辑单测，钉死各机型的 max_tokens 预算，防下次换机型再踩同一个坑。

## KV 缓存影响

模型是 KV 缓存身份的一部分，换模型必然作废主 Agent 现有的整条 lineage。部署后第一轮全量换入，属计划性成本，无法规避。`usage` 仍是 `agent` 单一身份，镜像主上下文的 fork task agent（contextSummarizer / todoSuggestionAgent / innerVoice）随之一起切，前缀继续逐字节一致。

`thinking` 配置不动（仍是 `adaptive` + `effort: low`）。Opus 5 上 `thinking: disabled` 只在 effort ≤ high 时被接受——当前 disabled 分支（vision / 强制 tool_choice 场景）不发 `output_config`，effort 走默认 high，不触发 400。

## 验证

`pnpm build` / `typecheck` / `lint` / `format` / `knip` 五件套全过；`pnpm test` 1384 passed。knip 只剩既有的 warn 级条目，与本次改动无关。