### PR TITLE
refactor(llm): claude-code 的 max_tokens 不再按机型分档

### DIFF
--- a/packages/llm-client/src/providers/claude-code-request.ts
+++ b/packages/llm-client/src/providers/claude-code-request.ts
@@ -9,8 +9,19 @@ import type {
 const CLAUDE_CODE_SDK_PROMPT = "You are a Claude agent, built on Anthropic's Claude Agent SDK.";
 const CLAUDE_CODE_BILLING_HEADER =
   "x-anthropic-billing-header: cc_version=2.1.76.b57; cc_entrypoint=sdk-cli; cch=00000;";
-const DEFAULT_MAX_TOKENS = 4096;
-const LARGE_OUTPUT_MAX_TOKENS = 32000;
+/**
+ * 所有机型统一的输出上限（`max_tokens` 是 Messages API 必填字段，省不掉）。
+ *
+ * 这里刻意不按机型分档：分档来自 provider 初版对齐官方 CLI 请求形状时的 Claude 3.x/4 代际
+ * 探测（当年 3.x 上限就是 4096 且不支持 thinking），代际差今天已消失——白名单里的机型输出
+ * 上限最低的是 haiku-4-5 的 64K，全都远高于此。留着分档只剩一个后果：新机型漏进白名单就
+ * 静默降到 4096，而 max_tokens 是「thinking + 正文」的合计硬顶，开着 adaptive thinking 时
+ * 表现为正文中途截断，很难往这上面想。
+ *
+ * 代价是若将来接入上限低于该值的机型，会拿到 Anthropic 的 400（max_tokens exceeds），
+ * 这是刻意的：显式失败远好过静默截断。
+ */
+const CLAUDE_MAX_TOKENS = 32000;
 
 /**
  * LlmChatRequest → Anthropic Messages 请求体（含 system 前缀块 / thinking / 工具映射）。
@@ -36,7 +47,7 @@ export function toClaudeCodeRequestBody(
   return {
     model,
     stream: true,
-    max_tokens: resolveClaudeMaxTokens(model),
+    max_tokens: CLAUDE_MAX_TOKENS,
     cache_control: {
       type: "ephemeral",
       ttl: "1h",
@@ -236,29 +247,6 @@ function toClaudeToolChoice(
     type: "tool",
     name: toolChoice.tool_name,
   };
-}
-
-function resolveClaudeMaxTokens(model: string): number {
-  if (isLargeOutputModel(model)) {
-    return LARGE_OUTPUT_MAX_TOKENS;
-  }
-
-  return DEFAULT_MAX_TOKENS;
-}
-
-/**
- * 支持大输出上限的机型（opus / sonnet 的 4 系与 5 系）。
- *
- * 注意 max_tokens 是「thinking + 正文」的合计硬顶：开着 adaptive thinking 时漏判会让思考
- * 吃掉配额、正文中途截断。新增机型必须同步这里，否则静默回落 4096。
- */
-function isLargeOutputModel(model: string): boolean {
-  return (
-    model.startsWith("claude-sonnet-4-") ||
-    model.startsWith("claude-opus-4-") ||
-    model.startsWith("claude-sonnet-5") ||
-    model.startsWith("claude-opus-5")
-  );
 }
 
 function requireRequestModel(request: { model?: string }): string {

--- a/packages/llm-client/test/claude-code-max-tokens.test.ts
+++ b/packages/llm-client/test/claude-code-max-tokens.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 import { toClaudeCodeRequestBody } from "../src/providers/claude-code-request.js";
 import type { LlmChatRequest } from "../src/types.js";
 
-// max_tokens 是「thinking + 正文」的合计硬顶：机型漏判会静默回落 4096，
-// 开着 adaptive thinking 时思考吃掉配额、正文中途截断。换主力机型时钉死这条。
+// max_tokens 不按机型分档：换主力机型不该再牵动这里。曾经的代际分档会让新机型静默降到
+// 4096，而 max_tokens 是「thinking + 正文」的合计硬顶，表现为正文中途截断、极难归因。
 
 function createChatRequest(model: string): LlmChatRequest {
   return {
@@ -22,11 +22,9 @@ describe("claude-code max_tokens", () => {
     "claude-opus-4-8",
     "claude-opus-4-6",
     "claude-sonnet-4-6",
-  ])("should give %s the large output budget", model => {
+    "claude-haiku-4-5",
+    "claude-some-future-model",
+  ])("should send the same budget regardless of model (%s)", model => {
     expect(toClaudeCodeRequestBody(createChatRequest(model)).max_tokens).toBe(32000);
-  });
-
-  it("should fall back to the conservative budget for other models", () => {
-    expect(toClaudeCodeRequestBody(createChatRequest("claude-haiku-4-5")).max_tokens).toBe(4096);
   });
 });


### PR DESCRIPTION
承接 #582 的收尾：把 `max_tokens` 的机型分档删掉，换成单一常量。

## 这个判断为什么是残留

`git log -S` 追到源头 `8be2ac67`（*fix: align Claude Code provider request shape*）——`CLAUDE_4_MAX_TOKENS` 是和 `CLAUDE_CODE_SDK_PROMPT` / `CLAUDE_CODE_BILLING_HEADER` 同一批进来的，属于「把请求体对齐官方 CLI 形状」的一部分。它当时还兼管 thinking 参数形态：

```ts
if (isClaude4Model(input.model)) {
  return { thinking: { type: "enabled", budget_tokens: CLAUDE_4_THINKING_BUDGET } };
}
```

所以它真正的语义是**机型代际探测**，不是能力评级——那个时间点 Claude 3.x 输出上限就是 4096、也不支持 extended thinking。#268（`2e8c2880`）把 thinking 改成 usage 配置驱动后 `isClaudeAdaptiveModel` 被删，这个函数只剩 max_tokens 一处调用，名字问「是不是 Claude 4」、实际答「输出上限给多少」，中间那条因果链早已不在。

## 为什么现在能直接删

`claudeCode.models` 白名单里已经没有任何机型需要 4096 那一档：

| 机型 | 官方输出上限 | 改前 | 改后 |
|---|---|---|---|
| claude-opus-5 / 4-8 / 4-6 | 128K | 32000 | 32000 |
| claude-sonnet-5 / 4-6 | 128K | 32000 | 32000 |
| claude-haiku-4-5 | 64K | **4096** | 32000 |

实际在用的两个 usage（`agent` = opus-5、`vision` = sonnet-5）本就走 32000，**行为零变更**。唯一变的 haiku-4-5 在白名单里但没有任何 usage 引用。

留着分档只剩一个后果：新机型漏同步就静默降到 4096，而 `max_tokens` 是「thinking + 正文」的合计硬顶，开着 adaptive thinking 时表现为正文中途截断——切 `claude-opus-5` 时刚踩过一次。

## 取舍

没有把上限抬到各机型的真实天花板（128K），也没有把 `maxTokens` 挪进 `providers.claudeCode.models` 配置——两者都会重新引入「逐机型关心上限」这件事，而这正是要消掉的。选 32000 是因为它对白名单里所有机型都安全，且对在用机型是零变更。

若将来接入上限低于 32000 的机型，会拿到 Anthropic 的 400（`max_tokens exceeds`）。这是刻意的：显式失败远好过静默截断。

## 验证

五件套全过；`pnpm test` 1407 passed。测试语义同步从「分档正确」改成「换任何机型都是同一个预算」，并塞了一个虚构机型 `claude-some-future-model` 钉死这条。