### PR TITLE
fix(observatory): 告警日志的 source 字段覆盖了模块名 + 收紧 secret 备份的 gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ node_modules
 .env.*
 !.env.example
 config.secret.yaml
+# 备份 / 临时副本也必须挡住：只写死文件名时，`config.secret.yaml.bak-<ts>` 这类副本会被
+# `git add -A` 一并提交（2026-07-28 真的发生过，凭据推上了公开仓库）。
+config.secret.yaml.*
+!config.secret.yaml.example
 data
 dist
 build

--- a/apps/observatory/src/application/alert.service.ts
+++ b/apps/observatory/src/application/alert.service.ts
@@ -47,7 +47,7 @@ export class AlertService {
     if (!decision.admit) {
       logger.info("Alert suppressed by dedupe window", {
         event: "observatory.alert.suppressed",
-        source: alert.source,
+        alertSource: alert.source,
         alertEvent: alert.event,
         severity: alert.severity,
       });
@@ -68,7 +68,7 @@ export class AlertService {
       // 告警仍被压制——见 AlertThrottle 的「以尝试为界」取舍。
       logger.errorWithCause("Alert delivery failed", error, {
         event: "observatory.alert.delivery_failed",
-        source: alert.source,
+        alertSource: alert.source,
         alertEvent: alert.event,
         severity: alert.severity,
       });
@@ -78,7 +78,7 @@ export class AlertService {
 
     logger.info("Alert delivered", {
       event: "observatory.alert.delivered",
-      source: alert.source,
+      alertSource: alert.source,
       alertEvent: alert.event,
       severity: alert.severity,
       suppressedSinceLast: decision.suppressedSinceLast,
@@ -97,6 +97,8 @@ export class AlertService {
           metricName: OBSERVATORY_ALERT_RAISED_METRIC,
           value: 1,
           tags: {
+            // metric tag 是独立命名空间，这里的 source / event 就是 PR 里定的 tag 名，
+            // 不受下面 logger metadata 那套改名影响。
             source: alert.source,
             event: alert.event,
             severity: alert.severity,


### PR DESCRIPTION
#602 上线后在生产日志里逮到的可观测性缺陷，外加一条我自己踩出来的 gitignore 缺口。

## 1. 日志 source 被覆盖

`AppLogger.log` 把 `source: this.source` 放在展开的调用方 metadata **之前**（`packages/kernel/src/logger/logger.ts:49`），所以调用方传的 `source` 会覆盖模块名；`stdout-sink` 又用 `metadata.source` 当 `[...]` 前缀。生产日志里长这样：

```
INFO  [manual] Alert delivered | event=observatory.alert.delivered
```

`[manual]` 是**调用方**的名字，本该是 `[observatory.alert-service]`。破坏了按 source 过滤日志和 `app_log.source` 列的语义。

三处 logger metadata 的 `source` 改名 `alertSource`。写 #602 时我已经意识到 `event` 会撞（所以有 `alertEvent`），漏了 `source` 是同一类问题。

**metric tag 那处的 `source` 保持不动**：tag 是独立命名空间，`source` / `event` / `severity` / `outcome` 就是 #602 定的 tag 名，metric 测试也断言它。加了注释说明两套命名互不影响——我自己第一遍批量改就打偏了这一处。

## 2. `.gitignore` 挡不住 secret 的备份副本

原规则只写死 `config.secret.yaml` 一个文件名。部署时我为了安全先备份成 `config.secret.yaml.bak-<ts>`，**它不被忽略**，被 `git add -A` 一并提交并推上了公开仓库（GitGuardian 拦住了，分支已删、PR 已关，凭据正在轮换）。

改成 `config.secret.yaml.*` + `!config.secret.yaml.example`。已验证：`.bak-*` 被挡、`.example` 不受影响。

五件套全绿（1532 测试）。日志改动无行为变化。
