### PR TITLE
revert(llm): agent usage 回退到 claude-opus-4-6

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -142,7 +142,7 @@ server:
       agent:
         attempts:
           - provider: claude-code
-            model: claude-opus-5
+            model: claude-opus-4-6
             times: 3
         # adaptive thinking effort（#573）。usage=agent 覆盖主 Agent 与镜像 fork task agent
         # （它们字节级复用主 Agent 前缀，必须同 lineage）。删掉此行即整体关回 disabled。


### PR DESCRIPTION
主 Agent 模型从 `claude-opus-5` 切回 `claude-opus-4-6`——#582 的反向操作。

只动 `usages.agent` 一行。`claude-opus-5` 保留在 `claudeCode.models` 白名单里，之后要再切回去只改这一行。

`max_tokens` 不受影响：#583 已经把机型分档删了，两个机型都是 32000。

换模型同样作废主 Agent 现有的 KV 缓存 lineage，部署后第一轮全量换入。