### PR TITLE
feat(agent): ReAct 空转分级检测——连续 4 轮无动作才挂起并告警（#602 P2）

### DIFF
--- a/apps/agent/package.json
+++ b/apps/agent/package.json
@@ -25,6 +25,7 @@
     "@kagami/napcat-api": "workspace:*",
     "@kagami/oss-api": "workspace:*",
     "@kagami/persistence": "workspace:*",
+    "@kagami/observatory-api": "workspace:*",
     "@kagami/pixel-api": "workspace:*",
     "@kagami/rpc-client": "workspace:*",
     "@kagami/scheduler-api": "workspace:*",

--- a/apps/agent/src/acl/observatory-client.ts
+++ b/apps/agent/src/acl/observatory-client.ts
@@ -1,0 +1,48 @@
+import { createClient, type JsonClient } from "@kagami/rpc-client/client";
+import { observatoryApiContract } from "@kagami/observatory-api/contract";
+import type { RaiseAlertRequest } from "@kagami/observatory-api/alert";
+import { AppLogger } from "@kagami/kernel/logger/logger";
+import type { AlertNotifier } from "../agent/runtime/root-agent/alert-notifier.js";
+
+const logger = new AppLogger({ source: "agent.observatory-client" });
+
+/**
+ * 告警上报客户端：把告警经 HTTP 打到独立的 kagami-observatory 进程（issue #602）。
+ *
+ * 语义是 fire-and-forget，与 `HttpMetricClient` 同族：**永不 reject**。`createClient` 在不可达 /
+ * 非 2xx / 坏响应时会抛，这里一律吞掉并记日志——调用点是 `void raise(...)`，reject 会变成
+ * unhandledRejection 把 agent 进程拉挂，那就成了「告警把被告警的东西杀了」。
+ *
+ * 告警本身不会因此丢失：调用方（`reportStall`）在调它之前已无条件写了一条本地 error 日志。
+ * observatory 回的 `{ delivered, suppressed }` 这里只用于记日志——上报方不该因「被去重压制」
+ * 或「通道失败」改变自己的行为，更不该重试。
+ */
+export class HttpObservatoryClient implements AlertNotifier {
+  private readonly api: JsonClient<typeof observatoryApiContract>;
+
+  public constructor({ baseUrl, fetch: fetchImpl }: { baseUrl: string; fetch?: typeof fetch }) {
+    this.api = createClient(observatoryApiContract, {
+      baseUrl,
+      unreachableMessage: "kagami-observatory 不可达，告警未推送",
+      ...(fetchImpl ? { fetch: fetchImpl } : {}),
+    });
+  }
+
+  public async raise(alert: RaiseAlertRequest): Promise<void> {
+    try {
+      const result = await this.api.raiseAlert(alert);
+      if (!result.delivered) {
+        logger.warn("Alert accepted by observatory but not delivered", {
+          event: "agent.observatory.alert_not_delivered",
+          alertEvent: alert.event,
+          suppressed: result.suppressed,
+        });
+      }
+    } catch (error) {
+      logger.errorWithCause("Failed to raise alert to observatory", error, {
+        event: "agent.observatory.raise_failed",
+        alertEvent: alert.event,
+      });
+    }
+  }
+}

--- a/apps/agent/src/agent/runtime/root-agent/alert-notifier.ts
+++ b/apps/agent/src/agent/runtime/root-agent/alert-notifier.ts
@@ -1,0 +1,21 @@
+import type { RaiseAlertRequest } from "@kagami/observatory-api/alert";
+
+/**
+ * 告警上报端口（issue #602）。收**通用**告警载荷而不是 agent 专有类型——这样 agent 里将来别的
+ * 告警源（毒上下文挂起、工具持续失败…）可以复用同一个端口，不必各自造一个通知器。
+ *
+ * 实现是 `HttpObservatoryClient`（`src/acl/observatory-client.ts`）。
+ *
+ * 契约：**永不 reject**。调用点是 `void notifier.raise(...)`，reject 会变成
+ * unhandledRejection 把 agent 进程拉挂——告警绝不能反过来杀掉被告警的东西。
+ */
+export type AlertNotifier = {
+  raise(alert: RaiseAlertRequest): Promise<void>;
+};
+
+/** 未配置 observatory / 测试用的 null-object（照 NOOP_METRIC_CLIENT 范式）。 */
+export const NOOP_ALERT_NOTIFIER: AlertNotifier = {
+  async raise(): Promise<void> {
+    // no-op
+  },
+};

--- a/apps/agent/src/agent/runtime/root-agent/root-agent-runtime.ts
+++ b/apps/agent/src/agent/runtime/root-agent/root-agent-runtime.ts
@@ -52,6 +52,16 @@ import { RootToolCallMetricExtension } from "./extensions/tool-call-metric.exten
 import { SnapshotPersistenceExtension } from "./extensions/snapshot-persistence.extension.js";
 import { RootToolFallbackExtension } from "./extensions/tool-fallback.extension.js";
 import { WakeReminderExtension } from "./extensions/wake-reminder.extension.js";
+import { NOOP_ALERT_NOTIFIER, type AlertNotifier } from "./alert-notifier.js";
+import {
+  StallGuard,
+  classifyRoundShape,
+  createStallAlert,
+  type StallAlertInput,
+} from "./stall-guard.js";
+
+/** 「她卡住了」的时间序列。tag `reason` 区分「什么都没输出」与「只说话不动手」。 */
+const AGENT_REACT_STALL_SUSPENDED_METRIC = "agent.react.stall_suspended";
 
 /**
  * 上下文摘要器的结构类型（SummaryTaskAgent 的 invoke 面）。runtime 只依赖
@@ -82,8 +92,12 @@ type RootAgentRuntimeDeps = {
   metricService?: MetricClient;
   llmRetryBackoffMs?: number;
   loopExtensions?: RootLoopExtension[];
-  /** 纯文本轮挂起的自唤醒上限；与 wait 工具的 maxWaitMs 同源（waitToolMaxWaitMs）。 */
+  /** 无动作轮挂起的自唤醒上限；与 wait 工具的 maxWaitMs 同源（waitToolMaxWaitMs）。 */
   idleWakeMaxWaitMs?: number;
+  /** stall 告警上报端口（issue #602）。缺省 = NOOP，测试与未配置 observatory 时不必注入。 */
+  alertNotifier?: AlertNotifier;
+  /** 连续多少轮无动作才判卡住。缺省 4（代码常量），仅测试注入以缩短用例。 */
+  stallThreshold?: number;
   now?: () => Date;
   sleep?: (ms: number) => Promise<void>;
 };
@@ -645,9 +659,14 @@ export class RootLoopAgent extends BaseLoopAgent<
   private readonly host: RootAgentHost;
   private readonly tools: ToolExecutor;
   private readonly eventQueue: AgentEventQueue;
-  /** 纯文本轮隐式挂起路径要置位状态供采样归 "wait" 桶（显式 wait 工具路径走 interpreter）。 */
+  /** 无动作轮隐式挂起路径要置位状态供采样归 "wait" 桶（显式 wait 工具路径走 interpreter）。 */
   private readonly session: Pick<RootAgentSessionController, "setSuspended">;
   private readonly idleWakeMaxWaitMs: number;
+  /** ReAct 空转分级检测（issue #602）。纯内存、不进快照：重启即新的活性窗口。 */
+  private readonly stallGuard: StallGuard;
+  private readonly alertNotifier: AlertNotifier;
+  private readonly metricService: MetricClient;
+  private readonly runtimeKey: string;
   private pendingResetPromise: Promise<{ resetAt: Date }> | null = null;
   private pendingCompactionPromise: Promise<ContextCompactionReport> | null = null;
 
@@ -661,6 +680,8 @@ export class RootLoopAgent extends BaseLoopAgent<
     session,
     context,
     idleWakeMaxWaitMs,
+    alertNotifier,
+    stallThreshold,
     ...rest
   }: RootAgentRuntimeDeps) {
     const resolvedSleep = sleep ?? createSleep;
@@ -716,6 +737,12 @@ export class RootLoopAgent extends BaseLoopAgent<
     this.eventQueue = eventQueue;
     this.session = session;
     this.idleWakeMaxWaitMs = idleWakeMaxWaitMs ?? DEFAULT_IDLE_WAKE_MAX_WAIT_MS;
+    this.stallGuard = new StallGuard(
+      stallThreshold !== undefined ? { threshold: stallThreshold } : {},
+    );
+    this.alertNotifier = alertNotifier ?? NOOP_ALERT_NOTIFIER;
+    this.metricService = rest.metricService ?? NOOP_METRIC_CLIENT;
+    this.runtimeKey = rest.runtimeKey ?? ROOT_AGENT_RUNTIME_SNAPSHOT_RUNTIME_KEY;
   }
 
   public async run(): Promise<void> {
@@ -744,6 +771,8 @@ export class RootLoopAgent extends BaseLoopAgent<
       await this.waitForActiveRunOnce();
 
       const result = await this.host.resetContext();
+      // 计划性重建后重开活性窗口：旧上下文里累起来的无动作连击不该算在新上下文头上。
+      this.stallGuard.reset();
       await this.notifyAfterReset();
       return result;
     })();
@@ -838,21 +867,91 @@ export class RootLoopAgent extends BaseLoopAgent<
     // until a producer (real event or timer-enqueued wake) resolves them.
     const roundResult = await this.runReactRound();
 
-    // toolChoice auto 下模型可以一个工具都不调（纯文本轮）。此时 text 照常随 assistant 消息
-    // 进上下文（见 toPersistableAssistantMessage / commitRoundResult 门控），但本轮无工具动作、
-    // 视为自然结束，挂起到事件队列非空才进下一轮——否则外层 while 会立即用几乎相同的上下文再
-    // 起一轮 LLM 调用空转。
-    if (roundResult?.shouldCommit && roundResult.assistantMessage.toolCalls.length === 0) {
+    // toolChoice auto 下模型可以一个工具都不调。此前这种轮次**一律立刻挂起**（#268 为
+    // 2026-05-30 用量暴涨事故加的闸），粒度太粗：她吐一个空 content 就睡 idleWakeMaxWaitMs，
+    // 外面看就是「卡死」，而且没有任何人被通知。现在交给 StallGuard 分级——空轮 / 纯文本轮各自
+    // 允许连续跑，到阈值才挂起并告警（issue #602）。
+    //
+    // 空轮那条路上下文一条不动（见 commitRoundResult 门控），所以重跑的请求逐字节相同、KV 全
+    // 命中；纯文本轮把 text 留尾部，下一轮起轮前 appendWakeReminderIfNeeded 会因「尾部是
+    // assistant」补一条 user 角色 wake-reminder，角色交替不变量已替我们兜住 provider 400。
+    if (!roundResult?.shouldCommit) {
+      // 模型报错已被重试扩展吃掉，本轮没有 completion——不是 stall，不动计数器。
+      return;
+    }
+
+    const shape = classifyRoundShape(roundResult.assistantMessage);
+    const decision = this.stallGuard.observe(shape);
+    if (shape !== "acted") {
       try {
-        // 可观测性：纯文本轮意味着模型「看到但选择不行动」（含对通知不回应）。
-        // text 已进上下文（完整原文亦在 llm_chat_call 可查），这里只留一条轻量事件供时间序列归因。
-        logger.info("Root agent idle round (zero tool calls); suspending until next event", {
-          event: "agent.root_agent_runtime.idle_round_suspended",
+        // 可观测性：无动作轮意味着模型「看到但没动手」（含对通知不回应）。text 已进上下文
+        //（完整原文亦在 llm_chat_call 可查），这里只留一条轻量事件供时间序列归因。
+        logger.info("Root agent produced no tool call this round", {
+          event: "agent.root_agent_runtime.idle_round_observed",
+          shape,
+          suspending: decision.suspend,
         });
       } catch {
         // Ignore logger runtime setup gaps in tests and early boot.
       }
+    }
+
+    if (decision.alert) {
+      this.reportStall(decision.alert);
+    }
+
+    if (decision.suspend) {
       await this.suspendUntilNextEvent();
+    }
+  }
+
+  /**
+   * stall 上报。**本地日志无条件先打**——observatory 或 napcat 挂掉时告警只是「没推送」，不是
+   * 「消失了」，PM2 日志里一定有痕。随后 fire-and-forget 推给 observatory：不 await（不阻塞主
+   * 循环）、不重试（重试只会加重下游压力）、`.catch` 兜住一切异常（reject 会变成
+   * unhandledRejection 把进程拉挂——告警绝不能反过来杀掉被告警的东西）。
+   */
+  private reportStall(alert: StallAlertInput): void {
+    try {
+      logger.error("Root agent stalled; suspending and raising alert", {
+        event: "agent.root_agent_runtime.stall_detected",
+        reason: alert.reason,
+        emptyStreak: alert.emptyStreak,
+        noToolStreak: alert.noToolStreak,
+      });
+    } catch {
+      // Ignore logger runtime setup gaps in tests and early boot.
+    }
+
+    void this.metricService
+      .record({
+        metricName: AGENT_REACT_STALL_SUSPENDED_METRIC,
+        value: 1,
+        tags: { runtime: "agent", reason: alert.reason },
+      })
+      .catch(() => undefined);
+
+    try {
+      void this.alertNotifier
+        .raise(createStallAlert({ ...alert, runtimeKey: this.runtimeKey }))
+        .catch(error => {
+          try {
+            logger.errorWithCause("Stall alert delivery failed", error, {
+              event: "agent.root_agent_runtime.stall_alert_failed",
+            });
+          } catch {
+            // Ignore logger runtime setup gaps in tests and early boot.
+          }
+        });
+    } catch (error) {
+      // 同步抛错（坏 notifier 实现）也不许拖垮主循环。
+      try {
+        logger.errorWithCause("Stall alert notifier threw synchronously", error, {
+          event: "agent.root_agent_runtime.stall_alert_failed",
+        });
+      } catch {
+        // Ignore logger runtime setup gaps in tests and early boot.
+      }
     }
   }
 

--- a/apps/agent/src/agent/runtime/root-agent/stall-guard.ts
+++ b/apps/agent/src/agent/runtime/root-agent/stall-guard.ts
@@ -1,0 +1,151 @@
+import type { RaiseAlertRequest } from "@kagami/observatory-api/alert";
+
+/**
+ * 连续多少轮「没动手」才判定为卡住。代码常量：不随环境变、运维不会在线上调它。
+ *
+ * 两个计数器共用同一个阈值。因为 empty ⊂ noTool，纯空的场景下两者同一轮到顶——此时取更具体的
+ * `empty`（见 {@link StallGuard.observe}）。
+ */
+const STALL_THRESHOLD = 4;
+
+/** 一轮 ReAct 的形状。 */
+export type RoundShape =
+  /** 有 tool call（含 `wait`、含只调 control 工具）——她动手了。 */
+  | "acted"
+  /** 零 tool call 但有文本——她说了话没动手。 */
+  | "text_only"
+  /** 零 tool call 且文本为空（含纯空白）——她什么都没输出。 */
+  | "empty";
+
+export type StallReason = "empty" | "no_tool";
+
+export type StallAlertInput = {
+  reason: StallReason;
+  emptyStreak: number;
+  noToolStreak: number;
+};
+
+export type StallDecision = {
+  /** 是否该挂起到下一个事件。 */
+  suspend: boolean;
+  /** 非 null = 该发一条告警（与 suspend 同时成立）。 */
+  alert: StallAlertInput | null;
+};
+
+/**
+ * 判定本轮形状。
+ *
+ * **`toolCalls` 必须是原始的、`toPersistableAssistantMessage` 过滤前的数组**：只调了 control
+ * 工具（如 `switch`）的轮次虽然不留痕进上下文，但那是**动作**不是 stall，误判会让「她正在切 App」
+ * 被当成卡住。
+ *
+ * 「文本为空」按 `trim()` 判，与[持久化门控](./root-agent-runtime.ts)逐字节一致（那里也是
+ * `content.trim().length > 0`）。两处必须同判，否则会出现「上下文里丢弃了、却被计为 text_only」
+ * 的错配。
+ */
+export function classifyRoundShape(message: {
+  content: string;
+  toolCalls: readonly unknown[];
+}): RoundShape {
+  if (message.toolCalls.length > 0) {
+    return "acted";
+  }
+
+  return message.content.trim().length > 0 ? "text_only" : "empty";
+}
+
+/**
+ * ReAct 空转分级检测的纯状态机（issue #602）。
+ *
+ * 背景：此前零工具轮**一律立刻挂起**（#268 为 2026-05-30 用量暴涨事故加的闸）。粒度太粗——她吐
+ * 一个空 content 就睡 10 分钟，外面看就是「卡死」，而且没有任何人被通知。现在改成允许连续跑，
+ * 到阈值才挂起并告警。
+ *
+ * 两个计数器一层包一层（`empty ⊂ noTool`）：
+ *
+ * | 形状 | emptyStreak | noToolStreak |
+ * |---|---|---|
+ * | `acted` | 归 0 | 归 0 |
+ * | `text_only` | **归 0** | +1 |
+ * | `empty` | +1 | +1 |
+ *
+ * 所以 `text, empty, empty, empty` → `noToolStreak=4` / `emptyStreak=3`，报 `no_tool`；
+ * `empty×4` → 两者都到 4，报更具体的 `empty`。任何时刻只发一条告警，载荷里带两个计数让人能
+ * 分辨混合形态。
+ *
+ * 触发后两个计数器都归零——否则醒来第一个无动作轮就会立刻再告警一次。
+ *
+ * 纯内存、不进快照：重启即清零，重启本身就是新的活性窗口。
+ */
+export class StallGuard {
+  private readonly threshold: number;
+  private emptyStreak = 0;
+  private noToolStreak = 0;
+
+  public constructor({ threshold }: { threshold?: number } = {}) {
+    this.threshold = threshold ?? STALL_THRESHOLD;
+  }
+
+  public observe(shape: RoundShape): StallDecision {
+    if (shape === "acted") {
+      this.emptyStreak = 0;
+      this.noToolStreak = 0;
+      return { suspend: false, alert: null };
+    }
+
+    this.noToolStreak += 1;
+    if (shape === "empty") {
+      this.emptyStreak += 1;
+    } else {
+      this.emptyStreak = 0;
+    }
+
+    // empty ⊂ noTool 且共用阈值，纯空场景下两者同轮到顶——先判 empty，取更具体的那个。
+    const reason: StallReason | null =
+      this.emptyStreak >= this.threshold
+        ? "empty"
+        : this.noToolStreak >= this.threshold
+          ? "no_tool"
+          : null;
+    if (reason === null) {
+      return { suspend: false, alert: null };
+    }
+
+    const alert: StallAlertInput = {
+      reason,
+      emptyStreak: this.emptyStreak,
+      noToolStreak: this.noToolStreak,
+    };
+    this.reset();
+    return { suspend: true, alert };
+  }
+
+  /** 计划性重建（`resetContext`）后重开活性窗口。 */
+  public reset(): void {
+    this.emptyStreak = 0;
+    this.noToolStreak = 0;
+  }
+}
+
+/**
+ * stall → 通用告警载荷的映射。纯函数、与状态机同处一文件，好让单测直接逐字段断言，而不是把
+ * 映射逻辑埋进 `runOnce` 里测不到。
+ */
+export function createStallAlert(
+  input: StallAlertInput & { runtimeKey: string },
+): RaiseAlertRequest {
+  const isEmpty = input.reason === "empty";
+  return {
+    source: "agent",
+    event: isEmpty ? "react.empty_stall" : "react.no_tool_stall",
+    severity: "error",
+    title: isEmpty
+      ? `连续 ${input.emptyStreak} 轮 LLM 返回空内容，已挂起等待下一个事件。`
+      : `连续 ${input.noToolStreak} 轮没有任何工具调用，已挂起等待下一个事件。`,
+    context: {
+      emptyStreak: input.emptyStreak,
+      noToolStreak: input.noToolStreak,
+      runtimeKey: input.runtimeKey,
+    },
+  };
+}

--- a/apps/agent/src/app/agent-runtime.factory.ts
+++ b/apps/agent/src/app/agent-runtime.factory.ts
@@ -56,6 +56,7 @@ import type { SpireClient } from "../acl/spire-client.js";
 import type { GbaClient } from "../acl/gba-client.js";
 import { PixelApp } from "../agent/apps/pixel/pixel.app.js";
 import type { PixelClient } from "../acl/pixel-client.js";
+import type { AlertNotifier } from "../agent/runtime/root-agent/alert-notifier.js";
 import { TodoApp } from "../agent/apps/todo/todo.app.js";
 import type { TodoService } from "../agent/capabilities/todo/application/todo.service.js";
 import { PrismaLinearMessageLedgerDao } from "../agent/capabilities/ledger/infra/impl/prisma-linear-message-ledger.impl.dao.js";
@@ -99,6 +100,8 @@ type BuildAgentRuntimeInput = {
   pixelClient: PixelClient;
   /** 生图客户端：打到 kagami-llm 的生图端点（走 codex 订阅额度，issue #508）。 */
   imageClient: ImageClient;
+  /** stall 告警上报端口：打到独立的 kagami-observatory 进程（issue #602）。 */
+  alertNotifier: AlertNotifier;
 };
 
 export type AgentRuntimeBundle = {
@@ -206,6 +209,7 @@ export async function buildAgentRuntime({
   gbaClient,
   pixelClient,
   imageClient,
+  alertNotifier,
 }: BuildAgentRuntimeInput): Promise<AgentRuntimeBundle> {
   const rootAgentRuntimeSnapshotRepository = new PrismaRootAgentRuntimeSnapshotRepository({
     database,
@@ -421,6 +425,7 @@ export async function buildAgentRuntime({
     // 纯文本轮挂起的自唤醒兜底与 wait 工具共用同一个上限，语义一致：Agent 最多
     // 安静这么久就会自己醒来一轮。
     idleWakeMaxWaitMs: config.server.agent.waitToolMaxWaitMs,
+    alertNotifier,
     loopExtensions: [
       new AppEntryResetExtension({ session: rootAgentSession }),
       innerVoiceExtension,

--- a/apps/agent/src/app/server-runtime.ts
+++ b/apps/agent/src/app/server-runtime.ts
@@ -34,6 +34,7 @@ import { HttpOssClient } from "../acl/oss-client.js";
 import { HttpBrowserClient } from "../acl/browser-client.js";
 import { HttpSpireClient } from "../acl/spire-client.js";
 import { HttpGbaClient } from "../acl/gba-client.js";
+import { HttpObservatoryClient } from "../acl/observatory-client.js";
 import { HttpPixelClient } from "../acl/pixel-client.js";
 import { PrismaIthomeArticleDao } from "../agent/capabilities/ithome/infra/prisma-ithome-article.dao.js";
 import { PrismaIthomeFeedCursorDao } from "../agent/capabilities/ithome/infra/prisma-ithome-feed-cursor.dao.js";
@@ -144,6 +145,12 @@ export async function buildServerRuntime(): Promise<ServerRuntime> {
   const gbaClient = new HttpGbaClient({
     baseUrl: `http://${config.services.gba.host}:${config.services.gba.port}`,
   });
+  // 告警上报拆成独立 kagami-observatory 进程（issue #602）：agent 经 HTTP client 上报，地址从
+  // 顶层 services.observatory 派生。服务未起时 client 吞掉异常只记日志——告警绝不能反过来拖垮
+  // 被告警的 agent；本地 error 日志已在 reportStall 里无条件留痕，告警不会丢。
+  const observatoryClient = new HttpObservatoryClient({
+    baseUrl: `http://${config.services.observatory.host}:${config.services.observatory.port}`,
+  });
   const eventQueue = new InMemoryQueue<Event>();
   // 手机 OS 模型：被动通知中心。各源（这里是 ithome poller）向它 push draft，它窗口
   // 聚合后把一条 notification 事件塞进事件队列——既投递内容也唤醒 Agent。
@@ -186,6 +193,7 @@ export async function buildServerRuntime(): Promise<ServerRuntime> {
     spireClient,
     gbaClient,
     pixelClient,
+    alertNotifier: observatoryClient,
     imageClient,
   });
 

--- a/apps/agent/test/agent/root-agent-idle-suspension.test.ts
+++ b/apps/agent/test/agent/root-agent-idle-suspension.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { InMemoryQueue } from "@kagami/agent-runtime";
 import { RootLoopAgent } from "../../src/agent/runtime/root-agent/root-agent-runtime.js";
 import type { AgentEventQueue } from "../../src/agent/runtime/event/event.queue.js";
+import type { AlertNotifier } from "../../src/agent/runtime/root-agent/alert-notifier.js";
 import { initTestLoggerRuntime } from "../helpers/logger.js";
 
 initTestLoggerRuntime();
@@ -9,21 +10,41 @@ initTestLoggerRuntime();
 const tick = (): Promise<void> => new Promise(resolve => setTimeout(resolve, 10));
 
 /**
- * toolChoice auto 的防空转契约（issue #268，2026-05-30 用量暴涨事故的形状）：
+ * toolChoice auto 的防空转契约。**本文件的语义在 issue #602 被有意反转过，别照旧读。**
  *
- * 模型某轮零工具调用（纯文本轮）时，主循环必须挂起在事件队列上，直到新事件
- * 入队才起下一轮 LLM 调用。没有这个挂起，BaseLoopAgent 的 while 会立即用几乎
- * 相同的上下文再打一轮 LLM，空转刷轮次。
+ * 原契约（#268，2026-05-30 用量暴涨事故的形状）：模型某轮零工具调用就**立刻**挂起，直到新事件
+ * 入队才起下一轮。没有这个挂起，BaseLoopAgent 的 while 会立即用几乎相同的上下文再打一轮 LLM，
+ * 空转刷轮次。
+ *
+ * 现契约（#602）：粒度太粗——她吐一个空 content 就睡 10 分钟，外面看就是「卡死」，而且没有任何人
+ * 被通知。改成分级：空轮 / 纯文本轮各自允许**连续跑到阈值**（默认 4）才挂起，并在挂起时告警。
+ * 闸没有被拆掉，只是从「1 轮」放宽到「最多 N 轮」——有 tool call 就归零 + 硬上限，仍然有界，
+ * 不会回到无界空转。代价是无动作轮的 LLM 调用最坏放大 N 倍。
  */
 const TEXT_ONLY_RESPONSE = {
   provider: "claude-code",
   model: "claude-opus-4-6",
   message: { role: "assistant", content: "这轮不需要动作。", toolCalls: [] },
 };
+const EMPTY_RESPONSE = {
+  provider: "claude-code",
+  model: "claude-opus-4-6",
+  message: { role: "assistant", content: "", toolCalls: [] },
+};
+const ACTED_RESPONSE = {
+  provider: "claude-code",
+  model: "claude-opus-4-6",
+  message: {
+    role: "assistant",
+    content: "看一眼列表。",
+    toolCalls: [{ id: "tc1", name: "invoke", arguments: {} }],
+  },
+};
 
-describe("RootLoopAgent — 纯文本轮挂起直到新事件", () => {
-  function makeAgent(options: { idleWakeMaxWaitMs?: number } = {}) {
+describe("RootLoopAgent — 无动作轮连击到阈值才挂起并告警", () => {
+  function makeAgent(options: { idleWakeMaxWaitMs?: number; stallThreshold?: number } = {}) {
     const chat = vi.fn().mockResolvedValue(TEXT_ONLY_RESPONSE);
+    const raise = vi.fn<AlertNotifier["raise"]>(async () => {});
     const rawQueue = new InMemoryQueue<{ type: string }>();
     const eventQueue = rawQueue as unknown as AgentEventQueue;
     const consumedEvents: unknown[] = [];
@@ -48,7 +69,7 @@ describe("RootLoopAgent — 纯文本轮挂起直到新事件", () => {
           consumedEvents.push(event);
         }),
         flushPendingIncomingEffects: vi.fn(async () => ({ shouldTriggerRound: false })),
-        // 纯文本轮隐式挂起路径会调 setSuspended 置位状态供采样归 "wait" 桶。
+        // 无动作轮隐式挂起路径会调 setSuspended 置位状态供采样归 "wait" 桶。
         setSuspended: vi.fn(),
       },
       tools: {
@@ -56,39 +77,189 @@ describe("RootLoopAgent — 纯文本轮挂起直到新事件", () => {
         getKind: () => "business",
         execute: async () => ({ content: "", kind: "business" }),
       },
+      alertNotifier: { raise },
       sleep: async () => {},
       ...(options.idleWakeMaxWaitMs !== undefined
         ? { idleWakeMaxWaitMs: options.idleWakeMaxWaitMs }
         : {}),
+      ...(options.stallThreshold !== undefined ? { stallThreshold: options.stallThreshold } : {}),
     } as unknown as ConstructorParameters<typeof RootLoopAgent>[0]);
 
-    return { agent, chat, eventQueue, rawQueue };
+    return { agent, chat, raise, eventQueue, rawQueue };
   }
 
-  it("零 toolCall 轮后不再自发起新轮；新事件入队才恢复", async () => {
-    const { agent, chat, eventQueue } = makeAgent();
+  it("纯文本轮：前 3 轮不挂起、连打 4 次 LLM，第 4 轮才挂起并告警 no_tool_stall", async () => {
+    const { agent, chat, raise } = makeAgent();
     const runPromise = agent.run();
 
-    // 第一轮：纯文本轮跑完后挂起。
+    // 连续跑到阈值：4 次 LLM 调用后挂起（旧契约这里只会有 1 次）。
     await tick();
-    expect(chat).toHaveBeenCalledTimes(1);
+    await tick();
+    expect(chat).toHaveBeenCalledTimes(4);
 
-    // 无事件期间不空转：多等几拍仍只有一次 LLM 调用。
+    // 挂起后不再空转。
     await tick();
     await tick();
-    expect(chat).toHaveBeenCalledTimes(1);
+    expect(chat).toHaveBeenCalledTimes(4);
 
-    // 新事件入队 → 解除挂起 → 起下一轮。
-    eventQueue.enqueue({ type: "wake" });
-    await tick();
-    expect(chat).toHaveBeenCalledTimes(2);
+    expect(raise).toHaveBeenCalledTimes(1);
+    const alert = raise.mock.calls[0]![0];
+    expect(alert.event).toBe("react.no_tool_stall");
+    expect(alert.severity).toBe("error");
+    expect(alert.source).toBe("agent");
+    expect(alert.context).toMatchObject({ noToolStreak: 4 });
 
     await agent.stop();
     await runPromise;
   });
 
-  it("自唤醒兜底：无外部事件时到 idleWakeMaxWaitMs 也会自己醒来一轮", async () => {
-    const { agent, chat } = makeAgent({ idleWakeMaxWaitMs: 20 });
+  it("空轮：同样连跑到阈值，告警是更具体的 empty_stall", async () => {
+    const { agent, chat, raise } = makeAgent();
+    chat.mockResolvedValue(EMPTY_RESPONSE);
+    const runPromise = agent.run();
+
+    await tick();
+    await tick();
+    expect(chat).toHaveBeenCalledTimes(4);
+
+    expect(raise).toHaveBeenCalledTimes(1);
+    const alert = raise.mock.calls[0]![0];
+    expect(alert.event).toBe("react.empty_stall");
+    expect(alert.context).toMatchObject({ emptyStreak: 4, noToolStreak: 4 });
+
+    await agent.stop();
+    await runPromise;
+  });
+
+  it("混合链 text,empty,empty,empty：报 no_tool_stall（不是 empty_stall）", async () => {
+    const { agent, chat, raise } = makeAgent();
+    chat
+      .mockResolvedValueOnce(TEXT_ONLY_RESPONSE)
+      .mockResolvedValueOnce(EMPTY_RESPONSE)
+      .mockResolvedValueOnce(EMPTY_RESPONSE)
+      .mockResolvedValue(EMPTY_RESPONSE);
+    const runPromise = agent.run();
+
+    await tick();
+    await tick();
+
+    expect(raise).toHaveBeenCalledTimes(1);
+    const alert = raise.mock.calls[0]![0];
+    expect(alert.event).toBe("react.no_tool_stall");
+    expect(alert.context).toMatchObject({ emptyStreak: 3, noToolStreak: 4 });
+
+    await agent.stop();
+    await runPromise;
+  });
+
+  it("链中出现 tool call 就归零：3 连无动作 + 1 次动作后，还得再攒 4 轮才告警", async () => {
+    const { agent, chat, raise } = makeAgent();
+    chat
+      .mockResolvedValueOnce(TEXT_ONLY_RESPONSE)
+      .mockResolvedValueOnce(TEXT_ONLY_RESPONSE)
+      .mockResolvedValueOnce(TEXT_ONLY_RESPONSE)
+      .mockResolvedValueOnce(ACTED_RESPONSE)
+      .mockResolvedValueOnce(TEXT_ONLY_RESPONSE)
+      .mockResolvedValueOnce(TEXT_ONLY_RESPONSE)
+      .mockResolvedValue(TEXT_ONLY_RESPONSE);
+    const runPromise = agent.run();
+
+    await tick();
+    await tick();
+
+    // 3 轮无动作 + 1 轮动作（把两个计数器归零）+ 重新攒满 4 轮 = 8 次 LLM 调用才告警一次。
+    expect(chat).toHaveBeenCalledTimes(8);
+    expect(raise).toHaveBeenCalledTimes(1);
+    expect(raise.mock.calls[0]![0].context).toMatchObject({
+      noToolStreak: 4,
+    });
+
+    await agent.stop();
+    await runPromise;
+  });
+
+  it("告警挂起后被事件唤醒，紧接着的那一轮不会立刻再告警（计数器已归零）", async () => {
+    const { agent, chat, raise, eventQueue } = makeAgent();
+    const runPromise = agent.run();
+
+    await tick();
+    await tick();
+    expect(chat).toHaveBeenCalledTimes(4);
+    expect(raise).toHaveBeenCalledTimes(1);
+
+    // 逐轮步进：让唤醒后的第一轮 LLM 悬停，这样能精确观察「刚醒来的那一轮」而不是「一个 tick
+    // 里能跑完的若干轮」——后者会攒满新的 4 连并如实再告警一次（那是正确行为，不是缺陷）。
+    let releaseRound!: (value: unknown) => void;
+    chat.mockImplementationOnce(() => new Promise(resolve => (releaseRound = resolve)));
+
+    eventQueue.enqueue({ type: "wake" });
+    await tick();
+
+    // 唤醒后的第 5 轮已起（第 5 次 chat 调用在飞），而告警仍只有第 4 轮那一条——这就是要验的
+    // 性质：计数器已归零，新一段连击从 1 开始，不会「刚醒就再响」。
+    expect(chat).toHaveBeenCalledTimes(5);
+    expect(raise).toHaveBeenCalledTimes(1);
+
+    // 放掉悬停的那一轮让循环能收尾；不再往后跑（继续跑会攒满新的 4 连并如实再告警一次，
+    // 那由下一个用例覆盖）。
+    releaseRound(TEXT_ONLY_RESPONSE);
+    await agent.stop();
+    await runPromise;
+  });
+
+  it("醒来后若继续不动手，攒满新的 4 连会如实再告警一次（不是压制，是分段计数）", async () => {
+    const { agent, chat, raise, eventQueue } = makeAgent();
+    const runPromise = agent.run();
+
+    await tick();
+    await tick();
+    expect(raise).toHaveBeenCalledTimes(1);
+
+    eventQueue.enqueue({ type: "wake" });
+    await tick();
+    await tick();
+
+    expect(chat).toHaveBeenCalledTimes(8);
+    expect(raise).toHaveBeenCalledTimes(2);
+
+    await agent.stop();
+    await runPromise;
+  });
+
+  it("告警通道抛错不拖垮主循环：照常挂起、不崩", async () => {
+    const { agent, chat, raise } = makeAgent();
+    raise.mockRejectedValue(new Error("observatory down"));
+    const runPromise = agent.run();
+
+    await tick();
+    await tick();
+    expect(chat).toHaveBeenCalledTimes(4);
+    expect(raise).toHaveBeenCalledTimes(1);
+
+    // 挂起仍然生效（没有因为告警失败而继续空转）。
+    await tick();
+    expect(chat).toHaveBeenCalledTimes(4);
+
+    await agent.stop();
+    await runPromise;
+  });
+
+  it("阈值可注入：threshold=1 时第一轮无动作即挂起（回归旧 #268 行为）", async () => {
+    const { agent, chat, raise } = makeAgent({ stallThreshold: 1 });
+    const runPromise = agent.run();
+
+    await tick();
+    expect(chat).toHaveBeenCalledTimes(1);
+    await tick();
+    expect(chat).toHaveBeenCalledTimes(1);
+    expect(raise).toHaveBeenCalledTimes(1);
+
+    await agent.stop();
+    await runPromise;
+  });
+
+  it("自唤醒兜底：无外部事件时到 idleWakeMaxWaitMs 也会自己醒来（#268 契约保留）", async () => {
+    const { agent, chat } = makeAgent({ idleWakeMaxWaitMs: 20, stallThreshold: 1 });
     const runPromise = agent.run();
 
     await tick();
@@ -102,8 +273,8 @@ describe("RootLoopAgent — 纯文本轮挂起直到新事件", () => {
     await runPromise;
   });
 
-  it("stop 的 wake 被同轮 drain 吃掉也不死锁（stopRequested 先行复查）", async () => {
-    const { agent, chat, rawQueue } = makeAgent();
+  it("stop 的 wake 被同轮 drain 吃掉也不死锁（stopRequested 先行复查，#268 契约保留）", async () => {
+    const { agent, chat, rawQueue } = makeAgent({ stallThreshold: 1 });
     let resolveChat!: (value: unknown) => void;
     chat.mockImplementationOnce(() => new Promise(resolve => (resolveChat = resolve)));
 

--- a/apps/agent/test/agent/stall-guard.test.ts
+++ b/apps/agent/test/agent/stall-guard.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import {
+  StallGuard,
+  classifyRoundShape,
+  createStallAlert,
+} from "../../src/agent/runtime/root-agent/stall-guard.js";
+
+describe("classifyRoundShape", () => {
+  it("有 tool call → acted（含只调 control 工具的轮次：切 App 是动作，不是卡住）", () => {
+    expect(classifyRoundShape({ content: "", toolCalls: [{}] })).toBe("acted");
+    expect(classifyRoundShape({ content: "说点什么", toolCalls: [{}, {}] })).toBe("acted");
+  });
+
+  it("零 tool call + 有文本 → text_only", () => {
+    expect(classifyRoundShape({ content: "这轮不动。", toolCalls: [] })).toBe("text_only");
+  });
+
+  it("零 tool call + 空文本 → empty", () => {
+    expect(classifyRoundShape({ content: "", toolCalls: [] })).toBe("empty");
+  });
+
+  it("纯空白文本判 empty——与持久化门控同判（那里也是 trim().length > 0）", () => {
+    expect(classifyRoundShape({ content: "   \n\t ", toolCalls: [] })).toBe("empty");
+  });
+});
+
+/**
+ * 两个计数器一层包一层（empty ⊂ noTool），共用阈值 4。issue #602。
+ */
+describe("StallGuard", () => {
+  function observeAll(guard: StallGuard, shapes: Parameters<StallGuard["observe"]>[0][]) {
+    return shapes.map(shape => guard.observe(shape));
+  }
+
+  it("acted 不挂起、不告警", () => {
+    const guard = new StallGuard();
+    for (let index = 0; index < 10; index += 1) {
+      expect(guard.observe("acted")).toEqual({ suspend: false, alert: null });
+    }
+  });
+
+  it("4 连纯文本轮：前 3 轮放行，第 4 轮挂起并报 no_tool", () => {
+    const guard = new StallGuard();
+    const results = observeAll(guard, ["text_only", "text_only", "text_only", "text_only"]);
+
+    expect(results.slice(0, 3)).toEqual([
+      { suspend: false, alert: null },
+      { suspend: false, alert: null },
+      { suspend: false, alert: null },
+    ]);
+    expect(results[3]).toEqual({
+      suspend: true,
+      alert: { reason: "no_tool", emptyStreak: 0, noToolStreak: 4 },
+    });
+  });
+
+  it("4 连空轮：两个计数器同轮到顶，取更具体的 empty", () => {
+    const guard = new StallGuard();
+    const results = observeAll(guard, ["empty", "empty", "empty", "empty"]);
+
+    expect(results[3]).toEqual({
+      suspend: true,
+      alert: { reason: "empty", emptyStreak: 4, noToolStreak: 4 },
+    });
+  });
+
+  it("text_only 清空 emptyStreak 但不清 noToolStreak（一层包一层）", () => {
+    const guard = new StallGuard();
+    const results = observeAll(guard, ["empty", "empty", "text_only", "empty"]);
+
+    // 第 4 轮：noTool 到 4，empty 只有 1（第 3 轮的 text_only 把它清了）→ 报 no_tool。
+    expect(results[3]).toEqual({
+      suspend: true,
+      alert: { reason: "no_tool", emptyStreak: 1, noToolStreak: 4 },
+    });
+  });
+
+  it("混合链 text,empty,empty,empty：报 no_tool，载荷带两个计数供分辨形态", () => {
+    const guard = new StallGuard();
+    const results = observeAll(guard, ["text_only", "empty", "empty", "empty"]);
+
+    expect(results[3]).toEqual({
+      suspend: true,
+      alert: { reason: "no_tool", emptyStreak: 3, noToolStreak: 4 },
+    });
+  });
+
+  it("acted 把两个计数器一起归零", () => {
+    const guard = new StallGuard();
+    observeAll(guard, ["empty", "empty", "empty"]);
+    expect(guard.observe("acted")).toEqual({ suspend: false, alert: null });
+
+    // 归零后要重新攒满 4 轮才触发。
+    const results = observeAll(guard, ["empty", "empty", "empty"]);
+    expect(results.every(result => result.suspend === false)).toBe(true);
+    expect(guard.observe("empty").suspend).toBe(true);
+  });
+
+  it("触发后自动归零：紧接着的下一个无动作轮不会立刻再触发", () => {
+    const guard = new StallGuard();
+    observeAll(guard, ["empty", "empty", "empty", "empty"]);
+
+    expect(guard.observe("empty")).toEqual({ suspend: false, alert: null });
+    expect(guard.observe("empty")).toEqual({ suspend: false, alert: null });
+    expect(guard.observe("empty")).toEqual({ suspend: false, alert: null });
+    expect(guard.observe("empty").suspend).toBe(true);
+  });
+
+  it("reset() 重开活性窗口（resetContext 用）", () => {
+    const guard = new StallGuard();
+    observeAll(guard, ["empty", "empty", "empty"]);
+    guard.reset();
+
+    expect(guard.observe("empty")).toEqual({ suspend: false, alert: null });
+  });
+
+  it("阈值可注入：threshold=1 时第一个无动作轮即触发", () => {
+    const guard = new StallGuard({ threshold: 1 });
+    expect(guard.observe("text_only")).toEqual({
+      suspend: true,
+      alert: { reason: "no_tool", emptyStreak: 0, noToolStreak: 1 },
+    });
+  });
+});
+
+describe("createStallAlert", () => {
+  it("empty → react.empty_stall，标题用 emptyStreak", () => {
+    expect(
+      createStallAlert({ reason: "empty", emptyStreak: 4, noToolStreak: 4, runtimeKey: "root" }),
+    ).toEqual({
+      source: "agent",
+      event: "react.empty_stall",
+      severity: "error",
+      title: "连续 4 轮 LLM 返回空内容，已挂起等待下一个事件。",
+      context: { emptyStreak: 4, noToolStreak: 4, runtimeKey: "root" },
+    });
+  });
+
+  it("no_tool → react.no_tool_stall，标题用 noToolStreak", () => {
+    expect(
+      createStallAlert({ reason: "no_tool", emptyStreak: 3, noToolStreak: 4, runtimeKey: "root" }),
+    ).toEqual({
+      source: "agent",
+      event: "react.no_tool_stall",
+      severity: "error",
+      title: "连续 4 轮没有任何工具调用，已挂起等待下一个事件。",
+      context: { emptyStreak: 3, noToolStreak: 4, runtimeKey: "root" },
+    });
+  });
+
+  it("不带 detail 字段（stall 的全部信息都在 title + context 里）", () => {
+    const alert = createStallAlert({
+      reason: "empty",
+      emptyStreak: 4,
+      noToolStreak: 4,
+      runtimeKey: "root",
+    });
+    expect("detail" in alert).toBe(false);
+  });
+});

--- a/apps/agent/tsconfig.json
+++ b/apps/agent/tsconfig.json
@@ -24,6 +24,7 @@
       "@kagami/oss-api/*": ["./../../packages/oss-api/src/*"],
       "@kagami/gba-api/*": ["./../../packages/gba-api/src/*"],
       "@kagami/spire-api/*": ["./../../packages/spire-api/src/*"],
+      "@kagami/observatory-api/*": ["./../../packages/observatory-api/src/*"],
       "@kagami/pixel-api/*": ["./../../packages/pixel-api/src/*"],
       "@kagami/rpc-client/*": ["./../../packages/rpc-client/src/*"],
       "@kagami/metric-api/*": ["./../../packages/metric-api/src/*"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       '@kagami/napcat-api':
         specifier: workspace:*
         version: link:../../packages/napcat-api
+      '@kagami/observatory-api':
+        specifier: workspace:*
+        version: link:../../packages/observatory-api
       '@kagami/oss-api':
         specifier: workspace:*
         version: link:../../packages/oss-api
@@ -6768,14 +6771,6 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@24.11.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.1(@types/node@24.11.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
-
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
@@ -9421,7 +9416,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4


### PR DESCRIPTION
#602 的 P2。**堆叠在 #604 之上**（base 指向 P1 分支，因为本 PR 编译期依赖 `@kagami/observatory-api`）。#604 合入后 GitHub 会自动把 base 重定向到 `master`——请先合 #604。

## 问题

此前零工具轮**一律立刻挂起**（#268 为 2026-05-30 用量暴涨事故加的闸）。粒度太粗：她吐一个空 content 就睡 `idleWakeMaxWaitMs`（600s），外面看就是「卡死」，而且**没有任何人被通知**——只有一行 `logger.info`，连「空轮」和「只说话不动手」都分不出来。

## 方案

新增纯状态机 `StallGuard`，两个计数器一层包一层（`empty ⊂ noTool`，共用阈值 4）：

| 形状 | `emptyStreak` | `noToolStreak` |
|---|---|---|
| `acted`（有 tool call，含 `wait` / 只调 control 工具） | 归 0 | 归 0 |
| `text_only`（零 tool call + 有文本） | **归 0** | +1 |
| `empty`（零 tool call + 文本为空） | +1 | +1 |

到阈值才挂起并告警。`text,empty,empty,empty` → `noTool=4` / `empty=3` 报 `no_tool`；`empty×4` → 两者同轮到顶，取更具体的 `empty`。任何时刻只发一条，载荷带两个计数供分辨混合形态。触发后计数器归零——否则醒来第一个无动作轮就会立刻再响。

## 这是对 #268 的有界回退，不是拆闸

有 tool call 就归零 + 硬上限 4，仍然有界，不会回到无界空转。**代价要说清楚**：

- 无动作轮的 LLM 调用最坏放大 **4 倍**。
- 上下文 churn 同样 4 倍——纯文本轮每轮留 text，下一轮起轮前 `appendWakeReminderIfNeeded` 会因「尾部是 assistant」补一条 wake-reminder，一次 4 连 stall 塞 8 条纯 churn 消息，压缩会更早触发。
- 空轮那条路上下文一条不动，重跑的请求逐字节相同、KV 全命中，成本几乎只有输出 token。

## 几处容易写错的细节

- **形状取原始 `toolCalls`**（`toPersistableAssistantMessage` 过滤前）。只调 control 工具（如 `switch`）的轮次不留痕进上下文，但那是**动作**不是 stall——用过滤后的数组会把「她正在切 App」误判成卡住。
- 「文本为空」按 `trim()` 判，与持久化门控逐字节一致。两处不同判会出现「上下文里丢弃了、却被计为 `text_only`」的错配。
- `shouldCommit: false` 的轮（模型报错被重试扩展吃掉）不动计数器。
- `resetContext` 后 `reset()`：旧上下文攒的连击不该算在新上下文头上。
- 纯内存、不进快照：重启即新的活性窗口。

## 告警路径的三层防护

本地 `logger.error` **无条件先打**，再 fire-and-forget 推 observatory：不 `await`（不阻塞主循环）、不重试（重试只会加重下游压力）、`.catch` 兜住一切（reject 会变 unhandledRejection 把进程拉挂——**告警绝不能反过来杀掉被告警的东西**），外面还有一层 try/catch 挡同步抛错的坏 notifier。observatory 挂掉时告警只是「没推送」，不是「消失」。

**不做告警后强制冷却**：评估过，明确否掉——那会让她在真卡住时对群消息失聪，是更糟的故障形态。

## 既有测试的语义反转

`root-agent-idle-suspension.test.ts` 的第一个断言（「零 toolCall 轮后不再自发起新轮」）**必须改**，这是预期动作而非破坏。文件头注释保留了 #268 的事故背景，并写清现在为什么允许 4 轮；自唤醒兜底与关停不死锁两个 case 原样保留。

## 验收

26 个新测试（16 个纯状态机 + 10 个循环集成），全 mock，无真端口 / 真 DB / 真 napcat。含混合链、control-only 轮、纯空白文本、通道抛错、`reset()`、阈值注入、以及「醒来后攒满新 4 连会如实再告警」。循环集成测试用悬停 promise 逐轮步进而非靠 `tick()` 撞节奏，连跑三次稳定。

五件套全绿，全仓 1532 测试通过。跨模型对抗 review 报 `NO REAL FINDINGS`；我另外自查了 `metricService` / `runtimeKey` 走 `...rest` 的接线（两侧默认值一致、无重复消费）。

**不部署**（部署红线：未经明确要求绝不 `app:deploy`）。合入后若要上线，agent 与 observatory 无部署顺序要求——`AlertNotifier` 缺省是 NOOP，observatory 没起也只是告警落本地日志。

Refs #602
