### PR TITLE
refactor(kernel): 文本截断收敛到唯一码点安全实现

### DIFF
--- a/apps/agent/src/agent/apps/amap/client/amap-fetch.ts
+++ b/apps/agent/src/agent/apps/amap/client/amap-fetch.ts
@@ -1,4 +1,5 @@
 import { BizError } from "@kagami/kernel/errors/biz-error";
+import { truncateWithEllipsis } from "@kagami/kernel/utils/text";
 import {
   RETRYABLE_STATUS,
   computeBackoffMs,
@@ -239,7 +240,8 @@ export async function amapFetchImage(url: string, options: AmapFetchOptions): Pr
     // 非 JSON 兜底文本可能回显含 key 的请求 URL，先脱敏再进 info，绝不让 key 泄漏进上下文。
     const text = await response.text();
     let infocode = "";
-    let info = redactUrl(text.slice(0, 200));
+    // 码点安全截断：这段错误文本会经 AmapError 进上下文，裸 slice 可能留半个 emoji。
+    let info = redactUrl(truncateWithEllipsis(text, 200, ""));
     try {
       const parsed = JSON.parse(text) as AmapJsonEnvelope;
       infocode = coerceStr(parsed.infocode);

--- a/apps/agent/src/agent/capabilities/ithome/application/ithome.service.ts
+++ b/apps/agent/src/agent/capabilities/ithome/application/ithome.service.ts
@@ -1,4 +1,4 @@
-import { stripLoneSurrogates } from "@kagami/kernel/utils/text";
+import { truncateWithEllipsisDetailed, type TruncatedText } from "@kagami/kernel/utils/text";
 import type { IthomeArticleDao, IthomeArticleListItem } from "./ithome-article.dao.js";
 import type { IthomeFeedCursorDao } from "./ithome-feed-cursor.dao.js";
 import type { IthomeClient } from "./ithome-client.js";
@@ -250,26 +250,8 @@ export class IthomeService {
   }
 }
 
-function truncateText(
-  value: string,
-  maxChars: number,
-): {
-  text: string;
-  truncated: boolean;
-} {
-  // 按 Unicode 码点截断，绝不从代理对（emoji）中间切开——半个 emoji 会让上游 400 掉
-  // 整条请求（见「引用预览按 UTF-16 长度截断劈开代理对」事故）。先剥落单代理项再按码点判长。
-  const clean = stripLoneSurrogates(value);
-  const codePoints = Array.from(clean);
-  if (codePoints.length <= maxChars) {
-    return {
-      text: clean,
-      truncated: false,
-    };
-  }
-
-  return {
-    text: `${codePoints.slice(0, maxChars).join("").trimEnd()}……`,
-    truncated: true,
-  };
+function truncateText(value: string, maxChars: number): TruncatedText {
+  // 码点安全截断走 kernel 正典（绝不劈开 emoji 代理对）；这里只声明本站点的排版：
+  // 后缀 "……"、截断时先去掉正文尾部空白。输出与手写版逐字节一致（正文进上下文，不可漂移）。
+  return truncateWithEllipsisDetailed(value, maxChars, { ellipsis: "……", trimEnd: true });
 }

--- a/apps/agent/src/agent/capabilities/terminal/application/terminal.service.ts
+++ b/apps/agent/src/agent/capabilities/terminal/application/terminal.service.ts
@@ -4,6 +4,7 @@ import { mkdir, stat } from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
 import { AppLogger } from "@kagami/kernel/logger/logger";
+import { truncateWithEllipsis } from "@kagami/kernel/utils/text";
 import { TERMINAL_ERROR, type TerminalErrorCode } from "../domain/errors.js";
 import type { TerminalStateDao } from "./terminal-state.dao.js";
 import type { TerminalOutputDao } from "./terminal-output.dao.js";
@@ -668,9 +669,15 @@ function killSpawnedProcessGroup(child: ChildProcess, signal: NodeJS.Signals): v
   }
 }
 
+/**
+ * Buffer.from("...", "utf8") 本身就会对非法字节做 replacement，但为了显式保证 JSON 可序列化，
+ * 再把 lone surrogate 也替换掉。
+ *
+ * 刻意**不复用** kernel 的 `stripLoneSurrogates`：那条正典是「丢弃」半个字符（面向要进 Agent
+ * 上下文的外部文本），而终端输出是给人看的原始字节流，这里要的是「替换成 U+FFFD」——保留坏
+ * 字节的位置与可见性，让人看得出哪里乱码。语义不同故各留一份；截断则统一走正典。
+ */
 function sanitizeUtf8String(s: string): string {
-  // Buffer.from("...", "utf8") 本身就会对非法字节做 replacement，但为了
-  // 显式保证 JSON 可序列化，再把 lone surrogate 也替换掉
   return s.replace(
     /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g,
     "\uFFFD",
@@ -686,5 +693,6 @@ function generateOutputId(): string {
 }
 
 function truncateForLog(s: string): string {
-  return s.length > 200 ? `${s.slice(0, 200)}…` : s;
+  // 命令行可能含 emoji；裸 `.slice()` 会把代理对劈成半个字符写进日志。
+  return truncateWithEllipsis(s, 200);
 }

--- a/apps/agent/src/agent/runtime/context/default-agent-context.ts
+++ b/apps/agent/src/agent/runtime/context/default-agent-context.ts
@@ -1,4 +1,5 @@
 import type { LlmMessage } from "@kagami/llm-client";
+import { truncateWithEllipsisDetailed, type TruncatedText } from "@kagami/kernel/utils/text";
 import { createAgentSystemPrompt } from "../root-agent/system-prompt.js";
 import type {
   AgentContext,
@@ -225,17 +226,9 @@ function renderUserMessagePreview(
   return parts.join("\n");
 }
 
-function truncateText(input: string, maxLength: number): { text: string; truncated: boolean } {
-  const normalized = input.trim();
-  if (normalized.length <= maxLength) {
-    return {
-      text: normalized,
-      truncated: false,
-    };
-  }
-
-  return {
-    text: `${normalized.slice(0, Math.max(0, maxLength - 1))}…`,
-    truncated: true,
-  };
+function truncateText(input: string, maxLength: number): TruncatedText {
+  // 码点安全截断走 kernel 正典：裸 `.slice()` 会劈开 emoji 代理对，给管理台预览留半个字符。
+  // 与旧手写版的唯一差异：省略号计在 maxLength 之外（旧版从预算里挪 1 个字符给它），
+  // 对管理台预览无影响，换来与全仓其它截断点一致的语义。
+  return truncateWithEllipsisDetailed(input.trim(), maxLength, { trimEnd: true });
 }

--- a/apps/agent/test/agent/default-agent-context.test.ts
+++ b/apps/agent/test/agent/default-agent-context.test.ts
@@ -330,6 +330,8 @@ describe("DefaultAgentContext", () => {
       },
     ]);
 
+    // previewLength 是正文码点预算，省略号计在预算之外（与全仓其它截断点一致：正文 12 码点
+    // + "…"，正文尾部空白先 trim 掉）。旧手写版从预算里挪 1 个字符给省略号，收敛到正典后统一。
     await expect(
       context.getDashboardSummary({
         limit: 2,
@@ -342,7 +344,7 @@ describe("DefaultAgentContext", () => {
         {
           kind: "llm_message",
           label: "Assistant",
-          preview: "assistant r…",
+          preview: "assistant re…",
           truncated: true,
         },
         {

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -5,10 +5,18 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+/**
+ * 按 Unicode 码点截断，绝不从代理对（emoji）中间切开——裸 `.slice()` 会让预览里出现半个字符
+ * （渲染成方块）。
+ *
+ * 这是全仓唯一不复用 `@kagami/kernel/utils/text` 正典的截断点：kernel 是后端包，前端不依赖它，
+ * 为一个函数把它拖进浏览器包会破坏包边界（还会把 @types/node 带进来）。逻辑等价、刻意各留一份。
+ */
 export function truncateText(value: string, maxLength: number): string {
-  if (value.length <= maxLength) {
+  const codePoints = Array.from(value); // 字符串迭代器按码点拆分，emoji 是单个元素
+  if (codePoints.length <= maxLength) {
     return value;
   }
 
-  return `${value.slice(0, maxLength)}...`;
+  return `${codePoints.slice(0, maxLength).join("")}...`;
 }

--- a/packages/kernel/src/utils/text.ts
+++ b/packages/kernel/src/utils/text.ts
@@ -24,18 +24,44 @@ export function stripLoneSurrogates(text: string): string {
   return out;
 }
 
+export type TruncatedText = {
+  text: string;
+  /** 是否真的发生了截断（用于「内容过长」类提示 / 落库标记）。 */
+  truncated: boolean;
+};
+
 /**
- * 按 Unicode 码点安全截断：绝不从代理对（emoji）中间切开。先剥除输入里已有的落单代理项，
- * 再按码点数截断——超过 maxCodePoints 时截到该长度并追加 ellipsis（默认 …）。
+ * 按 Unicode 码点安全截断并报告是否截断——**全仓截断逻辑的唯一实现**。绝不从代理对
+ * （emoji）中间切开：先剥除输入里已有的落单代理项，再按码点数截断，超出时截到该长度并
+ * 追加 ellipsis（默认 …）。
  *
  * maxCodePoints 以「码点」计（一个 emoji 记 1），不是 UTF-16 码元；这正是 `.slice(0, n)`
- * 会劈开代理对、而本函数不会的原因。
+ * 会劈开代理对、而本函数不会的原因。半个 emoji 进上下文会让上游以 "no low surrogate"
+ * 400 掉整条请求、每轮复发（见事故「半个 emoji 打挂会话」），所以任何外部文本在进入
+ * Agent 上下文前都必须走这里，不要再就地手写 slice / Array.from。
+ *
+ * - `ellipsis`：截断后缀，按站点排版需要给（省略号计在 maxCodePoints **之外**）。
+ * - `trimEnd`：截断分支里，追加后缀前先去掉正文尾部空白（避免「正文 …」这种空格夹缝）。
  */
-export function truncateWithEllipsis(text: string, maxCodePoints: number, ellipsis = "…"): string {
+export function truncateWithEllipsisDetailed(
+  text: string,
+  maxCodePoints: number,
+  options?: { ellipsis?: string; trimEnd?: boolean },
+): TruncatedText {
   const clean = stripLoneSurrogates(text);
   const codePoints = Array.from(clean); // 字符串迭代器按码点拆分，emoji 是单个元素
   if (codePoints.length <= maxCodePoints) {
-    return clean;
+    return { text: clean, truncated: false };
   }
-  return codePoints.slice(0, maxCodePoints).join("") + ellipsis;
+
+  const body = codePoints.slice(0, Math.max(0, maxCodePoints)).join("");
+  return {
+    text: `${options?.trimEnd ? body.trimEnd() : body}${options?.ellipsis ?? "…"}`,
+    truncated: true,
+  };
+}
+
+/** {@link truncateWithEllipsisDetailed} 的便捷封装：只要结果文本、不关心是否截断。 */
+export function truncateWithEllipsis(text: string, maxCodePoints: number, ellipsis = "…"): string {
+  return truncateWithEllipsisDetailed(text, maxCodePoints, { ellipsis }).text;
 }

--- a/packages/kernel/test/utils.test.ts
+++ b/packages/kernel/test/utils.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { assertNever } from "../src/utils/assert.js";
-import { stripLoneSurrogates, truncateWithEllipsis } from "../src/utils/text.js";
+import {
+  stripLoneSurrogates,
+  truncateWithEllipsis,
+  truncateWithEllipsisDetailed,
+} from "../src/utils/text.js";
 
 describe("stripLoneSurrogates — 剥除落单代理项（事故：半个 emoji 打挂会话）", () => {
   it("完整代理对（emoji）成对保留", () => {
@@ -50,6 +54,52 @@ describe("truncateWithEllipsis — 按码点截断，绝不劈代理对", () => 
   it("输入自带落单代理时先清理再计数", () => {
     const dirty = "ab" + "\uD83D" + "cd";
     expect(truncateWithEllipsis(dirty, 10)).toBe("abcd");
+  });
+});
+
+describe("truncateWithEllipsisDetailed — 全仓截断唯一实现，附是否截断标记", () => {
+  it("不超限时 truncated=false 且不加省略号", () => {
+    expect(truncateWithEllipsisDetailed("hello", 10)).toEqual({ text: "hello", truncated: false });
+  });
+
+  it("超限时 truncated=true 并追加省略号", () => {
+    expect(truncateWithEllipsisDetailed("abcdef", 3)).toEqual({ text: "abc…", truncated: true });
+  });
+
+  it("emoji 记 1 个码点，截断落在 emoji 边界（产物无落单代理）", () => {
+    const result = truncateWithEllipsisDetailed("😀😁😂🤣😃", 3);
+    expect(result).toEqual({ text: "😀😁😂…", truncated: true });
+    expect(stripLoneSurrogates(result.text)).toBe(result.text);
+  });
+
+  it("trimEnd 只作用于截断分支的正文尾部空白（ithome 正文排版依赖）", () => {
+    expect(truncateWithEllipsisDetailed("ab   cd", 5, { ellipsis: "……", trimEnd: true })).toEqual({
+      text: "ab……",
+      truncated: true,
+    });
+  });
+
+  it("不开 trimEnd 时保留正文尾部空白", () => {
+    expect(truncateWithEllipsisDetailed("ab   cd", 5, { ellipsis: "……" })).toEqual({
+      text: "ab   ……",
+      truncated: true,
+    });
+  });
+
+  it("不超限时即使开了 trimEnd 也原样返回（只剥落单代理）", () => {
+    expect(truncateWithEllipsisDetailed("ab  ", 10, { trimEnd: true })).toEqual({
+      text: "ab  ",
+      truncated: false,
+    });
+  });
+
+  it("maxCodePoints 为 0 / 负数时正文为空，不越界取值", () => {
+    expect(truncateWithEllipsisDetailed("abc", 0)).toEqual({ text: "…", truncated: true });
+    expect(truncateWithEllipsisDetailed("abc", -1)).toEqual({ text: "…", truncated: true });
+  });
+
+  it("truncateWithEllipsis 与本函数同源（便捷封装只取 text）", () => {
+    expect(truncateWithEllipsis("abcdef", 3)).toBe(truncateWithEllipsisDetailed("abcdef", 3).text);
   });
 });
 


### PR DESCRIPTION
技术债清理续：**文本截断助手仍分散**（上一批 PR #576 只修了 hn-reader 一处）。

## 问题

截断逻辑散在 5 处各写一份，两类写法都有问题：

- **裸 `.slice()`**（UTF-16 码元）会从 emoji 代理对中间切开 → 半个字符进上下文即触发上游 `no low surrogate` 400、每轮复发（事故簿「半个 emoji 打挂会话」的根因形状）。
- **手写 `Array.from` 码点版**是把 kernel 正典抄了一遍，各自漂移、无人保证一致。

## 做法

kernel 新增 **`truncateWithEllipsisDetailed`** 作为全仓唯一实现：返回 `{ text, truncated }`（此前需要「是否截断」标记的站点正是抄实现的动机），支持自定义省略号与截断分支 `trimEnd`。原 `truncateWithEllipsis` 退化成只取 `text` 的便捷封装，两者同源。

**收敛的调用点：**

| 站点 | 原状 | 处理 |
|---|---|---|
| `ithome.service` | 手写码点截断（抄正典） | 改调正典，**输出逐字节不变**（正文进上下文，不可漂移） |
| `default-agent-context` | 裸 `.slice()` | 改调正典（管理台预览） |
| `terminal.truncateForLog` | 裸 `.slice()` | 改调正典（命令行可能含 emoji） |
| `amap-fetch` | 错误正文 `slice(0,200)` | 改调正典（该文本经 `AmapError` 进上下文） |

**刻意各留一份，均已注明理由：**

- `amap-screen` / `hn-reader`：已是正典薄封装，只定制省略号，非重复实现。
- `terminal.sanitizeUtf8String`：语义是「替换成 U+FFFD」而非正典的「丢弃」——面向给人看的终端字节流，要保留坏字节的位置与可见性。
- `apps/web` 的 `truncateText`：就地改成码点安全，但**不导入 kernel**。kernel 是后端包、前端不依赖它，为一个函数把它拖进浏览器包会破坏包边界（还会带进 `@types/node`）。这是全仓唯一不复用正典的截断点。

## 一处有意的行为变化

`default-agent-context` 的省略号改为**计在预算之外**（正文 N 码点 + `…`），与全仓其它截断点统一；旧手写版从预算里挪 1 个字符给省略号。仅影响管理台预览长度（+1 字符），`truncated` 标记语义不变，测试断言已随之更新。

> 之所以不用 `maxLength - 1` 去保旧输出：那会让「正好等于 maxLength 的串」被误标成 `truncated=true`，比多一个字符更糟。

## 验证

`pnpm build` / `typecheck` / `lint` / `format` / `knip` 全过，`pnpm test` **1414 passed / 1 skipped**。kernel utils 测试 10 → 18（覆盖 trimEnd、自定义省略号、0/负数预算、emoji 边界、与便捷封装同源）。ithome 既有断言未改动即通过，佐证输出逐字节一致。