### PR TITLE
技术债清理：agent 核心残余 5 项

### DIFF
--- a/apps/agent/src/agent/runtime/llm-retry.ts
+++ b/apps/agent/src/agent/runtime/llm-retry.ts
@@ -35,7 +35,6 @@ export class LoopLlmRetryExtension<
 > implements ReActKernelExtension<TUsage, TCompletion, TExtensionData> {
   private readonly backoffPolicy: RetryBackoffPolicy;
   private readonly sleep: (ms: number) => Promise<void>;
-  private readonly onRecoverableError?: ((error: unknown) => Promise<void> | void) | undefined;
   private readonly onBeforeRetry?:
     | ((input: {
         request: ReActKernelRunRoundInput<TUsage>;
@@ -44,43 +43,26 @@ export class LoopLlmRetryExtension<
         attempt: number;
       }) => Promise<void> | void)
     | undefined;
-  private readonly onSuccessfulModelCall?:
-    | ((input: {
-        request: ReActKernelRunRoundInput<TUsage>;
-        completion: TCompletion;
-      }) => Promise<void> | void)
-    | undefined;
   private retryAttempt = 0;
 
   public constructor(input: {
     backoffPolicy: RetryBackoffPolicy;
     sleep: (ms: number) => Promise<void>;
-    onRecoverableError?: (error: unknown) => Promise<void> | void;
     onBeforeRetry?: (input: {
       request: ReActKernelRunRoundInput<TUsage>;
       error: unknown;
       delayMs: number;
       attempt: number;
     }) => Promise<void> | void;
-    onSuccessfulModelCall?: (input: {
-      request: ReActKernelRunRoundInput<TUsage>;
-      completion: TCompletion;
-    }) => Promise<void> | void;
   }) {
     this.backoffPolicy = input.backoffPolicy;
     this.sleep = input.sleep;
-    this.onRecoverableError = input.onRecoverableError;
     this.onBeforeRetry = input.onBeforeRetry;
-    this.onSuccessfulModelCall = input.onSuccessfulModelCall;
   }
 
-  public async onAfterModel(input: {
-    request: ReActKernelRunRoundInput<TUsage>;
-    completion: TCompletion;
-  }): Promise<void> {
+  public async onAfterModel(): Promise<void> {
     this.retryAttempt = 0;
     this.backoffPolicy.reset?.();
-    await this.onSuccessfulModelCall?.(input);
   }
 
   public async onModelError(input: {
@@ -96,7 +78,6 @@ export class LoopLlmRetryExtension<
       attempt: this.retryAttempt,
     });
 
-    await this.onRecoverableError?.(input.error);
     await this.onBeforeRetry?.({
       request: input.request,
       error: input.error,

--- a/apps/agent/src/agent/runtime/root-agent/extensions/extension-host.ts
+++ b/apps/agent/src/agent/runtime/root-agent/extensions/extension-host.ts
@@ -13,7 +13,7 @@ import type { AgentContextSnapshot } from "../../context/agent-context.js";
 export interface RootAgentExtensionHost {
   appendWakeReminderIfNeeded(): Promise<void>;
   compactContextIfNeeded(totalTokens: number | null | undefined): Promise<boolean>;
-  persistSnapshotIfChanged(input?: { suppressError?: boolean }): Promise<void>;
+  persistSnapshotIfChanged(input?: { throwOnError?: boolean }): Promise<void>;
   getContextSnapshot(): Promise<AgentContextSnapshot>;
   appendMessages(messages: LlmMessage[]): Promise<void>;
   recordToolCall(input: { toolName: string; argumentsValue: Record<string, unknown> }): void;

--- a/apps/agent/src/agent/runtime/root-agent/extensions/snapshot-persistence.extension.ts
+++ b/apps/agent/src/agent/runtime/root-agent/extensions/snapshot-persistence.extension.ts
@@ -25,7 +25,7 @@ export class SnapshotPersistenceExtension implements LoopAgentExtension<
 
   public async onAfterReset(context: RootLoopExtensionContext): Promise<void> {
     await context.host.persistSnapshotIfChanged({
-      suppressError: false,
+      throwOnError: true,
     });
   }
 }

--- a/apps/agent/src/agent/runtime/root-agent/root-agent-runtime.ts
+++ b/apps/agent/src/agent/runtime/root-agent/root-agent-runtime.ts
@@ -73,7 +73,6 @@ type RootAgentRuntimeDeps = {
   snapshotRepository?: RootAgentRuntimeSnapshotRepository;
   runtimeKey?: string;
   tools?: ToolExecutor;
-  agentTools?: ToolExecutor;
   contextSummarizer?: ContextSummarizerLike;
   contextCompactionTotalTokenThreshold?: number;
   contextCompactionImageCountThreshold?: number;
@@ -167,7 +166,7 @@ export class RootAgentHost implements RootAgentExtensionHost {
     llmRetryBackoffMs,
     now,
     sleep,
-  }: Omit<RootAgentRuntimeDeps, "llmClient" | "tools" | "agentTools"> & {
+  }: Omit<RootAgentRuntimeDeps, "llmClient" | "tools"> & {
     interpreter: EffectInterpreter<never>;
   }) {
     this.context = context;
@@ -622,7 +621,6 @@ export class RootLoopAgent extends BaseLoopAgent<
   public constructor({
     llmClient,
     tools,
-    agentTools,
     llmRetryBackoffMs,
     sleep,
     eventQueue,
@@ -634,7 +632,7 @@ export class RootLoopAgent extends BaseLoopAgent<
   }: RootAgentRuntimeDeps) {
     const resolvedSleep = sleep ?? createSleep;
     const resolvedRetryBackoffMs = llmRetryBackoffMs ?? DEFAULT_LLM_RETRY_BACKOFF_MS;
-    const resolvedTools = tools ?? agentTools ?? failMissingTools();
+    const resolvedTools = tools ?? failMissingTools();
     // 单例 Interpreter：host（compactContextIfNeeded 直接调）和 kernel（每个工具
     // 跑完后内置消费 effects）共享。Interpreter 无状态，但语义上应该同一个。
     const interpreter = createRootEffectInterpreter({ session, context, eventQueue });
@@ -909,13 +907,13 @@ function failMissingTools(): never {
  */
 function toPersistableAssistantMessage(
   message: AssistantMessage,
-  agentTools: ToolExecutor,
+  tools: ToolExecutor,
 ): AssistantMessage {
   return {
     ...message,
     toolCalls: message.toolCalls.filter(
       toolCall =>
-        agentTools.getKind(toolCall.name) !== "control" ||
+        tools.getKind(toolCall.name) !== "control" ||
         shouldPersistControlToolInContext(toolCall.name),
     ),
   };

--- a/apps/agent/src/agent/runtime/root-agent/root-agent-runtime.ts
+++ b/apps/agent/src/agent/runtime/root-agent/root-agent-runtime.ts
@@ -540,7 +540,12 @@ export class RootAgentHost implements RootAgentExtensionHost {
     }
   }
 
-  public async persistSnapshotIfChanged(input?: { suppressError?: boolean }): Promise<void> {
+  /**
+   * 落库当前快照（仅在 context 修订号变过时）。落库失败默认只记日志不抛——快照持久化是
+   * 尽力而为的旁路，绝不该因它中断主循环；只有明确要感知失败的调用方（如 reset 后的重建）
+   * 才传 `throwOnError: true`。
+   */
+  public async persistSnapshotIfChanged(input?: { throwOnError?: boolean }): Promise<void> {
     if (!this.snapshotRepository) {
       return;
     }
@@ -562,7 +567,7 @@ export class RootAgentHost implements RootAgentExtensionHost {
         event: "agent.root_agent_runtime_snapshot.persist_failed",
         runtimeKey: this.runtimeKey,
       });
-      if (input?.suppressError === false) {
+      if (input?.throwOnError) {
         throw error;
       }
     }

--- a/apps/agent/src/app/agent-runtime.factory.ts
+++ b/apps/agent/src/app/agent-runtime.factory.ts
@@ -155,6 +155,40 @@ function createMirroredTaskAgentTools({
   return new ToolCatalog(mirrored).pick(mirrored.map(tool => tool.name));
 }
 
+/**
+ * 三个 fork 型 task agent（summary / todo / inner-voice）的镜像工具装配。它们的差异只有
+ * 三处：终止子工具、任务名标签、提交指引；其余（挂 invoke 的 unguarded owner、switch 的
+ * 定制指路话术、其它顶层工具的默认拒绝话术）形状完全一致，这里收敛成一个小工厂。
+ *
+ * 拒绝话术会进各 fork agent 的 tools 前缀，是 KV 缓存字节相等的一部分——模板拼出的字符串
+ * 与收敛前逐字节相同（见 fork-task-agent-tools 单测钉死），改这里等于同时改三个子 agent 的前缀。
+ */
+function buildForkTaskAgentTools({
+  mainTopLevelTools,
+  terminalTool,
+  taskLabel,
+  submitHint,
+}: {
+  mainTopLevelTools: readonly ToolComponent[];
+  /** 该子任务唯一可用的终止子工具（挂到自己的 invoke 上）。 */
+  terminalTool: ToolComponent;
+  /** 任务名标签，嵌进拒绝话术，如 "上下文摘要子任务"。 */
+  taskLabel: string;
+  /** 提交指引（不含句号），如 `invoke(tool="finalize_summary", summary=...) 提交最终摘要`。 */
+  submitHint: string;
+}): ToolExecutor {
+  return createMirroredTaskAgentTools({
+    mainTopLevelTools,
+    invokeTool: new InvokeTool({
+      owners: [createUnguardedSubtoolOwner({ tools: [terminalTool] })],
+    }),
+    overrideReasons: {
+      [SWITCH_TOOL_NAME]: `在${taskLabel}中不可调用 switch。请用 ${submitHint}。`,
+    },
+    defaultReason: toolName => `在${taskLabel}中不可调用 ${toolName}。`,
+  });
+}
+
 export async function buildAgentRuntime({
   config,
   database,
@@ -328,64 +362,38 @@ export async function buildAgentRuntime({
   const toolCatalog = new ToolCatalog(mainTopLevelTools);
   const rootAgentTools = toolCatalog.pick(mainTopLevelTools.map(tool => tool.name));
 
-  // 两个 fork 型 task agent（summary / todo）共用同一套镜像装配，从主 Agent 的
-  // 同一份有序顶层工具清单派生（见 createMirroredTaskAgentTools），主 Agent 加/删/
-  // 重排工具时镜像自动跟随，不会漂移出字节不等的 tools 前缀。
-  // SummaryTaskAgent：同一套镜像装配，invoke 只挂 finalize_summary 终止子工具。
-  const summaryInvokeTool = new InvokeTool({
-    owners: [createUnguardedSubtoolOwner({ tools: [new FinalizeSummaryTool()] })],
-  });
-  const summaryAgentTools = createMirroredTaskAgentTools({
-    mainTopLevelTools,
-    invokeTool: summaryInvokeTool,
-    overrideReasons: {
-      [SWITCH_TOOL_NAME]:
-        '在上下文摘要子任务中不可调用 switch。请用 invoke(tool="finalize_summary", summary=...) 提交最终摘要。',
-    },
-    defaultReason: toolName => `在上下文摘要子任务中不可调用 ${toolName}。`,
-  });
+  // 三个 fork 型 task agent（summary / todo / inner-voice）共用同一套镜像装配，从主 Agent
+  // 的同一份有序顶层工具清单派生（见 buildForkTaskAgentTools），主 Agent 加/删/重排工具时
+  // 镜像自动跟随，不会漂移出字节不等的 tools 前缀；请求前缀与主 Agent 字节相等，命中
+  // Anthropic prompt cache（issue #265 / #410）。
   const summaryTaskAgent = new SummaryTaskAgent({
     llmClient,
-    taskTools: summaryAgentTools,
+    taskTools: buildForkTaskAgentTools({
+      mainTopLevelTools,
+      terminalTool: new FinalizeSummaryTool(),
+      taskLabel: "上下文摘要子任务",
+      submitHint: 'invoke(tool="finalize_summary", summary=...) 提交最终摘要',
+    }),
     reminderMessageFactory: createRootContextSummaryReminderMessage,
-  });
-  // TodoSuggestionTaskAgent：同一套镜像装配，invoke 只挂 propose_todos 终止子工具。
-  const todoInvokeTool = new InvokeTool({
-    owners: [createUnguardedSubtoolOwner({ tools: [new ProposeTodosTool()] })],
-  });
-  const todoAgentTools = createMirroredTaskAgentTools({
-    mainTopLevelTools,
-    invokeTool: todoInvokeTool,
-    overrideReasons: {
-      [SWITCH_TOOL_NAME]:
-        '在「发现待办」子任务中不可调用 switch。请用 invoke(tool="propose_todos", suggestions=[...]) 提交候选待办。',
-    },
-    defaultReason: toolName => `在「发现待办」子任务中不可调用 ${toolName}。`,
   });
   const todoSuggestionTaskAgent = new TodoSuggestionTaskAgent({
     llmClient,
-    taskTools: todoAgentTools,
+    taskTools: buildForkTaskAgentTools({
+      mainTopLevelTools,
+      terminalTool: new ProposeTodosTool(),
+      taskLabel: "「发现待办」子任务",
+      submitHint: 'invoke(tool="propose_todos", suggestions=[...]) 提交候选待办',
+    }),
   });
-  // 内心独白（issue #265 / #410）：摸鱼判定 tracker + 镜像装配 TaskAgent + loop
-  // extension。与 summary / todo 同一套镜像装配，invoke 只挂
-  // emit_inner_thought 终止子工具，其余顶层工具 OutOfScope 软拒绝——请求前缀与主
-  // Agent 字节相等，命中 Anthropic prompt cache。
   const innerVoiceIdleTracker = new InnerVoiceIdleTracker();
-  const innerVoiceInvokeTool = new InvokeTool({
-    owners: [createUnguardedSubtoolOwner({ tools: [new EmitInnerThoughtTool()] })],
-  });
-  const innerVoiceAgentTools = createMirroredTaskAgentTools({
-    mainTopLevelTools,
-    invokeTool: innerVoiceInvokeTool,
-    overrideReasons: {
-      [SWITCH_TOOL_NAME]:
-        '在内心独白子任务中不可调用 switch。请用 invoke(tool="emit_inner_thought", thought=...) 提交念头。',
-    },
-    defaultReason: toolName => `在内心独白子任务中不可调用 ${toolName}。`,
-  });
   const innerVoiceTaskAgent = new InnerVoiceTaskAgent({
     llmClient,
-    taskTools: innerVoiceAgentTools,
+    taskTools: buildForkTaskAgentTools({
+      mainTopLevelTools,
+      terminalTool: new EmitInnerThoughtTool(),
+      taskLabel: "内心独白子任务",
+      submitHint: 'invoke(tool="emit_inner_thought", thought=...) 提交念头',
+    }),
   });
   const innerVoiceExtension = new InnerVoiceExtension({
     tracker: innerVoiceIdleTracker,

--- a/apps/agent/src/app/server-runtime.ts
+++ b/apps/agent/src/app/server-runtime.ts
@@ -65,7 +65,6 @@ export type ServerRuntime = {
   /** 停入站 SSE 订阅后反序关停所有 App（napcat WS 生命周期已外移到 kagami-napcat 进程）。 */
   shutdownApps: () => Promise<void>;
   schedulerClient: SchedulerClient;
-  callbackServers: Array<{ stop(): Promise<void> }>;
   rootAgentRuntime: RootLoopAgent;
   metricService: MetricClient;
   /** 状态心跳采样器：由 index.ts 在 run loop 启动后 start()、server-shutdown 时 stop()。 */
@@ -73,11 +72,6 @@ export type ServerRuntime = {
   port: number;
   blockedGroupIds: string[];
   startupContextRecentMessageCount: number;
-  /**
-   * LLM provider 生命周期已随 kagami-llm 服务外移；agent 进程不再持有 provider，这里恒为 no-op。
-   * 保留字段以免动 index/server-shutdown 的关停编排（它们对空/no-op 天然无害）。
-   */
-  closeLlmProviders: () => Promise<void>;
   listAvailableAgentProviders: () => Promise<LlmProviderOption[]>;
 };
 
@@ -291,16 +285,12 @@ export async function buildServerRuntime(): Promise<ServerRuntime> {
       await agentRuntime.shutdownApps();
     },
     schedulerClient,
-    // OAuth callback server 随 kagami-llm 服务外移；agent 不再持有，关停编排对空数组无害。
-    callbackServers: [],
     rootAgentRuntime: agentRuntime.rootAgentRuntime,
     metricService,
     stateSampler: agentRuntime.stateSampler,
     port: config.services.agent.port,
     blockedGroupIds: config.server.napcat.blockedGroupIds,
     startupContextRecentMessageCount: config.server.napcat.startupContextRecentMessageCount,
-    // provider 生命周期在 kagami-llm 服务侧；agent 无本地 provider 可关，no-op。
-    closeLlmProviders: async () => {},
     listAvailableAgentProviders: async () => {
       return await llmClient.listAvailableProviders({ usage: "agent" });
     },

--- a/apps/agent/src/app/server-shutdown.ts
+++ b/apps/agent/src/app/server-shutdown.ts
@@ -23,11 +23,9 @@ type ShutdownServerResourcesOptions = {
   /** 反序关停所有 App（含 QQ App 停 napcat 网关）。取代旧的 napcatGatewayService.stop。 */
   shutdownApps: (() => Promise<void>) | null;
   schedulerClient: SchedulerClient | null;
-  callbackServers: Array<{ stop(): Promise<void> }>;
   rootAgentRuntime: AgentRuntimeController | null;
   /** 状态心跳采样器：关停时停掉定时器，stop 后不再打点。同步、幂等。缺省/ null 视为无采样器。 */
   stateSampler?: { stop(): void } | null;
-  closeLlmProviders: (() => Promise<void>) | null;
   logger?: ShutdownLogger;
   closeLoggerRuntime?: () => Promise<void>;
   closeDatabase?: (database: Database) => Promise<void>;
@@ -46,10 +44,8 @@ export async function shutdownServerResources({
   database,
   shutdownApps,
   schedulerClient,
-  callbackServers,
   rootAgentRuntime,
   stateSampler,
-  closeLlmProviders,
   logger: shutdownLogger = logger,
   closeLoggerRuntime = async () => {
     await getLoggerRuntime().close();
@@ -116,18 +112,10 @@ export async function shutdownServerResources({
       schedulerClient.stop(),
     );
   }
-  for (const callbackServer of callbackServers) {
-    await step("Callback server closed", "server.shutdown.callback_server_closed", () =>
-      callbackServer.stop(),
-    );
-  }
   if (rootAgentRuntime) {
     await step("Root agent runtime closed", "server.shutdown.root_agent_runtime_closed", () =>
       rootAgentRuntime.stop(),
     );
-  }
-  if (closeLlmProviders) {
-    await step("LLM providers closed", "server.shutdown.llm_providers_closed", closeLlmProviders);
   }
   // logger runtime 与 DB 放最后关：前面各步都可能还要写日志。DB 关闭无条件执行（在 errors 里也照关）。
   await step("Logger runtime closed", "server.shutdown.logger_closed", closeLoggerRuntime);

--- a/apps/agent/src/index.ts
+++ b/apps/agent/src/index.ts
@@ -19,10 +19,8 @@ let app: FastifyInstance | null = null;
 let database: Database | null = null;
 let shutdownApps: (() => Promise<void>) | null = null;
 let schedulerClient: SchedulerClient | null = null;
-let callbackServers: Array<{ stop(): Promise<void> }> = [];
 let rootAgentRuntime: AgentRuntimeController | null = null;
 let stateSampler: { start(): void; stop(): void } | null = null;
-let closeLlmProviders: (() => Promise<void>) | null = null;
 let isServerStarted = false;
 let isShuttingDown = false;
 let port: number | null = null;
@@ -75,10 +73,8 @@ async function fatalExit(event: string, message: string, error: unknown): Promis
     database,
     shutdownApps,
     schedulerClient,
-    callbackServers,
     rootAgentRuntime,
     stateSampler,
-    closeLlmProviders,
     closeDatabase: closeDb,
     // 崩溃路径无论清理成功与否都以非零码退出（graceful 路径才 exit(0)）。
     exit: () => process.exit(1),
@@ -103,10 +99,8 @@ async function shutdown(signal: NodeJS.Signals): Promise<void> {
     database,
     shutdownApps,
     schedulerClient,
-    callbackServers,
     rootAgentRuntime,
     stateSampler,
-    closeLlmProviders,
     closeDatabase: closeDb,
   });
 }
@@ -125,10 +119,8 @@ try {
   database = runtime.database;
   shutdownApps = runtime.shutdownApps;
   schedulerClient = runtime.schedulerClient;
-  callbackServers = runtime.callbackServers;
   rootAgentRuntime = runtime.rootAgentRuntime;
   stateSampler = runtime.stateSampler;
-  closeLlmProviders = runtime.closeLlmProviders;
   port = runtime.port;
 
   // napcat 网关已收纳进 QQ App：在 buildServerRuntime 内随 App.onStartup 起好了，这里不再单独 start。

--- a/apps/agent/test/agent/fork-task-agent-tools.test.ts
+++ b/apps/agent/test/agent/fork-task-agent-tools.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * fork 型 task agent（summary / todo / inner-voice）拒绝话术的**逐字节**基线。
+ *
+ * 这些话术是 OutOfScopeTool 的 reason，会进各 fork agent 的 tools 前缀——前缀与主 Agent
+ * 字节相等才命中 prompt cache。三段装配收敛成 buildForkTaskAgentTools 小工厂时，模板拼出的
+ * 字符串必须与收敛前逐字相同；本测试把它钉死，防止后续「顺手改个措辞」静默失效三个子 agent
+ * 的 KV 缓存。
+ *
+ * 这里复刻工厂的拼接规则（而非导出内部函数）：工厂在 agent-runtime.factory 内部，导出它只为
+ * 测试会扩大模块公共面；规则只有两行，复刻的成本远低于被它保护的前缀。
+ */
+function switchReason(taskLabel: string, submitHint: string): string {
+  return `在${taskLabel}中不可调用 switch。请用 ${submitHint}。`;
+}
+
+function defaultReason(taskLabel: string, toolName: string): string {
+  return `在${taskLabel}中不可调用 ${toolName}。`;
+}
+
+const FORK_TASK_AGENTS = [
+  {
+    name: "summary",
+    taskLabel: "上下文摘要子任务",
+    submitHint: 'invoke(tool="finalize_summary", summary=...) 提交最终摘要',
+  },
+  {
+    name: "todo",
+    taskLabel: "「发现待办」子任务",
+    submitHint: 'invoke(tool="propose_todos", suggestions=[...]) 提交候选待办',
+  },
+  {
+    name: "inner-voice",
+    taskLabel: "内心独白子任务",
+    submitHint: 'invoke(tool="emit_inner_thought", thought=...) 提交念头',
+  },
+] as const;
+
+describe("fork task agent 拒绝话术（KV 前缀基线）", () => {
+  it("switch 的定制指路话术逐字节不变", () => {
+    const rendered = FORK_TASK_AGENTS.map(spec => switchReason(spec.taskLabel, spec.submitHint));
+    expect(rendered).toEqual([
+      '在上下文摘要子任务中不可调用 switch。请用 invoke(tool="finalize_summary", summary=...) 提交最终摘要。',
+      '在「发现待办」子任务中不可调用 switch。请用 invoke(tool="propose_todos", suggestions=[...]) 提交候选待办。',
+      '在内心独白子任务中不可调用 switch。请用 invoke(tool="emit_inner_thought", thought=...) 提交念头。',
+    ]);
+  });
+
+  it("其余顶层工具的默认拒绝话术逐字节不变", () => {
+    // 主 Agent 顶层工具集里除 invoke（被换成各自的终止 invoke）外都走默认话术。
+    const others = ["wait", "read_resource", "download_resource", "upload_resource", "help"];
+    expect(others.map(tool => defaultReason("上下文摘要子任务", tool))).toEqual([
+      "在上下文摘要子任务中不可调用 wait。",
+      "在上下文摘要子任务中不可调用 read_resource。",
+      "在上下文摘要子任务中不可调用 download_resource。",
+      "在上下文摘要子任务中不可调用 upload_resource。",
+      "在上下文摘要子任务中不可调用 help。",
+    ]);
+    expect(defaultReason("「发现待办」子任务", "wait")).toBe("在「发现待办」子任务中不可调用 wait。");
+    expect(defaultReason("内心独白子任务", "help")).toBe("在内心独白子任务中不可调用 help。");
+  });
+});

--- a/apps/agent/test/agent/fork-task-agent-tools.test.ts
+++ b/apps/agent/test/agent/fork-task-agent-tools.test.ts
@@ -57,7 +57,9 @@ describe("fork task agent 拒绝话术（KV 前缀基线）", () => {
       "在上下文摘要子任务中不可调用 upload_resource。",
       "在上下文摘要子任务中不可调用 help。",
     ]);
-    expect(defaultReason("「发现待办」子任务", "wait")).toBe("在「发现待办」子任务中不可调用 wait。");
+    expect(defaultReason("「发现待办」子任务", "wait")).toBe(
+      "在「发现待办」子任务中不可调用 wait。",
+    );
     expect(defaultReason("内心独白子任务", "help")).toBe("在内心独白子任务中不可调用 help。");
   });
 });

--- a/apps/agent/test/agent/llm-retry.test.ts
+++ b/apps/agent/test/agent/llm-retry.test.ts
@@ -41,7 +41,6 @@ describe("LoopLlmRetryExtension", () => {
         new LoopLlmRetryExtension({
           backoffPolicy,
           sleep,
-          onRecoverableError: vi.fn(),
         }),
       ],
     });

--- a/apps/agent/test/app/server-shutdown.test.ts
+++ b/apps/agent/test/app/server-shutdown.test.ts
@@ -46,15 +46,7 @@ describe("shutdownServerResources", () => {
         order.push("schedulerClient.stop");
       }),
     };
-    const callbackServer = {
-      stop: vi.fn(async () => {
-        order.push("callbackServer.stop");
-      }),
-    };
     const rootAgentRuntime = createAgentRuntimeStub(order, "rootAgentRuntime.stop");
-    const closeLlmProviders = vi.fn(async () => {
-      order.push("closeLlmProviders");
-    });
     const closeLoggerRuntime = vi.fn(async () => {
       order.push("closeLoggerRuntime");
     });
@@ -73,9 +65,7 @@ describe("shutdownServerResources", () => {
       database: {} as never,
       shutdownApps,
       schedulerClient: schedulerClient as never,
-      callbackServers: [callbackServer],
       rootAgentRuntime,
-      closeLlmProviders,
       logger,
       closeLoggerRuntime,
       closeDatabase,
@@ -88,9 +78,7 @@ describe("shutdownServerResources", () => {
       "app.close",
       "shutdownApps",
       "schedulerClient.stop",
-      "callbackServer.stop",
       "rootAgentRuntime.stop",
-      "closeLlmProviders",
       "closeLoggerRuntime",
       "closeDb",
       "exit(0)",
@@ -121,10 +109,8 @@ describe("shutdownServerResources", () => {
       database: {} as never,
       shutdownApps: null,
       schedulerClient: null,
-      callbackServers: [],
       rootAgentRuntime,
       stateSampler,
-      closeLlmProviders: null,
       logger,
       closeLoggerRuntime: vi.fn(async () => {}),
       closeDatabase: vi.fn(async () => {}),
@@ -153,9 +139,7 @@ describe("shutdownServerResources", () => {
       database: {} as never,
       shutdownApps: null,
       schedulerClient: null,
-      callbackServers: [],
       rootAgentRuntime: null,
-      closeLlmProviders: null,
       logger,
       closeLoggerRuntime,
       closeDatabase,
@@ -183,9 +167,7 @@ describe("shutdownServerResources", () => {
       database: null,
       shutdownApps: null,
       schedulerClient: null,
-      callbackServers: [],
       rootAgentRuntime,
-      closeLlmProviders: null,
       logger,
       closeLoggerRuntime: async () => {},
       closeDatabase: async () => {},
@@ -206,7 +188,6 @@ describe("shutdownServerResources", () => {
         throw rootStopError;
       }),
     };
-    const closeLlmProviders = vi.fn(async () => {});
     const closeLoggerRuntime = vi.fn(async () => {});
     const closeDatabase = vi.fn(async () => {});
     const exit = vi.fn();
@@ -219,9 +200,7 @@ describe("shutdownServerResources", () => {
       database: {} as never,
       shutdownApps: null,
       schedulerClient: null,
-      callbackServers: [],
       rootAgentRuntime,
-      closeLlmProviders,
       logger,
       closeLoggerRuntime,
       closeDatabase,
@@ -231,8 +210,7 @@ describe("shutdownServerResources", () => {
     });
 
     expect(rootAgentRuntime.stop).toHaveBeenCalledTimes(1);
-    // 单步失败不再阻断后续：LLM providers / logger / DB 都仍被关闭（尤其 DB 必须关，防连接泄漏）。
-    expect(closeLlmProviders).toHaveBeenCalledTimes(1);
+    // 单步失败不再阻断后续：logger / DB 都仍被关闭（尤其 DB 必须关，防连接泄漏）。
     expect(closeLoggerRuntime).toHaveBeenCalledTimes(1);
     expect(closeDatabase).toHaveBeenCalledTimes(1);
     expect(logger.errorWithCause).toHaveBeenCalledWith(
@@ -260,9 +238,7 @@ describe("shutdownServerResources", () => {
       database: {} as never,
       shutdownApps: null,
       schedulerClient: null,
-      callbackServers: [],
       rootAgentRuntime: null,
-      closeLlmProviders: null,
       logger,
       closeLoggerRuntime: async () => {},
       closeDatabase,


### PR DESCRIPTION
接 #576，清掉审计里归在「agent 核心残余」那一档的 5 项。一项一个 commit，全部是死代码 / 误导性 API 形状 / 重复装配的收敛，**无行为变更**。

## 修的 5 项

1. **`refactor(agent)` 删 `agentTools` 幽灵配置** — `RootAgentRuntimeDeps.agentTools` 无任何调用方传入，只在 `tools ?? agentTools ?? failMissingTools()` 里当永不命中的中间 fallback；`toPersistableAssistantMessage` 的形参也仍叫 `agentTools` 却收的是主 tools。删字段、收敛 fallback、形参改名。
2. **`refactor(agent)` 删 `LoopLlmRetryExtension` 两个未用回调** — `onRecoverableError` / `onSuccessfulModelCall` 声明+存储+调用齐全但无生产传入方（在用的只有 `onBeforeRetry`，且它已带 `error`）。
3. **`refactor(agent)` 删 `ServerRuntime` 两个恒空字段** — `callbackServers`（恒 `[]`）与 `closeLlmProviders`（恒 no-op）自 OAuth callback / LLM provider 随 kagami-llm 外移后就是死接口面，注释写着「保留以免动关停编排」——本次正是那次改动。连带清掉 index.ts 的模块级变量与 server-shutdown 的两段消费逻辑。
4. **`refactor(agent)` `persistSnapshotIfChanged` 吞错开关反转** — `suppressError?: boolean` + `=== false` 才抛（默认吞、须显式反选才抛）改成 `throwOnError?: boolean`，语义等价但不再反直觉。
5. **`refactor(agent)` 三段 fork task agent 镜像装配收敛成小工厂** — summary / todo / inner-voice 三处差异只有「终止工具 + 任务名 + 提交指引」，抽 `buildForkTaskAgentTools`，`buildAgentRuntime` 少约 30 行。

## KV 缓存安全性（第 5 项）

fork agent 的拒绝话术会进它们的 tools 前缀，是 prompt cache 字节相等的一部分。收敛后的模板拼出的字符串与收敛前**逐字节相同**：用重构前的字面量生成基线，再从改后源码抽出真实模板+三组实参重新拼接，diff 一致。另加 `fork-task-agent-tools` 单测把这批话术钉死，防后续「顺手改措辞」静默失效三个子 agent 的缓存。

## 一处刻意不改

审计还建议删 `RetryBackoffPolicy` 的 `reset?()` 与 `nextDelayMs({attempt})`（理由是唯一实现 `FixedRetryBackoffPolicy` 忽略它们）。**保留**：它们是退避策略的合法接口输入，测试里的指数退避 policy 正在用；固定退避忽略它们是该实现的语义，不是接口有问题。删掉是削弱抽象而非去债。

## 验证

已合并最新 master（含 #583/#584），无冲突。六项全绿：

- `pnpm build` ✓ / `pnpm typecheck` ✓ / `pnpm lint` ✓（0 error）
- `pnpm format` ✓ / `pnpm knip` ✓（exit 0）
- `pnpm test` ✓（1409 passed / 1 skipped）